### PR TITLE
Fix the virtual machine cannot be deleted due to ACPI exception

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -48,9 +48,9 @@ const (
 	// are automatically re-tried by the controller.
 	CloningFailedReason = "CloningFailed"
 
-	// TaskFailure (Severity=Warning) documents a ElfMachine task failure; the reconcile look will automatically
+	// TaskFailureReason (Severity=Warning) documents a ElfMachine task failure; the reconcile look will automatically
 	// retry the operation, but a user intervention might be required to fix the problem.
-	TaskFailure = "TaskFailure"
+	TaskFailureReason = "TaskFailure"
 
 	// WaitingForNetworkAddressesReason (Severity=Info) documents a ElfMachine waiting for the the machine network
 	// settings to be reported after machine being powered on.

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -38,3 +38,7 @@ func IsVMNotFound(err error) bool {
 func IsVMDuplicate(err error) bool {
 	return strings.Contains(err.Error(), VMDuplicate)
 }
+
+func IsShutDownTimeout(message string) bool {
+	return strings.Contains(message, "JOB_VM_SHUTDOWN_TIMEOUT")
+}

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -36,6 +36,21 @@ func (m *MockVMService) EXPECT() *MockVMServiceMockRecorder {
 	return m.recorder
 }
 
+// AddLabelsToVM mocks base method.
+func (m *MockVMService) AddLabelsToVM(vmID string, labels []string) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddLabelsToVM", vmID, labels)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddLabelsToVM indicates an expected call of AddLabelsToVM.
+func (mr *MockVMServiceMockRecorder) AddLabelsToVM(vmID, labels interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLabelsToVM", reflect.TypeOf((*MockVMService)(nil).AddLabelsToVM), vmID, labels)
+}
+
 // Clone mocks base method.
 func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, machine *v1beta10.Machine, elfMachine *v1beta1.ElfMachine, bootstrapData string) (*models.WithTaskVM, error) {
 	m.ctrl.T.Helper()
@@ -201,6 +216,21 @@ func (mr *MockVMServiceMockRecorder) PowerOn(uuid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PowerOn", reflect.TypeOf((*MockVMService)(nil).PowerOn), uuid)
 }
 
+// ShutDown mocks base method.
+func (m *MockVMService) ShutDown(uuid string) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShutDown", uuid)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShutDown indicates an expected call of ShutDown.
+func (mr *MockVMServiceMockRecorder) ShutDown(uuid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutDown", reflect.TypeOf((*MockVMService)(nil).ShutDown), uuid)
+}
+
 // UpsertLabel mocks base method.
 func (m *MockVMService) UpsertLabel(key, value string) (*models.Label, error) {
 	m.ctrl.T.Helper()
@@ -214,19 +244,4 @@ func (m *MockVMService) UpsertLabel(key, value string) (*models.Label, error) {
 func (mr *MockVMServiceMockRecorder) UpsertLabel(key, value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertLabel", reflect.TypeOf((*MockVMService)(nil).UpsertLabel), key, value)
-}
-
-// AddLabelsToVM mocks base method.
-func (m *MockVMService) AddLabelsToVM(vmID string, labels []string) (*models.Task, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddLabelsToVM", vmID, labels)
-	ret0, _ := ret[0].(*models.Task)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AddLabelsToVM indicates an expected call of AddLabelToVM.
-func (mr *MockVMServiceMockRecorder) AddLabelsToVM(vmID, labels interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLabelsToVM", reflect.TypeOf((*MockVMService)(nil).AddLabelsToVM), vmID, labels)
 }

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -45,6 +45,7 @@ type VMService interface {
 	Delete(uuid string) (*models.Task, error)
 	PowerOff(uuid string) (*models.Task, error)
 	PowerOn(uuid string) (*models.Task, error)
+	ShutDown(uuid string) (*models.Task, error)
 	Get(id string) (*models.VM, error)
 	GetByName(name string) (*models.VM, error)
 	GetVMTemplate(templateUUID string) (*models.VMTemplate, error)
@@ -256,23 +257,23 @@ func (svr *TowerVMService) Delete(id string) (*models.Task, error) {
 
 // PowerOff powers off a virtual machine.
 func (svr *TowerVMService) PowerOff(id string) (*models.Task, error) {
-	shutDownVMParams := clientvm.NewShutDownVMParams()
-	shutDownVMParams.RequestBody = &models.VMOperateParams{
+	poweroffVMParams := clientvm.NewPoweroffVMParams()
+	poweroffVMParams.RequestBody = &models.VMOperateParams{
 		Where: &models.VMWhereInput{
 			OR: []*models.VMWhereInput{{LocalID: util.TowerString(id)}, {ID: util.TowerString(id)}},
 		},
 	}
 
-	shutDownVMResp, err := svr.Session.VM.ShutDownVM(shutDownVMParams)
+	poweroffVMResp, err := svr.Session.VM.PoweroffVM(poweroffVMParams)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(shutDownVMResp.Payload) == 0 {
+	if len(poweroffVMResp.Payload) == 0 {
 		return nil, errors.New(VMNotFound)
 	}
 
-	return &models.Task{ID: shutDownVMResp.Payload[0].TaskID}, nil
+	return &models.Task{ID: poweroffVMResp.Payload[0].TaskID}, nil
 }
 
 // PowerOn powers on a virtual machine.
@@ -294,6 +295,27 @@ func (svr *TowerVMService) PowerOn(id string) (*models.Task, error) {
 	}
 
 	return &models.Task{ID: startVMResp.Payload[0].TaskID}, nil
+}
+
+// ShutDown shut down a virtual machine.
+func (svr *TowerVMService) ShutDown(id string) (*models.Task, error) {
+	shutDownVMParams := clientvm.NewShutDownVMParams()
+	shutDownVMParams.RequestBody = &models.VMOperateParams{
+		Where: &models.VMWhereInput{
+			OR: []*models.VMWhereInput{{LocalID: util.TowerString(id)}, {ID: util.TowerString(id)}},
+		},
+	}
+
+	shutDownVMResp, err := svr.Session.VM.ShutDownVM(shutDownVMParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(shutDownVMResp.Payload) == 0 {
+		return nil, errors.New(VMNotFound)
+	}
+
+	return &models.Task{ID: shutDownVMResp.Payload[0].TaskID}, nil
 }
 
 // Get searches for a virtual machine.

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -86,8 +86,8 @@ var _ = Describe("CAPE HA e2e test", func() {
 		})
 		Expect(len(machines)).Should(Equal(3))
 
-		Logf("Powering off VM")
-		PowerOffVM(ctx, PowerOffVMInput{
+		Logf("Shut down VM")
+		ShutDownVM(ctx, ShutDownVMInput{
 			UUID:               util.ConvertProviderIDToUUID(machines[0].Spec.ProviderID),
 			VMService:          vmService,
 			WaitVMJobIntervals: e2eConfig.GetIntervals(specName, "wait-vm-job"),

--- a/test/e2e/vm_helpers.go
+++ b/test/e2e/vm_helpers.go
@@ -25,16 +25,16 @@ import (
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 )
 
-// PowerOffVMInput is the input for PowerOffVM.
-type PowerOffVMInput struct {
+// ShutDownVMInput is the input for ShutDownVM.
+type ShutDownVMInput struct {
 	UUID               string
 	VMService          service.VMService
 	WaitVMJobIntervals []interface{}
 }
 
-// PowerOffVM power off a VM.
-func PowerOffVM(ctx context.Context, input PowerOffVMInput) {
-	task, err := input.VMService.PowerOff(input.UUID)
+// ShutDownVM shut down a VM.
+func ShutDownVM(ctx context.Context, input ShutDownVMInput) {
+	task, err := input.VMService.ShutDown(input.UUID)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	Eventually(func() (bool, error) {
@@ -46,7 +46,7 @@ func PowerOffVM(ctx context.Context, input PowerOffVMInput) {
 		if *task.Status == models.TaskStatusSUCCESSED {
 			return true, nil
 		} else if *task.Status == models.TaskStatusFAILED {
-			task, err = input.VMService.PowerOff(input.UUID)
+			task, err = input.VMService.ShutDown(input.UUID)
 
 			return false, err
 		}


### PR DESCRIPTION
### Bug
https://github.com/smartxworks/cluster-api-provider-elf/issues/30

### 解决方案
通过 Tower 接口正常关闭虚拟机如果遇到 JOB_VM_SHUTDOWN_TIMEOUT 错误，就使用强制关机。

### 其他修改
- 重新命名 shut down：正常关机；power off 强制关机

### 测试
1. 单测请看代码部分
2. 手动测试
2.1 创建集群
2.2 关闭 worker 节点的 ACPI
```bash
vi /etc/default/grub

GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet noacpi acpi=off"

grub2-mkconfig -o /boot/grub2/grub.cfg

systemctl reboot
```
第一次无法正常关机失败
![image](https://user-images.githubusercontent.com/19967151/179456837-a9eb317e-ed48-4d1c-b33c-de57f715ddbb.png)

第二次使用强制关机成功
![image](https://user-images.githubusercontent.com/19967151/179456888-668d9e8d-690a-4da7-824d-891def090e73.png)

![image](https://user-images.githubusercontent.com/19967151/179456907-029c8b60-9372-4a8d-b1f8-bc9a409ba390.png)


