### PR TITLE
Add NetworkType NONE and remove NetworkIndex

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -35,6 +35,16 @@ const (
 	FastClone CloneMode = "FastClone"
 )
 
+// NetworkType is the VM network type.
+type NetworkType string
+
+// Network types.
+const (
+	NetworkTypeNone     NetworkType = ""
+	NetworkTypeIPV4     NetworkType = "IPV4"
+	NetworkTypeIPV4DHCP NetworkType = "IPV4_DHCP"
+)
+
 type Tower struct {
 	// Server is address of the tower server.
 	Server string `json:"server,omitempty"`
@@ -91,8 +101,6 @@ type NetworkStatus struct {
 	// NetworkName is the name of the network.
 	// +optional
 	NetworkName string `json:"networkName,omitempty"`
-
-	NetworkIndex int `json:"networkIndex"`
 }
 
 // NetworkSpec defines the virtual machine's network configuration.
@@ -108,9 +116,7 @@ type NetworkSpec struct {
 // NetworkDeviceSpec defines the network configuration for a virtual machine's
 // network device.
 type NetworkDeviceSpec struct {
-	NetworkIndex int `json:"networkIndex"`
-
-	NetworkType string `json:"networkType"`
+	NetworkType NetworkType `json:"networkType"`
 
 	// Vlan is the virtual LAN used by the virtual machine.
 	Vlan string `json:"vlan,omitempty"`

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -40,7 +40,7 @@ type NetworkType string
 
 // Network types.
 const (
-	NetworkTypeNone     NetworkType = ""
+	NetworkTypeNone     NetworkType = "NONE"
 	NetworkTypeIPV4     NetworkType = "IPV4"
 	NetworkTypeIPV4DHCP NetworkType = "IPV4_DHCP"
 )
@@ -141,6 +141,10 @@ type NetworkDeviceSpec struct {
 	// Required when DHCP4 is false.
 	// +optional
 	Routes []NetworkDeviceRouteSpec `json:"routes,omitempty"`
+}
+
+func (d *NetworkDeviceSpec) HasNetworkType() bool {
+	return !(d.NetworkType == "" || d.NetworkType == NetworkTypeNone)
 }
 
 // NetworkDeviceRouteSpec defines the network configuration for a virtual machine's

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -84,9 +84,8 @@ spec:
                           description: Netmask is the subnet mask used by this device.
                             Required when DHCP4 is false.
                           type: string
-                        networkIndex:
-                          type: integer
                         networkType:
+                          description: NetworkType is the VM network type.
                           type: string
                         routes:
                           description: Required when DHCP4 is false.
@@ -113,7 +112,6 @@ spec:
                             machine.
                           type: string
                       required:
-                      - networkIndex
                       - networkType
                       type: object
                     type: array
@@ -262,14 +260,11 @@ spec:
                     macAddr:
                       description: MACAddr is the MAC address of the network device.
                       type: string
-                    networkIndex:
-                      type: integer
                     networkName:
                       description: NetworkName is the name of the network.
                       type: string
                   required:
                   - macAddr
-                  - networkIndex
                   type: object
                 type: array
               ready:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
@@ -93,9 +93,8 @@ spec:
                                   description: Netmask is the subnet mask used by
                                     this device. Required when DHCP4 is false.
                                   type: string
-                                networkIndex:
-                                  type: integer
                                 networkType:
+                                  description: NetworkType is the VM network type.
                                   type: string
                                 routes:
                                   description: Required when DHCP4 is false.
@@ -123,7 +122,6 @@ spec:
                                     virtual machine.
                                   type: string
                               required:
-                              - networkIndex
                               - networkType
                               type: object
                             type: array

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -291,7 +291,9 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 	ctx.Logger.Info("Reconciling ElfMachine delete")
 
 	if !ctx.ElfMachine.HasVM() || !ctx.ElfMachine.WithVM() {
-		ctx.Logger.Info("VM has been deleted")
+		ctx.Logger.Info("VM already deleted")
+
+		ctrlutil.RemoveFinalizer(ctx.ElfMachine, infrav1.MachineFinalizer)
 
 		return reconcile.Result{}, nil
 	}

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -17,8 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"strings"
-
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -136,9 +134,13 @@ func (svr *TowerVMService) Clone(
 			MacAddress:    util.TowerString(device.MACAddr),
 		})
 
+		if device.NetworkType == infrav1.NetworkTypeNone {
+			continue
+		}
+
 		// networks
 		networkType := models.CloudInitNetworkTypeEnumIPV4DHCP
-		if strings.ToUpper(device.NetworkType) == string(models.CloudInitNetworkTypeEnumIPV4) {
+		if string(device.NetworkType) == string(models.CloudInitNetworkTypeEnumIPV4) {
 			networkType = models.CloudInitNetworkTypeEnumIPV4
 		}
 
@@ -166,7 +168,7 @@ func (svr *TowerVMService) Clone(
 		}
 
 		networks = append(networks, &models.CloudInitNetWork{
-			NicIndex:  util.TowerInt32(device.NetworkIndex),
+			NicIndex:  util.TowerInt32(i),
 			Type:      &networkType,
 			IPAddress: util.TowerString(ipAddress),
 			Netmask:   util.TowerString(device.Netmask),

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -134,7 +134,7 @@ func (svr *TowerVMService) Clone(
 			MacAddress:    util.TowerString(device.MACAddr),
 		})
 
-		if device.NetworkType == infrav1.NetworkTypeNone {
+		if !device.HasNetworkType() {
 			continue
 		}
 

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -116,14 +116,13 @@ func GetNetworkStatus(ipsStr string) []infrav1.NetworkStatus {
 	}
 
 	ips := strings.Split(ipsStr, ",")
-	for index, ip := range ips {
+	for _, ip := range ips {
 		if ip == "127.0.0.1" || strings.HasPrefix(ip, "169.254.") || strings.HasPrefix(ip, "172.17.0") {
 			continue
 		}
 
 		networks = append(networks, infrav1.NetworkStatus{
-			NetworkIndex: index,
-			IPAddrs:      []string{ip},
+			IPAddrs: []string{ip},
 		})
 	}
 

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -195,8 +195,7 @@ func TestGetNetworkStatus(t *testing.T) {
 			name: "valid IP",
 			ips:  "116.116.116.116",
 			networkStatus: []infrav1.NetworkStatus{{
-				NetworkIndex: 0,
-				IPAddrs:      []string{"116.116.116.116"},
+				IPAddrs: []string{"116.116.116.116"},
 			}},
 		},
 	}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -51,9 +51,8 @@ spec:
       diskGiB: ${CONTROL_PLANE_MACHINE_DISK_GB:-40}
       network:
         devices:
-          - networkIndex: 0
-            networkType: ipv4_dhcp
-            vlan: '${ELF_VLAN}'
+        - networkType: IPV4_DHCP
+          vlan: '${ELF_VLAN}'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -174,9 +173,8 @@ spec:
       diskGiB: ${WORKER_MACHINE_DISK_GB:-40}
       network:
         devices:
-          - networkIndex: 0
-            networkType: ipv4_dhcp
-            vlan: '${ELF_VLAN}'
+        - networkType: IPV4_DHCP
+          vlan: '${ELF_VLAN}'
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/test/e2e/data/infrastructure-elf/cluster-template-conformance.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-conformance.yaml
@@ -199,8 +199,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -218,8 +217,7 @@ spec:
       memoryMiB: 4096
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       numCPUs: 4
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template-cp-ha.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-cp-ha.yaml
@@ -199,8 +199,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -216,7 +215,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-kcp-remediation.yaml
@@ -214,8 +214,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -231,7 +230,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-kcp-scale-in.yaml
@@ -202,8 +202,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -219,7 +218,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-md-remediation.yaml
@@ -215,8 +215,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -232,7 +231,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template-node-drain.yaml
@@ -201,8 +201,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -218,7 +217,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-elf/cluster-template.yaml
@@ -199,8 +199,7 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}
 ---
@@ -216,7 +215,6 @@ spec:
       ha: true
       network:
         devices:
-        - networkIndex: 0
-          networkType: ipv4_dhcp
+        - networkType: IPV4_DHCP
           vlan: ${ELF_VLAN}
       template: ${ELF_TEMPLATE}

--- a/test/e2e/data/infrastructure-elf/kustomization/base/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-elf/kustomization/base/cluster-template.yaml
@@ -48,9 +48,8 @@ spec:
       cloneMode: FastClone
       network:
         devices:
-          - networkIndex: 0
-            networkType: ipv4_dhcp
-            vlan: '${ELF_VLAN}'
+        - networkType: IPV4_DHCP
+          vlan: '${ELF_VLAN}'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -168,9 +167,8 @@ spec:
       cloneMode: FastClone
       network:
         devices:
-          - networkIndex: 0
-            networkType: ipv4_dhcp
-            vlan: '${ELF_VLAN}'
+        - networkType: IPV4_DHCP
+          vlan: '${ELF_VLAN}'
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment


### PR DESCRIPTION
### 需求
增加不配置网卡的支持

### 实现
通过移除 network index，增加 NetworkTypeNone 类型，默认不作网卡的配置。

### 功能

1. 移除 network index
2. fix 删除创建中集群无法删除（创建中的 ElfMachine 无法被删除导致的原因）

### 测试
测试 yaml
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: elfk8s158-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: ElfCluster
    name: elfk8s158
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfCluster
metadata:
  name: elfk8s158
  namespace: default
spec:
  cluster: 576ad467-d09e-4235-9dec-b615814ddc7e
  controlPlaneEndpoint:
    host: 192.168.30.158
    port: 6443
  tower:
    authMode: LOCAL
    password: K5yt3hcjtUE4Teqe
    server: cape.dev-cloudtower.smartx.com
    username: system-service
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: KubeadmControlPlane
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs: null
      clusterName: elfk8s158
      controllerManager:
        extraArgs: null
      imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
    files:
    - content: |
        apiVersion: v1
        kind: Pod
        metadata:
          creationTimestamp: null
          name: kube-vip
          namespace: kube-system
        spec:
          containers:
          - args:
            - start
            env:
            - name: vip_arp
              value: "true"
            - name: vip_leaderelection
              value: "true"
            - name: vip_address
              value: '192.168.30.158'
            - name: vip_interface
              value: eth0
            - name: vip_leaseduration
              value: "15"
            - name: vip_renewdeadline
              value: "10"
            - name: vip_retryperiod
              value: "2"
            image: ghcr.io/kube-vip/kube-vip:v0.3.5
            imagePullPolicy: IfNotPresent
            name: kube-vip
            resources: {}
            securityContext:
              capabilities:
                add:
                - NET_ADMIN
                - SYS_TIME
            volumeMounts:
            - mountPath: /etc/kubernetes/admin.conf
              name: kubeconfig
          hostNetwork: true
          volumes:
          - hostPath:
              path: /etc/kubernetes/admin.conf
              type: FileOrCreate
            name: kubeconfig
        status: {}
      owner: root:root
      path: /etc/kubernetes/manifests/kube-vip.yaml
    initConfiguration:
      nodeRegistration:
        kubeletExtraArgs: null
        name: '{{ ds.meta_data.hostname }}'
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    useExperimentalRetryJoin: true
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: ElfMachineTemplate
      name: elfk8s158-control-plane
  replicas: 1
  version: v1.20.6
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: KubeadmConfigTemplate
metadata:
  name: elfk8s158-md-0
  namespace: default
spec:
  template:
    spec:
      clusterConfiguration:
        clusterName: elfk8s158
        imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
      joinConfiguration:
        nodeRegistration:
          kubeletExtraArgs: null
          name: '{{ ds.meta_data.hostname }}'
      preKubeadmCommands:
      - hostname "{{ ds.meta_data.hostname }}"
      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
      - echo "127.0.0.1   localhost" >>/etc/hosts
      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-worker
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
        - networkType: IPV4
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
          ipAddrs:
          - 192.168.31.157
          netmask: 255.255.240.0
          routes:
          - gateway: 192.168.31.215
        - networkType: ""
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158-md-0
  namespace: default
spec:
  clusterName: elfk8s158
  replicas: 1
  selector:
    matchLabels: {}
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: elfk8s158
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: elfk8s158-md-0
      clusterName: elfk8s158
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: ElfMachineTemplate
        name: elfk8s158-worker
      version: v1.20.6
```
worker 节点配置三种类型的网卡：IPV4、DHCP、不做配置
![image](https://user-images.githubusercontent.com/19967151/169936863-55ab594b-34d0-46d8-b956-a72f8da14268.png)

![image](https://user-images.githubusercontent.com/19967151/169936894-75875eb2-a543-486a-aa0e-72ea472d6a87.png)
