### PR TITLE
Add default docker repo to fix `clusterctl init -i elf`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ IMAGE_NAME ?= cape-manager
 PULL_POLICY ?= Always
 
 # Release docker variables
-REGISTRY ?= smartxworks
+REGISTRY ?= docker.io/smartxworks
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 
 ## --------------------------------------

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,6 +2,6 @@
   "name": "infrastructure-elf",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v0.1.0"
+    "nextVersion": "v0.2.1"
   }
 }


### PR DESCRIPTION
How to verify:
```
cat <<EOF >  ~/.cluster-api/clusterctl.yaml
providers:
- name: "elf"
  url: "https://github.com/smartxworks/cluster-api-provider-elf/releases/latest/infrastructure-components.yaml"
  type: "InfrastructureProvider"
EOF
clusterctl init -i elf
```