### PR TITLE
Fix VM operation use tower VM ID

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -43,6 +43,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service/mock_services"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
@@ -278,7 +279,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			mockVMService.EXPECT().Clone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("VM_DUPLICATE"))
+			mockVMService.EXPECT().Clone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(service.VMDuplicate))
 			mockVMService.EXPECT().GetByName(machine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.ID).Return(vm, nil)
 
@@ -326,13 +327,13 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New("VM_NOT_FOUND"))
+			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(err.Error()).To(ContainSubstring("VM_NOT_FOUND"))
+			Expect(err.Error()).To(ContainSubstring(service.VMNotFound))
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(*elfMachine.Status.FailureReason).To(Equal(capierrors.UpdateMachineError))
@@ -351,7 +352,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New("VM_NOT_FOUND"))
+			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
@@ -603,7 +604,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			vmNotFoundError := errors.New("VM_NOT_FOUND")
+			vmNotFoundError := errors.New(service.VMNotFound)
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, vmNotFoundError)
 
 			buf := new(bytes.Buffer)

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -18,10 +18,21 @@ package service
 
 import "strings"
 
+// error codes.
+const (
+	ClusterNotFound    = "CLUSTER_NOT_FOUND"
+	HostNotFound       = "HOST_NOT_FOUND"
+	VMTemplateNotFound = "VM_TEMPLATE_NOT_FOUND"
+	VMNotFound         = "VM_NOT_FOUND"
+	VMDuplicate        = "VM_DUPLICATE"
+	TaskNotFound       = "TASK_NOT_FOUND"
+	VlanNotFound       = "VLAN_NOT_FOUND"
+)
+
 func IsVMNotFound(err error) bool {
-	return err.Error() == "VM_NOT_FOUND"
+	return err.Error() == VMNotFound
 }
 
 func IsVMDuplicate(err error) bool {
-	return strings.Contains(err.Error(), "VM_DUPLICATE")
+	return strings.Contains(err.Error(), VMDuplicate)
 }


### PR DESCRIPTION
### 问题描述
https://github.com/smartxworks/cluster-api-provider-elf/issues/26

### 解决方法
通过增加支持 Tower VM ID 对虚拟机进行操作。


### 测试

测试 yaml

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: elfk8s158-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: ElfCluster
    name: elfk8s158
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfCluster
metadata:
  name: elfk8s158
  namespace: default
spec:
  cluster: 576ad467-d09e-4235-9dec-b615814ddc7e
  controlPlaneEndpoint:
    host: 192.168.30.158
    port: 6443
  tower:
    authMode: LOCAL
    password: K5yt3hcjtUE4Teqe
    server: cape.dev-cloudtower.smartx.com
    username: system-service
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkIndex: 0
          networkType: ipv4_dhcp
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: KubeadmControlPlane
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs: null
      clusterName: elfk8s158
      controllerManager:
        extraArgs: null
      imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
    files:
    - content: |
        apiVersion: v1
        kind: Pod
        metadata:
          creationTimestamp: null
          name: kube-vip
          namespace: kube-system
        spec:
          containers:
          - args:
            - start
            env:
            - name: vip_arp
              value: "true"
            - name: vip_leaderelection
              value: "true"
            - name: vip_address
              value: '192.168.30.158'
            - name: vip_interface
              value: eth0
            - name: vip_leaseduration
              value: "15"
            - name: vip_renewdeadline
              value: "10"
            - name: vip_retryperiod
              value: "2"
            image: ghcr.io/kube-vip/kube-vip:v0.3.5
            imagePullPolicy: IfNotPresent
            name: kube-vip
            resources: {}
            securityContext:
              capabilities:
                add:
                - NET_ADMIN
                - SYS_TIME
            volumeMounts:
            - mountPath: /etc/kubernetes/admin.conf
              name: kubeconfig
          hostNetwork: true
          volumes:
          - hostPath:
              path: /etc/kubernetes/admin.conf
              type: FileOrCreate
            name: kubeconfig
        status: {}
      owner: root:root
      path: /etc/kubernetes/manifests/kube-vip.yaml
    initConfiguration:
      nodeRegistration:
        kubeletExtraArgs: null
        name: '{{ ds.meta_data.hostname }}'
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    useExperimentalRetryJoin: true
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: ElfMachineTemplate
      name: elfk8s158-control-plane
  replicas: 1
  version: v1.20.6
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: KubeadmConfigTemplate
metadata:
  name: elfk8s158-md-0
  namespace: default
spec:
  template:
    spec:
      clusterConfiguration:
        clusterName: elfk8s158
        imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
      joinConfiguration:
        nodeRegistration:
          kubeletExtraArgs: null
          name: '{{ ds.meta_data.hostname }}'
      preKubeadmCommands:
      - hostname "{{ ds.meta_data.hostname }}"
      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
      - echo "127.0.0.1   localhost" >>/etc/hosts
      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-worker
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkIndex: 0
          networkType: ipv4_dhcp
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158-md-0
  namespace: default
spec:
  clusterName: elfk8s158
  replicas: 1
  selector:
    matchLabels: {}
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: elfk8s158
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: elfk8s158-md-0
      clusterName: elfk8s158
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: ElfMachineTemplate
        name: elfk8s158-worker
      version: v1.20.6
```

原来的集群 LCM 操作正常。
![image](https://user-images.githubusercontent.com/19967151/169780686-a209eee5-f164-4a8c-a983-0fc472684fe4.png)

![image](https://user-images.githubusercontent.com/19967151/169780722-7fbe3b2c-0b15-402d-a85f-277e9bba3c8b.png)


支持通过 Tower VM ID 关闭虚拟机
```go
	task, err := towerService.PowerOff("cl3ib0odw1gc60758l755u889")
	if err != nil {
		panic(err)
	}

	fmt.Println(*task.ID)
```
