### PR TITLE
Wait for ip allocation when vm ipv4 network device without ip

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -32,6 +32,10 @@ const (
 	// script to be ready before starting the provisioning process.
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
 
+	// WaitingForStaticIPAllocationReason (Severity=Info) documents a ElfMachine waiting for the allocation of
+	// a static IP address.
+	WaitingForStaticIPAllocationReason = "WaitingForStaticIPAllocation"
+
 	// CloningReason documents (Severity=Info) ElfMachine currently executing the clone operation.
 	CloningReason = "Cloning"
 


### PR DESCRIPTION
## 支持虚拟机等待静态 IP 分配。

## 测试
创建新的 ElfMachine ，device先不设置 IP，之后再设置 IP。

![image](https://user-images.githubusercontent.com/19967151/183028698-35bd2f33-1c10-43f7-b292-823d6241bad2.png)

![image](https://user-images.githubusercontent.com/19967151/183028716-4030292d-761f-47b1-ab8c-75a989b9d2b1.png)
