### PR TITLE
Update ElfCluster and ElfMachine printcolumns

### DIFF
--- a/api/v1beta1/elfcluster_types.go
+++ b/api/v1beta1/elfcluster_types.go
@@ -53,6 +53,9 @@ type ElfClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready"
+//+kubebuilder:printcolumn:name="Tower",type="string",JSONPath=".spec.tower.server",description="Tower is the address of the Tower endpoint"
+//+kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint",priority=1
 
 // ElfCluster is the Schema for the elfclusters API.
 type ElfCluster struct {

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -144,6 +144,10 @@ type ElfMachineStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElfMachine ready status"
+//+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="ElfMachine instance ID"
+//+kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.addresses[0].address",description="IP address of the first network device of the virtual machine"
+//+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this ElfMachine"
 
 // ElfMachine is the Schema for the elfmachines API.
 type ElfMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
@@ -15,7 +15,21 @@ spec:
     singular: elfcluster
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Tower is the address of the Tower endpoint
+      jsonPath: .spec.tower.server
+      name: Tower
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElfCluster is the Schema for the elfclusters API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -15,7 +15,24 @@ spec:
     singular: elfmachine
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: ElfMachine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: ElfMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: IP address of the first network device of the virtual machine
+      jsonPath: .status.addresses[0].address
+      name: IP
+      type: string
+    - description: Machine object which owns with this ElfMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElfMachine is the Schema for the elfmachines API.


### PR DESCRIPTION
### 增加 CRD 的 printcolumn

```bash
kubectl get elfcluster
NAME      READY   TOWER
elfk8s3   true    tower.caas.smtx.io
```

```bash
kubectl get elfmachines
NAME                         READY    PROVIDERID                                   IP           MACHINE
elfk8s3-worker-zbmnm         true     elf://1aae6679-98c3-4a5c-a5b9-a976c8ef9ba6   10.255.1.8   elfk8s3-md-0-76c75b7cd5-wcspt
elfk8s3-control-plane-7n9wz  true     elf://af567d8a-a9ac-4741-b7d9-73ef369e8a64   10.255.1.7   elfk8s3-control-plane-t5plq
```