### PR TITLE
Fix force delete failed when tower is disconnected

### DIFF
--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -237,7 +237,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeNil())
 			Expect(logBuffer.String()).To(ContainSubstring(""))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -180,8 +180,8 @@ func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_
 		PatchHelper:       patchHelper,
 	}
 
-	// Create the vm service.
-	// if ElfMachine is in deleting and ElfCluster need to force delete, may be Tower server is disconnected, skipping NewVMService
+	// If ElfMachine is being deleting and ElfCLuster ForceDeleteCluster flag is set, skip creating the VMService object,
+	// because Tower server may be out of service. So we can force delete ElfCluster.
 	if elfMachine.ObjectMeta.DeletionTimestamp.IsZero() || !elfCluster.HasForceDeleteCluster() {
 		vmService, err := r.NewVMService(r.Context, elfCluster.GetTower(), logger)
 		if err != nil {


### PR DESCRIPTION
修复ElfCluster/ElfMachine 在tower失联场景下，强制删除失败问题
1.  失联场景下，tower session过期，需要重新获取tower session失败，会跳过reconcileDelete
2.  失联场景下，cape重启，需要重新获取tower session，重新获取tower session失败，会跳过reconcileDelete

Test
测试集群
<img width="444" alt="image" src="https://user-images.githubusercontent.com/114376205/198026940-a045d2ce-3367-450a-8fe0-c9fdf88c76d2.png">
创建完成后修改tower地址保证tower连接不上
<img width="397" alt="image" src="https://user-images.githubusercontent.com/114376205/198026820-9ea28ea8-938a-4c70-8648-bc47381f6969.png">
cape 报错连接不上tower
<img width="618" alt="image" src="https://user-images.githubusercontent.com/114376205/198026757-80fe4f34-8905-4a15-974c-ca1d44ddb9b4.png">
正常删除cape一直报错无法删除
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/114376205/198029521-a085fa8a-7a3b-4162-aec6-f83a6475d47d.png">

<img width="638" alt="image" src="https://user-images.githubusercontent.com/114376205/198027619-102ecdfa-046d-486a-878c-6e9f89b60006.png">
添加强制删除annotations
<img width="626" alt="image" src="https://user-images.githubusercontent.com/114376205/198028018-a5414ce2-69a0-4712-a2eb-879ea585c655.png">
强制删除成功
<img width="735" alt="image" src="https://user-images.githubusercontent.com/114376205/198028507-ba61d72e-366b-42e7-97d2-6d778167898b.png">
vm删除被跳过
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/114376205/198029746-6a18eb1b-b0a0-4b01-b064-cf8e5c246420.png">

