### PR TITLE
Set cluster failure when cloning VM with cloud-init config error

### DIFF
--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package service
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // error codes.
 const (
@@ -29,6 +32,7 @@ const (
 	VlanNotFound       = "VLAN_NOT_FOUND"
 	LabelCreateFailed  = "LABEL_CREATE_FAILED"
 	LabelAddFailed     = "LABEL_ADD_FAILED"
+	CloudInitError     = "VM_CLOUD_INIT_CONFIG_ERROR"
 )
 
 func IsVMNotFound(err error) bool {
@@ -41,4 +45,29 @@ func IsVMDuplicate(err error) bool {
 
 func IsShutDownTimeout(message string) bool {
 	return strings.Contains(message, "JOB_VM_SHUTDOWN_TIMEOUT")
+}
+
+func IsTaskNotFound(err error) bool {
+	return err.Error() == TaskNotFound
+}
+
+func IsCloudInitConfigError(message string) bool {
+	return strings.Contains(message, CloudInitError)
+}
+
+// FormatCloudInitError parses useful error message from orignal tower error message.
+// Example: The gateway [192.168.31.215] is unreachable.
+func FormatCloudInitError(message string) string {
+	firstIndex := strings.LastIndex(message, fmt.Sprintf("[%s]", CloudInitError))
+	if firstIndex == -1 {
+		return message
+	}
+
+	msg := message[firstIndex+len(CloudInitError)+2:]
+	msg = strings.TrimRight(msg, "}")
+	msg = strings.TrimRight(msg, "\"")
+	msg = strings.TrimRight(msg, "\\")
+	msg = strings.TrimSpace(msg)
+
+	return msg
 }


### PR DESCRIPTION
1. 当创建虚拟机遇到 cloud-init 错误，设置 failure
2. 优化 task 的处理逻辑，把删除虚拟机和创建虚拟机相关的 task 代码合并

```yaml
status:
  conditions:
  - lastTransitionTime: "2022-11-01T08:25:20Z"
    message: "Cannot unwrap Ok value of Result.Err.\r\ncode: CREATE_VM_FORM_TEMPLATE_FAILED\r\nmessage:
      {\"data\":{},\"ec\":\"VM_CLOUD_INIT_CONFIG_ERROR\",\"error\":{\"msg\":\"[VM_CLOUD_INIT_CONFIG_ERROR]The
      gateway [192.168.31.215] is unreachable. \"}}"
    reason: TaskFailure
    severity: Info
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-11-01T08:24:58Z"
    status: "True"
    type: TowerAvailable
  - lastTransitionTime: "2022-11-01T08:25:20Z"
    message: "Cannot unwrap Ok value of Result.Err.\r\ncode: CREATE_VM_FORM_TEMPLATE_FAILED\r\nmessage:
      {\"data\":{},\"ec\":\"VM_CLOUD_INIT_CONFIG_ERROR\",\"error\":{\"msg\":\"[VM_CLOUD_INIT_CONFIG_ERROR]The
      gateway [192.168.31.215] is unreachable. \"}}"
    reason: TaskFailure
    severity: Info
    status: "False"
    type: VMProvisioned
  failureMessage: 'VM cloud-init config error: The gateway [192.168.31.215] is unreachable.'
  failureReason: CreateError
```