### PR TITLE
Refactor reconciling control plane endpoint

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -78,7 +78,7 @@ const (
 	// ControlPlaneEndpointReadyCondition documents the status of control plane endpoint.
 	ControlPlaneEndpointReadyCondition clusterv1.ConditionType = "ControlPlaneEndpointReady"
 
-	// WaitingForHostReason (Severity=Info) documents the control plane endpoint of ElfCluster
+	// WaitingForVIPReason (Severity=Info) documents the control plane endpoint of ElfCluster
 	// waiting for a address and port.
-	WaitingForHostReason = "WaitingForHost"
+	WaitingForVIPReason = "WaitingForVIP"
 )

--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -79,6 +79,6 @@ const (
 	ControlPlaneEndpointReadyCondition clusterv1.ConditionType = "ControlPlaneEndpointReady"
 
 	// WaitingForVIPReason (Severity=Info) documents the control plane endpoint of ElfCluster
-	// waiting for a address and port.
+	// waiting for an IP Address and port.
 	WaitingForVIPReason = "WaitingForVIP"
 )

--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -71,3 +71,14 @@ const (
 	// issues with tower reachability.
 	TowerUnreachableReason = "TowerUnreachable"
 )
+
+// Conditions and condition Reasons for the ElfCluster object.
+
+const (
+	// ControlPlaneEndpointReadyCondition documents the status of control plane endpoint.
+	ControlPlaneEndpointReadyCondition clusterv1.ConditionType = "ControlPlaneEndpointReady"
+
+	// WaitingForHostReason (Severity=Info) documents the control plane endpoint of ElfCluster
+	// waiting for a address and port.
+	WaitingForHostReason = "WaitingForHost"
+)

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -275,7 +275,7 @@ func (r *ElfClusterReconciler) reconcileControlPlaneEndpoint(ctx *context.Cluste
 		return true
 	}
 
-	conditions.MarkFalse(ctx.ElfCluster, infrav1.ControlPlaneEndpointReadyCondition, infrav1.WaitingForHostReason, clusterv1.ConditionSeverityInfo, "")
+	conditions.MarkFalse(ctx.ElfCluster, infrav1.ControlPlaneEndpointReadyCondition, infrav1.WaitingForVIPReason, clusterv1.ConditionSeverityInfo, "")
 	ctx.Logger.Info("The ControlPlaneEndpoint of ElfCluster is not set")
 
 	return false

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -169,8 +169,8 @@ var _ = Describe("ElfClusterReconciler", func() {
 			Expect(logBuffer.String()).To(ContainSubstring("The ControlPlaneEndpoint of ElfCluster is not set"))
 			Expect(reconciler.Client.Get(reconciler, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
 			expectConditions(elfCluster, []conditionAssertion{
-				{clusterv1.ReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForHostReason},
-				{infrav1.ControlPlaneEndpointReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForHostReason},
+				{clusterv1.ReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForVIPReason},
+				{infrav1.ControlPlaneEndpointReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForVIPReason},
 				{conditionType: infrav1.TowerAvailableCondition, status: corev1.ConditionTrue},
 			})
 		})

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -131,12 +132,13 @@ var _ = Describe("ElfClusterReconciler", func() {
 		})
 
 		It("should add finalizer to the elfcluster", func() {
+			elfCluster.Spec.ControlPlaneEndpoint.Host = "127.0.0.1"
+			elfCluster.Spec.ControlPlaneEndpoint.Port = 6443
 			ctrlMgrContext := fake.NewControllerManagerContext(cluster, elfCluster)
 			ctrlContext := &context.ControllerContext{
 				ControllerManagerContext: ctrlMgrContext,
 				Logger:                   ctrllog.Log,
 			}
-
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
@@ -145,9 +147,14 @@ var _ = Describe("ElfClusterReconciler", func() {
 			Expect(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster)).To(Succeed())
 			Expect(elfCluster.Status.Ready).To(BeTrue())
 			Expect(elfCluster.Finalizers).To(ContainElement(infrav1.ClusterFinalizer))
+			expectConditions(elfCluster, []conditionAssertion{
+				{conditionType: clusterv1.ReadyCondition, status: corev1.ConditionTrue},
+				{conditionType: infrav1.ControlPlaneEndpointReadyCondition, status: corev1.ConditionTrue},
+				{conditionType: infrav1.TowerAvailableCondition, status: corev1.ConditionTrue},
+			})
 		})
 
-		It("should error if without ControlPlaneEndpoint", func() {
+		It("should not reconcile if without ControlPlaneEndpoint", func() {
 			ctrlMgrContext := fake.NewControllerManagerContext(cluster, elfCluster)
 			ctrlContext := &context.ControllerContext{
 				ControllerManagerContext: ctrlMgrContext,
@@ -157,8 +164,15 @@ var _ = Describe("ElfClusterReconciler", func() {
 
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
-			Expect(err.Error()).To(ContainSubstring("Failed to reconcile ControlPlaneEndpoint for ElfCluster"))
+			Expect(err).To(BeNil())
 			Expect(result).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("The ControlPlaneEndpoint of ElfCluster is not set"))
+			Expect(reconciler.Client.Get(reconciler, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			expectConditions(elfCluster, []conditionAssertion{
+				{clusterv1.ReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForHostReason},
+				{infrav1.ControlPlaneEndpointReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForHostReason},
+				{conditionType: infrav1.TowerAvailableCondition, status: corev1.ConditionTrue},
+			})
 		})
 	})
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -805,10 +805,10 @@ type conditionAssertion struct {
 	reason        string
 }
 
-func expectConditions(m *infrav1.ElfMachine, expected []conditionAssertion) {
-	Expect(len(m.Status.Conditions)).To(BeNumerically(">=", len(expected)), "number of conditions")
+func expectConditions(getter conditions.Getter, expected []conditionAssertion) {
+	Expect(len(getter.GetConditions())).To(BeNumerically(">=", len(expected)), "number of conditions")
 	for _, c := range expected {
-		actual := conditions.Get(m, c.conditionType)
+		actual := conditions.Get(getter, c.conditionType)
 		Expect(actual).To(Not(BeNil()))
 		Expect(actual.Type).To(Equal(c.conditionType))
 		Expect(actual.Status).To(Equal(c.status))


### PR DESCRIPTION
### 优化 control plane endpoint 逻辑

1. 没有设置 ControlPlaneEndpoint 不再直接抛异常，而是等待
2. 增加 ControlPlaneEndpointReadyCondition，提高可观测性