### PR TITLE
Upgrade Tower SDK to v2.0

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cloudtower-go-sdk v1.9.0
+	github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -882,8 +882,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartxworks/cloudtower-go-sdk v1.9.0 h1:3DsBmsxLSUU2y7HLVvCDsynq9Xkg7Kp8qeB+FcAd6/U=
-github.com/smartxworks/cloudtower-go-sdk v1.9.0/go.mod h1:hkH2NrYZ7X42gmrZeLMXEEcBLgReerD2SiP4KAj1A24=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1 h1:LJf5rfzBPfsXKh0u8QRTB5JnpPCg0GF4KRBWhb/Rmic=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1/go.mod h1:BDfvWLTppdFHlw+Ix/eUsPAxUseh6tBUpGxtObEYMRA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	models "github.com/smartxworks/cloudtower-go-sdk/models"
+	models "github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	v1beta1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 )

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -22,13 +22,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	clientcluster "github.com/smartxworks/cloudtower-go-sdk/client/cluster"
-	clienthost "github.com/smartxworks/cloudtower-go-sdk/client/host"
-	clienttask "github.com/smartxworks/cloudtower-go-sdk/client/task"
-	clientvlan "github.com/smartxworks/cloudtower-go-sdk/client/vlan"
-	clientvm "github.com/smartxworks/cloudtower-go-sdk/client/vm"
-	clientvmtemplate "github.com/smartxworks/cloudtower-go-sdk/client/vm_template"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	clientcluster "github.com/smartxworks/cloudtower-go-sdk/v2/client/cluster"
+	clienthost "github.com/smartxworks/cloudtower-go-sdk/v2/client/host"
+	clienttask "github.com/smartxworks/cloudtower-go-sdk/v2/client/task"
+	clientvlan "github.com/smartxworks/cloudtower-go-sdk/v2/client/vlan"
+	clientvm "github.com/smartxworks/cloudtower-go-sdk/v2/client/vm"
+	clientvmtemplate "github.com/smartxworks/cloudtower-go-sdk/v2/client/vm_template"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
@@ -118,7 +118,7 @@ func (svr *TowerVMService) Clone(
 	}}
 
 	nics := make([]*models.VMNicParams, 0, len(elfMachine.Spec.Network.Devices))
-	networks := make([]*models.VMCreateVMFromTemplateParamsCloudInitNetworksItems0, 0, len(elfMachine.Spec.Network.Devices))
+	networks := make([]*models.CloudInitNetWork, 0, len(elfMachine.Spec.Network.Devices))
 	for i := 0; i < len(elfMachine.Spec.Network.Devices); i++ {
 		device := elfMachine.Spec.Network.Devices[i]
 
@@ -147,7 +147,7 @@ func (svr *TowerVMService) Clone(
 			ipAddress = device.IPAddrs[0]
 		}
 
-		routes := make([]*models.VMCreateVMFromTemplateParamsCloudInitNetworksItems0RoutesItems0, 0, len(device.Routes))
+		routes := make([]*models.CloudInitNetWorkRoute, 0, len(device.Routes))
 		for _, route := range device.Routes {
 			netmask := route.Netmask
 			if netmask == "" {
@@ -158,14 +158,14 @@ func (svr *TowerVMService) Clone(
 				network = "0.0.0.0"
 			}
 
-			routes = append(routes, &models.VMCreateVMFromTemplateParamsCloudInitNetworksItems0RoutesItems0{
+			routes = append(routes, &models.CloudInitNetWorkRoute{
 				Gateway: util.TowerString(route.Gateway),
 				Netmask: util.TowerString(netmask),
 				Network: util.TowerString(network),
 			})
 		}
 
-		networks = append(networks, &models.VMCreateVMFromTemplateParamsCloudInitNetworksItems0{
+		networks = append(networks, &models.CloudInitNetWork{
 			NicIndex:  util.TowerInt32(device.NetworkIndex),
 			Type:      &networkType,
 			IPAddress: util.TowerString(ipAddress),

--- a/pkg/session/tower.go
+++ b/pkg/session/tower.go
@@ -20,9 +20,9 @@ import (
 	"github.com/go-openapi/runtime"
 	openapiclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	towerclient "github.com/smartxworks/cloudtower-go-sdk/client"
-	clientuser "github.com/smartxworks/cloudtower-go-sdk/client/user"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	towerclient "github.com/smartxworks/cloudtower-go-sdk/v2/client"
+	clientuser "github.com/smartxworks/cloudtower-go-sdk/v2/client/user"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 )

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -40,14 +40,14 @@ func TowerCPU(cpu int32) *int32 {
 	return &cpu
 }
 
-func TowerMemory(memoryMiB int64) *float64 {
-	memory := float64(memoryMiB) * 1024 * 1024
+func TowerMemory(memoryMiB int64) *int64 {
+	memory := memoryMiB * 1024 * 1024
 
 	return &memory
 }
 
-func TowerDisk(diskGiB int32) *float64 {
-	disk := float64(diskGiB)
+func TowerDisk(diskGiB int32) *int64 {
+	disk := int64(diskGiB)
 	disk = disk * 1024 * 1024 * 1024
 
 	return &disk

--- a/test/e2e/vm_helpers.go
+++ b/test/e2e/vm_helpers.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	. "github.com/onsi/gomega"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 )

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/smartxworks/cloudtower-go-sdk/models"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )


### PR DESCRIPTION
### 需求
[升级 Tower SDK 2.0](https://github.com/smartxworks/cluster-api-provider-elf/issues/21)

### 测试
创建和删除集群通过（已调用所有 Tower SDK 依赖的接口）
目前兼容 Tower 1.9
