### PR TITLE
Fix multi cloudtower error

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,13 +52,14 @@ import (
 
 var _ = Describe("ElfMachineReconciler", func() {
 	var (
-		elfCluster    *infrav1.ElfCluster
-		cluster       *clusterv1.Cluster
-		elfMachine    *infrav1.ElfMachine
-		machine       *clusterv1.Machine
-		secret        *corev1.Secret
-		mockCtrl      *gomock.Controller
-		mockVMService *mock_services.MockVMService
+		elfCluster       *infrav1.ElfCluster
+		cluster          *clusterv1.Cluster
+		elfMachine       *infrav1.ElfMachine
+		machine          *clusterv1.Machine
+		secret           *corev1.Secret
+		mockCtrl         *gomock.Controller
+		mockVMService    *mock_services.MockVMService
+		mockNewVMService func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (service.VMService, error)
 	)
 
 	BeforeEach(func() {
@@ -75,6 +77,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 		// mock
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockVMService = mock_services.NewMockVMService(mockCtrl)
+		// nolint:unparam
+		mockNewVMService = func(_ goctx.Context, _ infrav1.Tower, _ logr.Logger) (service.VMService, error) {
+			return mockVMService, nil
+		}
 	})
 
 	AfterEach(func() {
@@ -126,7 +132,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 			Expect(result).To(BeZero())
@@ -139,7 +145,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -158,7 +164,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -180,7 +186,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -201,7 +207,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -223,7 +229,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -258,7 +264,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -286,7 +292,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -306,7 +312,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Clone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -329,7 +335,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -355,7 +361,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -390,7 +396,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -423,7 +429,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOn(*vm.LocalID).Return(nil, errors.New("some error"))
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -459,7 +465,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -491,7 +497,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -523,7 +529,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -549,7 +555,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -580,7 +586,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -608,7 +614,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -638,7 +644,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -668,7 +674,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -699,7 +705,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -726,7 +732,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -756,7 +762,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})
@@ -786,7 +792,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, VMService: mockVMService}
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: elfMachineKey})

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,12 @@ go 1.17
 
 require (
 	github.com/go-logr/logr v1.2.0
-	github.com/go-openapi/runtime v0.23.1
-	github.com/go-openapi/strfmt v0.21.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1
+	github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.1-0.20220614053620-27c71da72e4f
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0
@@ -54,7 +52,9 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/loads v0.21.1 // indirect
+	github.com/go-openapi/runtime v0.23.1 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
+	github.com/go-openapi/strfmt v0.21.2 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -882,8 +882,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1 h1:LJf5rfzBPfsXKh0u8QRTB5JnpPCg0GF4KRBWhb/Rmic=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-rc1/go.mod h1:BDfvWLTppdFHlw+Ix/eUsPAxUseh6tBUpGxtObEYMRA=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.1-0.20220614053620-27c71da72e4f h1:9Ou9C0BkPyJ9qbUxshZuJc8B8J18rbfWRlzvUNBmyTo=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.1-0.20220614053620-27c71da72e4f/go.mod h1:BDfvWLTppdFHlw+Ix/eUsPAxUseh6tBUpGxtObEYMRA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 )
 
 // MachineContext is a Go context used with a ElfMachine.
