### PR TITLE
Add cluster machine graceful shutdown option

### DIFF
--- a/api/v1beta1/elfcluster_types.go
+++ b/api/v1beta1/elfcluster_types.go
@@ -40,11 +40,10 @@ type ElfClusterSpec struct {
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// GraciedShutdown is the config for whether cluster machine should grace shutdown
-	// when cluster machine need be delete.
-	// Defaults is false to force shutdown
+	// VMGracefulShutdown indicates the VMs in this ElfCluster should shutdown gracefully when deleting the VMs.
+	// Default to false because sometimes the OS stuck when shutting down gracefully.
 	// +optional
-	GraciedShutdown bool `json:"graciedShutdown,omitempty"`
+	VMGracefulShutdown bool `json:"vmGracefulShutdown,omitempty"`
 }
 
 // ElfClusterStatus defines the observed state of ElfCluster.

--- a/api/v1beta1/elfcluster_types.go
+++ b/api/v1beta1/elfcluster_types.go
@@ -39,6 +39,12 @@ type ElfClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// GraciedShutdown is the config for whether cluster machine should grace shutdown
+	// when cluster machine need be delete.
+	// Defaults is false to force shutdown
+	// +optional
+	GraciedShutdown bool `json:"graciedShutdown,omitempty"`
 }
 
 // ElfClusterStatus defines the observed state of ElfCluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
@@ -71,11 +71,6 @@ spec:
                 - host
                 - port
                 type: object
-              graciedShutdown:
-                description: GraciedShutdown is the config for whether cluster machine
-                  should grace shutdown when cluster machine need be delete. Defaults
-                  is false to force shutdown
-                type: boolean
               tower:
                 description: Tower is the config of tower.
                 properties:
@@ -100,6 +95,11 @@ spec:
                     description: Username is the name used to log into the tower server.
                     type: string
                 type: object
+              vmGracefulShutdown:
+                description: VMGracefulShutdown indicates the VMs in this ElfCluster
+                  should shutdown gracefully when deleting the VMs. Default to false
+                  because sometimes the OS stuck when shutting down gracefully.
+                type: boolean
             type: object
           status:
             description: ElfClusterStatus defines the observed state of ElfCluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfclusters.yaml
@@ -71,6 +71,11 @@ spec:
                 - host
                 - port
                 type: object
+              graciedShutdown:
+                description: GraciedShutdown is the config for whether cluster machine
+                  should grace shutdown when cluster machine need be delete. Defaults
+                  is false to force shutdown
+                type: boolean
               tower:
                 description: Tower is the config of tower.
                 properties:

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -267,7 +267,7 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 		var err error
 		// If shut down timeout or cluster machine force shutdown , the VM may not be shut down unexpectedly, just power off the VM.
 		if service.IsShutDownTimeout(conditions.GetMessage(ctx.ElfMachine, infrav1.VMProvisionedCondition)) ||
-			!ctx.ElfCluster.Spec.GraciedShutdown {
+			!ctx.ElfCluster.Spec.VMGracefulShutdown {
 			task, err = ctx.VMService.PowerOff(ctx.ElfMachine.Status.VMRef)
 		} else {
 			task, err = ctx.VMService.ShutDown(ctx.ElfMachine.Status.VMRef)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -265,8 +265,9 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 	if *vm.Status == models.VMStatusRUNNING {
 		var task *models.Task
 		var err error
-		// If shut down timeout, the VM may not be shut down unexpectedly, just power off the VM.
-		if service.IsShutDownTimeout(conditions.GetMessage(ctx.ElfMachine, infrav1.VMProvisionedCondition)) {
+		// If shut down timeout or cluster machine force shutdown , the VM may not be shut down unexpectedly, just power off the VM.
+		if service.IsShutDownTimeout(conditions.GetMessage(ctx.ElfMachine, infrav1.VMProvisionedCondition)) ||
+			!ctx.ElfCluster.Spec.GraciedShutdown {
 			task, err = ctx.VMService.PowerOff(ctx.ElfMachine.Status.VMRef)
 		} else {
 			task, err = ctx.VMService.ShutDown(ctx.ElfMachine.Status.VMRef)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -265,7 +265,7 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 	if *vm.Status == models.VMStatusRUNNING {
 		var task *models.Task
 		var err error
-		// If shut down timeout or cluster machine force shutdown , the VM may not be shut down unexpectedly, just power off the VM.
+		// If VM shutdown timed out or VMGracefulShutdown is set to false, simply power off the VM.
 		if service.IsShutDownTimeout(conditions.GetMessage(ctx.ElfMachine, infrav1.VMProvisionedCondition)) ||
 			!ctx.ElfCluster.Spec.VMGracefulShutdown {
 			task, err = ctx.VMService.PowerOff(ctx.ElfMachine.Status.VMRef)

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -35,6 +35,8 @@ spec:
   controlPlaneEndpoint:
     host: '${CONTROL_PLANE_ENDPOINT_IP}'
     port: 6443
+  graciedShutdown: ${CLUSTER_MACHINE_GRACIED_SHUTDOWN:=false}
+
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -31,7 +31,7 @@ spec:
     username: '${TOWER_USERNAME}'
     password: '${TOWER_PASSWORD}'
     authMode: '${TOWER_AUTH_MODE:=LOCAL}'
-    skipTLSVerify: '${TOWER_SKIP_TLS_VERIFY:=false}'
+    skipTLSVerify: ${TOWER_SKIP_TLS_VERIFY:=false}
   controlPlaneEndpoint:
     host: '${CONTROL_PLANE_ENDPOINT_IP}'
     port: 6443

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -35,7 +35,7 @@ spec:
   controlPlaneEndpoint:
     host: '${CONTROL_PLANE_ENDPOINT_IP}'
     port: 6443
-  graciedShutdown: ${CLUSTER_MACHINE_GRACIED_SHUTDOWN:=false}
+  vmGracefulShutdown: ${VM_GRACEFUL_SHUTDOWN:=false}
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Add option ElfCluster.VMGracefulShutdown to support shutting down VMs gracefully or forcefully.