@@ -35,6 +36,7 @@ type MachineContext struct {
 	ElfMachine  *infrav1.ElfMachine
 	Logger      logr.Logger
 	PatchHelper *patch.Helper
+	VMService   service.VMService
 }
 
 // String returns ElfMachineGroupVersionKindElfMachineNamespace/ElfMachineName.

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -17,6 +17,8 @@ limitations under the License.
 package service
 
 import (
+	goctx "context"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	clientcluster "github.com/smartxworks/cloudtower-go-sdk/v2/client/cluster"
@@ -51,8 +53,8 @@ type VMService interface {
 	GetVlan(id string) (*models.Vlan, error)
 }
 
-func NewVMService(auth infrav1.Tower, logger logr.Logger) (VMService, error) {
-	authSession, err := session.NewTowerSession(auth)
+func NewVMService(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error) {
+	authSession, err := session.GetOrCreate(ctx, auth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/session/tower.go
+++ b/pkg/session/tower.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	goctx "context"
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ type TowerSession struct {
 func GetOrCreate(ctx goctx.Context, tower infrav1.Tower) (*TowerSession, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("session").WithValues("server", tower.Server, "username", tower.Username, "source", tower.AuthMode)
 
-	sessionKey := tower.Server + tower.Username + tower.AuthMode
+	sessionKey := getSessionKey(tower)
 	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
 		session := cachedSession.(*TowerSession)
 		logger.V(3).Info("found active cached tower client session")
@@ -69,4 +70,8 @@ func GetOrCreate(ctx goctx.Context, tower infrav1.Tower) (*TowerSession, error) 
 	logger.V(3).Info("cached tower client session")
 
 	return session, nil
+}
+
+func getSessionKey(tower infrav1.Tower) string {
+	return fmt.Sprintf("%s-%s-%s", tower.Server, tower.Username, tower.AuthMode)
 }

--- a/pkg/session/tower_test.go
+++ b/pkg/session/tower_test.go
@@ -1,0 +1,26 @@
+package session
+
+import (
+	goctx "context"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+)
+
+func TestGetOrCreate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("should get cached session", func(t *testing.T) {
+		tower := infrav1.Tower{Server: "127.0.0.1", Username: "tower", Password: "tower"}
+
+		sessionKey := tower.Server + tower.Username + tower.AuthMode
+		cachedSession := &TowerSession{}
+		sessionCache.Store(sessionKey, cachedSession)
+
+		session, err := GetOrCreate(goctx.Background(), tower)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(session).To(gomega.Equal(cachedSession))
+	})
+}

--- a/pkg/session/tower_test.go
+++ b/pkg/session/tower_test.go
@@ -15,7 +15,7 @@ func TestGetOrCreate(t *testing.T) {
 	t.Run("should get cached session", func(t *testing.T) {
 		tower := infrav1.Tower{Server: "127.0.0.1", Username: "tower", Password: "tower"}
 
-		sessionKey := tower.Server + tower.Username + tower.AuthMode
+		sessionKey := getSessionKey(tower)
 		cachedSession := &TowerSession{}
 		sessionCache.Store(sessionKey, cachedSession)
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -104,7 +104,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	e2eConfig, err = helpers.LoadE2EConfig(configPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Initializing the ELF session to ensure credentials are working", initElfSession)
+	By("Initializing the Tower session to ensure credentials are working", initTowerSession)
 
 	Byf("Creating a clusterctl local repository into %q", artifactFolder)
 	clusterctlConfigPath, err = helpers.CreateClusterctlLocalRepository(e2eConfig, filepath.Join(artifactFolder, "repository"), true)

--- a/test/e2e/tower_test.go
+++ b/test/e2e/tower_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	goctx "context"
 	"flag"
 	"os"
 
@@ -42,9 +43,9 @@ func init() {
 	flag.StringVar(&towerServer, "e2e.towerServer", os.Getenv("TOWER_SERVER"), "the tower server used for e2e tests")
 }
 
-func initElfSession() {
+func initTowerSession() {
 	var err error
-	vmService, err = service.NewVMService(infrav1.Tower{
+	vmService, err = service.NewVMService(goctx.Background(), infrav1.Tower{
 		Server:   towerServer,
 		Username: towerUsername,
 		Password: towerPassword,


### PR DESCRIPTION
### Fix
https://github.com/smartxworks/cluster-api-provider-elf/issues/25

### 解决
CAPE 支持多个 session，并通过缓存 session 优化性能

### 测试
启动 CAPE 服务，且服务一直稳定运行情况下在不同的 Tower 环境各创建一个集群。

1. 在 cape.dev-cloudtower.smartx.com ELF-Dogfood-50x-vhost-rdma-19-11 创建集群，正常工作
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: elfk8s158-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: ElfCluster
    name: elfk8s158
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfCluster
metadata:
  name: elfk8s158
  namespace: default
spec:
  cluster: 576ad467-d09e-4235-9dec-b615814ddc7e
  controlPlaneEndpoint:
    host: 192.168.30.158
    port: 6443
  tower:
    authMode: LOCAL
    password: root
    server: tower.com
    username: system-service
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: KubeadmControlPlane
metadata:
  name: elfk8s158-control-plane
  namespace: default
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs: null
      clusterName: elfk8s158
      controllerManager:
        extraArgs: null
      imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
    files:
    - content: |
        apiVersion: v1
        kind: Pod
        metadata:
          creationTimestamp: null
          name: kube-vip
          namespace: kube-system
        spec:
          containers:
          - args:
            - start
            env:
            - name: vip_arp
              value: "true"
            - name: vip_leaderelection
              value: "true"
            - name: vip_address
              value: '192.168.30.158'
            - name: vip_interface
              value: eth0
            - name: vip_leaseduration
              value: "15"
            - name: vip_renewdeadline
              value: "10"
            - name: vip_retryperiod
              value: "2"
            image: ghcr.io/kube-vip/kube-vip:v0.3.5
            imagePullPolicy: IfNotPresent
            name: kube-vip
            resources: {}
            securityContext:
              capabilities:
                add:
                - NET_ADMIN
                - SYS_TIME
            volumeMounts:
            - mountPath: /etc/kubernetes/admin.conf
              name: kubeconfig
          hostNetwork: true
          volumes:
          - hostPath:
              path: /etc/kubernetes/admin.conf
              type: FileOrCreate
            name: kubeconfig
        status: {}
      owner: root:root
      path: /etc/kubernetes/manifests/kube-vip.yaml
    initConfiguration:
      nodeRegistration:
        kubeletExtraArgs: null
        name: '{{ ds.meta_data.hostname }}'
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    useExperimentalRetryJoin: true
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: ElfMachineTemplate
      name: elfk8s158-control-plane
  replicas: 1
  version: v1.20.6
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: KubeadmConfigTemplate
metadata:
  name: elfk8s158-md-0
  namespace: default
spec:
  template:
    spec:
      clusterConfiguration:
        clusterName: elfk8s158
        imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
      joinConfiguration:
        nodeRegistration:
          kubeletExtraArgs: null
          name: '{{ ds.meta_data.hostname }}'
      preKubeadmCommands:
      - hostname "{{ ds.meta_data.hostname }}"
      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
      - echo "127.0.0.1   localhost" >>/etc/hosts
      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s158-worker
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: 576ad467-d09e-4235-9dec-b615814ddc7e_c8a1e42d-e0f3-4d50-a190-53209a98f157
      template: 336820d7-5ba5-4707-9d0c-8f3e583b950f
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s158
  name: elfk8s158-md-0
  namespace: default
spec:
  clusterName: elfk8s158
  replicas: 1
  selector:
    matchLabels: {}
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: elfk8s158
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: elfk8s158-md-0
      clusterName: elfk8s158
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: ElfMachineTemplate
        name: elfk8s158-worker
      version: v1.20.6

```
![image](https://user-images.githubusercontent.com/19967151/173514451-2ffc9351-5024-470a-a6a8-c40a00dbe5d8.png)


2. 在 tower.caas.smtx.io CAAS-ELF-20-216 创建集群，正常工作
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s2
  name: elfk8s2
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: elfk8s2-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: ElfCluster
    name: elfk8s2
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfCluster
metadata:
  name: elfk8s2
  namespace: default
spec:
  cluster: dd1f408f-7715-48c1-a817-13c3568f1d93
  controlPlaneEndpoint:
    host: 10.255.160.2
    port: 6443
  tower:
    authMode: LOCAL
    password: root
    server: tower.com
    username: system-service
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s2-control-plane
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08
      template: 923ca782-e556-4d76-85cf-28a37130cbb0
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: KubeadmControlPlane
metadata:
  name: elfk8s2-control-plane
  namespace: default
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs: null
      clusterName: elfk8s2
      controllerManager:
        extraArgs: null
      imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
    files:
    - content: |
        apiVersion: v1
        kind: Pod
        metadata:
          creationTimestamp: null
          name: kube-vip
          namespace: kube-system
        spec:
          containers:
          - args:
            - start
            env:
            - name: vip_arp
              value: "true"
            - name: vip_leaderelection
              value: "true"
            - name: vip_address
              value: '10.255.160.2'
            - name: vip_interface
              value: eth0
            - name: vip_leaseduration
              value: "15"
            - name: vip_renewdeadline
              value: "10"
            - name: vip_retryperiod
              value: "2"
            image: ghcr.io/kube-vip/kube-vip:v0.3.5
            imagePullPolicy: IfNotPresent
            name: kube-vip
            resources: {}
            securityContext:
              capabilities:
                add:
                - NET_ADMIN
                - SYS_TIME
            volumeMounts:
            - mountPath: /etc/kubernetes/admin.conf
              name: kubeconfig
          hostNetwork: true
          volumes:
          - hostPath:
              path: /etc/kubernetes/admin.conf
              type: FileOrCreate
            name: kubeconfig
        status: {}
      owner: root:root
      path: /etc/kubernetes/manifests/kube-vip.yaml
    initConfiguration:
      nodeRegistration:
        kubeletExtraArgs: null
        name: '{{ ds.meta_data.hostname }}'
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    useExperimentalRetryJoin: true
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: ElfMachineTemplate
      name: elfk8s2-control-plane
  replicas: 1
  version: v1.22.8
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: KubeadmConfigTemplate
metadata:
  name: elfk8s2-md-0
  namespace: default
spec:
  template:
    spec:
      clusterConfiguration:
        clusterName: elfk8s2
        imageRepository: registry.cn-hangzhou.aliyuncs.com/google_containers
      joinConfiguration:
        nodeRegistration:
          kubeletExtraArgs: null
          name: '{{ ds.meta_data.hostname }}'
      preKubeadmCommands:
      - hostname "{{ ds.meta_data.hostname }}"
      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
      - echo "127.0.0.1   localhost" >>/etc/hosts
      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s2-worker
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      network:
        devices:
        - networkType: IPV4_DHCP
          vlan: dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08
      template: 923ca782-e556-4d76-85cf-28a37130cbb0
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s2
  name: elfk8s2-md-0
  namespace: default
spec:
  clusterName: elfk8s2
  replicas: 1
  selector:
    matchLabels: {}
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: elfk8s2
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: elfk8s2-md-0
      clusterName: elfk8s2
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: ElfMachineTemplate
        name: elfk8s2-worker
      version: v1.22.8
```

![image](https://user-images.githubusercontent.com/19967151/173514499-80f0f362-c039-479c-93b7-120616391532.png)
