### PR TITLE
SKS-489: Wait for VM Volumes created by ELF CSI to be detached when ElfMachine is being deleted

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -32,6 +32,9 @@ const (
 
 	// VMDisconnectionTimestampAnnotation is the annotation identifying the VM of ElfMachine disconnection time.
 	VMDisconnectionTimestampAnnotation = "cape.infrastructure.cluster.x-k8s.io/vm-disconnection-timestamp"
+
+	// DefaultELFCSIVMVolumeClusterLabel is the cluster label key of VM Volume which created by ELF CSI in Tower.
+	DefaultELFCSIVMVolumeClusterLabel = "system.cloudtower/k8s-cluster-id"
 )
 
 // ElfMachineSpec defines the desired state of ElfMachine.

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -34,7 +34,7 @@ const (
 	VMDisconnectionTimestampAnnotation = "cape.infrastructure.cluster.x-k8s.io/vm-disconnection-timestamp"
 
 	// DefaultELFCSIVMVolumeClusterLabel is the cluster label key of VM Volume which created by ELF CSI in Tower.
-	DefaultELFCSIVMVolumeClusterLabel = "system.cloudtower/k8s-cluster-id"
+	DefaultELFCSIVMVolumeClusterLabel = "system.cloudtower/elf-csi.k8s-cluster-id"
 )
 
 // ElfMachineSpec defines the desired state of ElfMachine.

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -636,17 +636,17 @@ func (r *ElfMachineReconciler) isVMDiskAttachedByELFCSI(ctx *context.MachineCont
 
 	for i := 0; i < len(vmVolume.Labels); i++ {
 		if vmVolume.Labels[i].ID == nil {
-			ctx.Logger.Info("Volome's label ID is nil, skip to compare label key", "volume", *vmVolume.ID)
+			ctx.Logger.V(2).Info("Volome's label ID is nil so skip label key check", "volume", *vmVolume.ID)
 			continue
 		}
 
 		volumeLabel, err := ctx.VMService.GetLabelByID(*vmVolume.Labels[i].ID)
 		if err != nil {
-			return true, errors.Wrapf(err, "failed to get label %s", *vmVolume.Labels[i].ID)
+			return true, errors.Wrapf(err, "failed to get VM volume label by id %s", *vmVolume.Labels[i].ID)
 		}
 
 		if volumeLabel.Key == nil {
-			ctx.Logger.Info("Label's key is nil, skip to compare label key", "label", *volumeLabel.ID)
+			ctx.Logger.V(2).Info("VM volume label's key is nil so skip label key check", "label", *volumeLabel.ID)
 			continue
 		}
 

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -645,12 +645,12 @@ func (r *ElfMachineReconciler) isVMDiskAttachedByELFCSI(ctx *context.MachineCont
 	}
 
 	if vmDisk.VMVolume == nil || vmDisk.ID == nil {
-		return false, fmt.Errorf("failed to get VM volume associated with the VM Disk %s, because VM Disk VM Volume is nil", *vmDisk.ID)
+		return true, fmt.Errorf("failed to get VM volume associated with the VM Disk %s, because VM Disk VM Volume is nil", *vmDisk.ID)
 	}
 
 	vmVolume, err := ctx.VMService.GetVMVolumeByID(*vmDisk.VMVolume.ID)
 	if err != nil {
-		return false, err
+		return true, err
 	}
 
 	// If the volume associated with the VM Disk has a label created by the cluster's ELF CSI,

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -318,11 +318,11 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 		}
 	}
 
-	if ok, err := r.shouldWaitForELFCSIVMVolumeDetach(ctx); ok || err != nil {
+	if attachedVolumes, ok, err := r.shouldWaitForVMVolumesToBeDetached(ctx); ok || err != nil {
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		ctx.Logger.Info("Waiting for VM volumes which created by ELF CSI to be detached", "elfMachine", ctx.ElfMachine.Name)
+		ctx.Logger.Info(fmt.Sprintf("Waiting for %d VM volumes which created by ELF CSI to be detached", attachedVolumes), "elfMachine", ctx.ElfMachine.Name)
 		return ctrl.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
 	}
 
@@ -574,68 +574,72 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 	return vm, nil
 }
 
-// shouldWaitForELFCSIVMVolumeDetach returns true if VM still have volumes which created by ELF CSI attached or cluster is being deleted.
-// VM deletion and volume detach happen asynchronously, so VM shutdown or deletion and volume detach may occur at the same time
-// this could cause issue for SMTX OS ELF, the volume which has been detached will be deleted together with the VM,
-// so we need to check if all volumes are detached before deleting the VM.
-func (r *ElfMachineReconciler) shouldWaitForELFCSIVMVolumeDetach(ctx *context.MachineContext) (bool, error) {
+// shouldWaitForVMVolumesToBeDetached returns true only if VM still have volumes created by ELF CSI attached and cluster is not being deleted.
+// VM deletion and volume detach happen asynchronously, so VM shutdown or deletion and volume detach may occur at the same time,
+// this could cause issue ELF-4117 for SMTX OS ELF, the volume which has been detached will be deleted together with the VM,
+// so we need to check if all volumes created by ELF CSI are detached before deleting the VM.
+func (r *ElfMachineReconciler) shouldWaitForVMVolumesToBeDetached(ctx *context.MachineContext) (int, bool, error) {
 	// Return early if the cluster is being deleted.
 	if !ctx.Cluster.DeletionTimestamp.IsZero() {
-		return false, nil
+		return 0, false, nil
 	}
 
-	// Get all VM Disk in this VM
+	// Get all VM Disk in this VM.
 	vmDisks, err := ctx.VMService.GetVMDisksByVMID(ctx.ElfMachine.Status.VMRef)
 	if err != nil {
-		return false, err
+		return 0, false, err
 	}
 
 	// Return early if the VM disks length is 0.
 	if len(vmDisks) == 0 {
-		return false, nil
+		return 0, false, nil
 	}
 
-	// Get all labels which create by ELF CSI
-	systemLabelsCreatedByELFCSI, err := ctx.VMService.GetLabelsByKey(infrav1.DefaultELFCSIVMVolumeClusterLabel)
+	// The volume label value created by ELF CSI is like "sks.{{cluster.Namespace}}.{{cluster.Name}}.KSC_UUID",
+	// If label value starts with "sks.{{cluster.Namespace}}.{{cluster.Name}}.", it means the label is created by ELF CSI running in this cluster.
+	labelValueStarts := label.GetELFCSILabelValueStarts(ctx.Cluster)
+
+	// Get labels which create by ELF CSI running in this cluster.
+	systemLabelsCreatedByELFCSI, err := ctx.VMService.GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, labelValueStarts)
 	if err != nil {
-		return false, err
+		return 0, false, err
 	}
 
-	// the label value created by ELF CSI like this sks.{{cluster.Namespace}}.{{cluster.Name}}.UUID
-	// If label value contains {{cluster.Namespace}}.{{cluster.Name}},
-	// we can make sure that the label is created by this cluster's ELF CSI.
-	labelValueContains := fmt.Sprintf("%s.%s", ctx.Cluster.Namespace, ctx.Cluster.Name)
-	currentClusterLabelCreatedByELFCSIMap := make(map[string]string)
+	if len(systemLabelsCreatedByELFCSI) == 0 {
+		return 0, false, fmt.Errorf("the label which create by ELF CSI in this cluster %s/%s is not found", ctx.Cluster.Namespace, ctx.Cluster.Name)
+	}
+
+	currentClusterLabelCreatedByELFCSIMap := make(map[string]bool)
 	for i := 0; i < len(systemLabelsCreatedByELFCSI); i++ {
-		if strings.Contains(*systemLabelsCreatedByELFCSI[i].Value, labelValueContains) {
-			currentClusterLabelCreatedByELFCSIMap[*systemLabelsCreatedByELFCSI[i].ID] = *systemLabelsCreatedByELFCSI[i].ID
-		}
+		currentClusterLabelCreatedByELFCSIMap[*systemLabelsCreatedByELFCSI[i].ID] = true
 	}
 
-	if len(currentClusterLabelCreatedByELFCSIMap) == 0 {
-		return false, fmt.Errorf("the label which create by ELF CSI in this cluster %s/%s is not found", ctx.Cluster.Namespace, ctx.Cluster.Name)
-	}
+	vmDiskAttachedByELFCSICount := 0
 
 	for i := 0; i < len(vmDisks); i++ {
 		ok, err := r.isVMDiskAttachedByELFCSI(ctx, vmDisks[i], currentClusterLabelCreatedByELFCSIMap)
 		if err != nil {
-			return false, err
+			return 0, false, err
 		}
 
-		// if VM Disk is attached by ELF CSI,
-		// should wait for VM Disk to be detached.
 		if ok {
-			return true, nil
+			vmDiskAttachedByELFCSICount++
 		}
 	}
 
-	return false, nil
+	// if count for VM Disk attached by ELF CSI is >0,
+	// should wait for VM Disk attached by ELF CSI to be detached.
+	if vmDiskAttachedByELFCSICount > 0 {
+		return vmDiskAttachedByELFCSICount, true, nil
+	}
+
+	return vmDiskAttachedByELFCSICount, false, nil
 }
 
 // isVMDiskAttachedByELFCSI return true if VM Disk attached by ELF CSI.
 func (r *ElfMachineReconciler) isVMDiskAttachedByELFCSI(ctx *context.MachineContext, vmDisk *models.VMDisk,
-	currentClusterLabelCreatedByELFCSIMap map[string]string) (bool, error) {
-	// Skip VM Disk which type is CD_ROM
+	currentClusterLabelCreatedByELFCSIMap map[string]bool) (bool, error) {
+	// Skip VM Disk which type is CD_ROM.
 	if *vmDisk.Type == models.VMDiskTypeCDROM {
 		return false, nil
 	}

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -927,7 +927,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should wait for vm volume which create by ELF CSI to be detached", func() {
 			vm := fake.NewTowerVM()
 			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("sks.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
+			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
 			volume.Labels = []*models.NestedLabel{{
 				ID: towerLabel.ID,
 			}}
@@ -939,7 +939,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return([]*models.Label{towerLabel}, nil)
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return([]*models.Label{towerLabel}, nil)
 			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(volume, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -971,7 +971,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should return error when get labels which created by ELF CSI failed", func() {
 			vm := fake.NewTowerVM()
 			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("sks.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
+			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
 			volume.Labels = []*models.NestedLabel{{
 				ID: towerLabel.ID,
 			}}
@@ -983,7 +983,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return(nil, errors.New("failed to get label"))
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return(nil, errors.New("failed to get label"))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1004,7 +1004,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return([]*models.Label{}, nil)
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return([]*models.Label{}, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1017,7 +1017,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should return error when get VM volume failed", func() {
 			vm := fake.NewTowerVM()
 			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("sks.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
+			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
 			volume.Labels = []*models.NestedLabel{{
 				ID: towerLabel.ID,
 			}}
@@ -1029,7 +1029,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return([]*models.Label{towerLabel}, nil)
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return([]*models.Label{towerLabel}, nil)
 			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(nil, errors.New("failed to get volume"))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -1040,10 +1040,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get volume"))
 		})
 
-		It("should return error when VM Disk VM Volume is nil", func() {
+		It("should delete when VM Disk VM Volume is nil", func() {
 			vm := fake.NewTowerVM()
 			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("sks.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
+			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
 			volume.Labels = []*models.NestedLabel{{
 				ID: towerLabel.ID,
 			}}
@@ -1055,21 +1055,25 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
+			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return([]*models.Label{towerLabel}, nil)
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return([]*models.Label{towerLabel}, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
 			Expect(result.RequeueAfter).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("because VM Disk VM Volume is nil"))
+			Expect(logBuffer.String()).To(ContainSubstring("VM already deleted"))
+			elfMachine = &infrav1.ElfMachine{}
+			err = reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
 		It("should delete when vm volume which create by ELF CSI has been detached", func() {
 			vm := fake.NewTowerVM()
 			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("sks.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
+			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
 			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
 
 			elfMachine.Status.VMRef = *vm.LocalID
@@ -1079,7 +1083,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
 			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelsByKeyAndValueStarts(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueStarts(cluster)).Return([]*models.Label{towerLabel}, nil)
+			mockVMService.EXPECT().GetLabelsByKeyAndValueContains(infrav1.DefaultELFCSIVMVolumeClusterLabel, label.GetELFCSILabelValueSubstring(cluster)).Return([]*models.Label{towerLabel}, nil)
 			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(volume, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -641,6 +641,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.ID).Return(vm, nil)
+			mockVMService.EXPECT().GetVMDisksByVMID(*vm.ID).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -668,6 +669,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.LocalID).Return(vm, nil)
 			mockVMService.EXPECT().ShutDown(*vm.LocalID).Return(task, nil)
+			mockVMService.EXPECT().GetVMDisksByVMID(*vm.LocalID).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -19,8 +19,6 @@ package label
 import (
 	"fmt"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )
 
@@ -51,8 +49,4 @@ func GetVMLabelClusterName() string {
 
 func GetVMLabelVIP() string {
 	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelVIP)
-}
-
-func GetELFCSILabelValueSubstring(cluster *clusterv1.Cluster) string {
-	return fmt.Sprintf(".%s.%s.", cluster.Namespace, cluster.Name)
 }

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -19,6 +19,8 @@ package label
 import (
 	"fmt"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )
 
@@ -49,4 +51,8 @@ func GetVMLabelClusterName() string {
 
 func GetVMLabelVIP() string {
 	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelVIP)
+}
+
+func GetELFCSILabelValueStarts(cluster *clusterv1.Cluster) string {
+	return fmt.Sprintf("sks.%s.%s.", cluster.Namespace, cluster.Name)
 }

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -53,6 +53,6 @@ func GetVMLabelVIP() string {
 	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelVIP)
 }
 
-func GetELFCSILabelValueStarts(cluster *clusterv1.Cluster) string {
-	return fmt.Sprintf("sks.%s.%s.", cluster.Namespace, cluster.Name)
+func GetELFCSILabelValueSubstring(cluster *clusterv1.Cluster) string {
+	return fmt.Sprintf(".%s.%s.", cluster.Namespace, cluster.Name)
 }

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -34,6 +34,7 @@ const (
 	LabelAddFailed     = "LABEL_ADD_FAILED"
 	CloudInitError     = "VM_CLOUD_INIT_CONFIG_ERROR"
 	VMVolumeNotFound   = "VM_VOLUME_NOT_FOUND"
+	LabelNotFound      = "LABEL_NOT_FOUND"
 )
 
 func IsVMNotFound(err error) bool {
@@ -54,6 +55,10 @@ func IsTaskNotFound(err error) bool {
 
 func IsCloudInitConfigError(message string) bool {
 	return strings.Contains(message, CloudInitError)
+}
+
+func IsLabelNotFound(err error) bool {
+	return err.Error() == LabelNotFound
 }
 
 // FormatCloudInitError parses useful error message from orignal tower error message.

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -33,6 +33,7 @@ const (
 	LabelCreateFailed  = "LABEL_CREATE_FAILED"
 	LabelAddFailed     = "LABEL_ADD_FAILED"
 	CloudInitError     = "VM_CLOUD_INIT_CONFIG_ERROR"
+	VMVolumeNotFound   = "VM_VOLUME_NOT_FOUND"
 )
 
 func IsVMNotFound(err error) bool {

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -156,19 +156,19 @@ func (mr *MockVMServiceMockRecorder) GetHost(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHost", reflect.TypeOf((*MockVMService)(nil).GetHost), id)
 }
 
-// GetLabelsByKey mocks base method.
-func (m *MockVMService) GetLabelsByKey(key string) ([]*models.Label, error) {
+// GetLabelsByKeyAndValueStarts mocks base method.
+func (m *MockVMService) GetLabelsByKeyAndValueStarts(key, valueStart string) ([]*models.Label, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLabelsByKey", key)
+	ret := m.ctrl.Call(m, "GetLabelsByKeyAndValueStarts", key, valueStart)
 	ret0, _ := ret[0].([]*models.Label)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLabelsByKey indicates an expected call of GetLabelsByKey.
-func (mr *MockVMServiceMockRecorder) GetLabelsByKey(key interface{}) *gomock.Call {
+// GetLabelsByKeyAndValueStarts indicates an expected call of GetLabelsByKeyAndValueStarts.
+func (mr *MockVMServiceMockRecorder) GetLabelsByKeyAndValueStarts(key, valueStart interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKey", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKey), key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKeyAndValueStarts", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKeyAndValueStarts), key, valueStart)
 }
 
 // GetTask mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -156,19 +156,19 @@ func (mr *MockVMServiceMockRecorder) GetHost(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHost", reflect.TypeOf((*MockVMService)(nil).GetHost), id)
 }
 
-// GetLabelsByKeyAndValueContains mocks base method.
-func (m *MockVMService) GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error) {
+// GetLabelByID mocks base method.
+func (m *MockVMService) GetLabelByID(labelID string) (*models.Label, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLabelsByKeyAndValueContains", key, valueContains)
-	ret0, _ := ret[0].([]*models.Label)
+	ret := m.ctrl.Call(m, "GetLabelByID", labelID)
+	ret0, _ := ret[0].(*models.Label)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLabelsByKeyAndValueContains indicates an expected call of GetLabelsByKeyAndValueContains.
-func (mr *MockVMServiceMockRecorder) GetLabelsByKeyAndValueContains(key, valueContains interface{}) *gomock.Call {
+// GetLabelByID indicates an expected call of GetLabelByID.
+func (mr *MockVMServiceMockRecorder) GetLabelByID(labelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKeyAndValueContains", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKeyAndValueContains), key, valueContains)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelByID", reflect.TypeOf((*MockVMService)(nil).GetLabelByID), labelID)
 }
 
 // GetTask mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -156,6 +156,21 @@ func (mr *MockVMServiceMockRecorder) GetHost(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHost", reflect.TypeOf((*MockVMService)(nil).GetHost), id)
 }
 
+// GetLabelsByKey mocks base method.
+func (m *MockVMService) GetLabelsByKey(key string) ([]*models.Label, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLabelsByKey", key)
+	ret0, _ := ret[0].([]*models.Label)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLabelsByKey indicates an expected call of GetLabelsByKey.
+func (mr *MockVMServiceMockRecorder) GetLabelsByKey(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKey", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKey), key)
+}
+
 // GetTask mocks base method.
 func (m *MockVMService) GetTask(id string) (*models.Task, error) {
 	m.ctrl.T.Helper()
@@ -171,6 +186,21 @@ func (mr *MockVMServiceMockRecorder) GetTask(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockVMService)(nil).GetTask), id)
 }
 
+// GetVMDisksByVMID mocks base method.
+func (m *MockVMService) GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMDisksByVMID", vmID)
+	ret0, _ := ret[0].([]*models.VMDisk)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMDisksByVMID indicates an expected call of GetVMDisksByVMID.
+func (mr *MockVMServiceMockRecorder) GetVMDisksByVMID(vmID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMDisksByVMID", reflect.TypeOf((*MockVMService)(nil).GetVMDisksByVMID), vmID)
+}
+
 // GetVMTemplate mocks base method.
 func (m *MockVMService) GetVMTemplate(id string) (*models.ContentLibraryVMTemplate, error) {
 	m.ctrl.T.Helper()
@@ -184,6 +214,21 @@ func (m *MockVMService) GetVMTemplate(id string) (*models.ContentLibraryVMTempla
 func (mr *MockVMServiceMockRecorder) GetVMTemplate(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMTemplate", reflect.TypeOf((*MockVMService)(nil).GetVMTemplate), id)
+}
+
+// GetVMVolumeByID mocks base method.
+func (m *MockVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMVolumeByID", volumeID)
+	ret0, _ := ret[0].(*models.VMVolume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMVolumeByID indicates an expected call of GetVMVolumeByID.
+func (mr *MockVMServiceMockRecorder) GetVMVolumeByID(volumeID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMVolumeByID", reflect.TypeOf((*MockVMService)(nil).GetVMVolumeByID), volumeID)
 }
 
 // GetVlan mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -156,19 +156,19 @@ func (mr *MockVMServiceMockRecorder) GetHost(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHost", reflect.TypeOf((*MockVMService)(nil).GetHost), id)
 }
 
-// GetLabelsByKeyAndValueStarts mocks base method.
-func (m *MockVMService) GetLabelsByKeyAndValueStarts(key, valueStart string) ([]*models.Label, error) {
+// GetLabelsByKeyAndValueContains mocks base method.
+func (m *MockVMService) GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLabelsByKeyAndValueStarts", key, valueStart)
+	ret := m.ctrl.Call(m, "GetLabelsByKeyAndValueContains", key, valueContains)
 	ret0, _ := ret[0].([]*models.Label)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLabelsByKeyAndValueStarts indicates an expected call of GetLabelsByKeyAndValueStarts.
-func (mr *MockVMServiceMockRecorder) GetLabelsByKeyAndValueStarts(key, valueStart interface{}) *gomock.Call {
+// GetLabelsByKeyAndValueContains indicates an expected call of GetLabelsByKeyAndValueContains.
+func (mr *MockVMServiceMockRecorder) GetLabelsByKeyAndValueContains(key, valueContains interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKeyAndValueStarts", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKeyAndValueStarts), key, valueStart)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelsByKeyAndValueContains", reflect.TypeOf((*MockVMService)(nil).GetLabelsByKeyAndValueContains), key, valueContains)
 }
 
 // GetTask mocks base method.

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -60,7 +60,7 @@ type VMService interface {
 	AddLabelsToVM(vmID string, labels []string) (*models.Task, error)
 	GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error)
 	GetVMVolumeByID(volumeID string) (*models.VMVolume, error)
-	GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error)
+	GetLabelByID(labelID string) (*models.Label, error)
 }
 
 type NewVMServiceFunc func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error)
@@ -592,12 +592,11 @@ func (svr *TowerVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, e
 	return getVMVolumeResp.Payload[0], nil
 }
 
-func (svr *TowerVMService) GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error) {
+func (svr *TowerVMService) GetLabelByID(labelID string) (*models.Label, error) {
 	getLabelParams := clientlabel.NewGetLabelsParams()
 	getLabelParams.RequestBody = &models.GetLabelsRequestBody{
 		Where: &models.LabelWhereInput{
-			Key:           util.TowerString(key),
-			ValueContains: util.TowerString(valueContains),
+			ID: util.TowerString(labelID),
 		},
 	}
 
@@ -606,5 +605,9 @@ func (svr *TowerVMService) GetLabelsByKeyAndValueContains(key, valueContains str
 		return nil, err
 	}
 
-	return getLabelResp.Payload, nil
+	if len(getLabelResp.Payload) == 0 {
+		return nil, errors.New(LabelNotFound)
+	}
+
+	return getLabelResp.Payload[0], nil
 }

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -60,7 +60,7 @@ type VMService interface {
 	AddLabelsToVM(vmID string, labels []string) (*models.Task, error)
 	GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error)
 	GetVMVolumeByID(volumeID string) (*models.VMVolume, error)
-	GetLabelsByKeyAndValueStarts(key, valueStart string) ([]*models.Label, error)
+	GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error)
 }
 
 type NewVMServiceFunc func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error)
@@ -592,12 +592,12 @@ func (svr *TowerVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, e
 	return getVMVolumeResp.Payload[0], nil
 }
 
-func (svr *TowerVMService) GetLabelsByKeyAndValueStarts(key, valueStarts string) ([]*models.Label, error) {
+func (svr *TowerVMService) GetLabelsByKeyAndValueContains(key, valueContains string) ([]*models.Label, error) {
 	getLabelParams := clientlabel.NewGetLabelsParams()
 	getLabelParams.RequestBody = &models.GetLabelsRequestBody{
 		Where: &models.LabelWhereInput{
-			Key:             util.TowerString(key),
-			ValueStartsWith: util.TowerString(valueStarts),
+			Key:           util.TowerString(key),
+			ValueContains: util.TowerString(valueContains),
 		},
 	}
 

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -28,6 +28,8 @@ import (
 	clienttask "github.com/smartxworks/cloudtower-go-sdk/v2/client/task"
 	clientvlan "github.com/smartxworks/cloudtower-go-sdk/v2/client/vlan"
 	clientvm "github.com/smartxworks/cloudtower-go-sdk/v2/client/vm"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/client/vm_disk"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/client/vm_volume"
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
@@ -56,6 +58,9 @@ type VMService interface {
 	UpsertLabel(key, value string) (*models.Label, error)
 	DeleteLabel(key, value string, strict bool) (string, error)
 	AddLabelsToVM(vmID string, labels []string) (*models.Task, error)
+	GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error)
+	GetVMVolumeByID(volumeID string) (*models.VMVolume, error)
+	GetLabelsByKey(key string) ([]*models.Label, error)
 }
 
 type NewVMServiceFunc func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error)
@@ -547,4 +552,58 @@ func (svr *TowerVMService) AddLabelsToVM(vmID string, labelIds []string) (*model
 		return nil, errors.New(LabelAddFailed)
 	}
 	return &models.Task{ID: addLabelsResp.Payload[0].TaskID}, nil
+}
+
+func (svr *TowerVMService) GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error) {
+	getVMDiskParams := vm_disk.NewGetVMDisksParams()
+	getVMDiskParams.RequestBody = &models.GetVMDisksRequestBody{
+		Where: &models.VMDiskWhereInput{
+			VM: &models.VMWhereInput{
+				OR: []*models.VMWhereInput{{LocalID: util.TowerString(vmID)}, {ID: util.TowerString(vmID)}},
+			},
+		},
+	}
+
+	getVMDiskResp, err := svr.Session.VMDisk.GetVMDisks(getVMDiskParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return getVMDiskResp.Payload, nil
+}
+
+func (svr *TowerVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, error) {
+	getVMVolumeParams := vm_volume.NewGetVMVolumesParams()
+	getVMVolumeParams.RequestBody = &models.GetVMVolumesRequestBody{
+		Where: &models.VMVolumeWhereInput{
+			ID: util.TowerString(volumeID),
+		},
+	}
+
+	getVMVolumeResp, err := svr.Session.VMVolume.GetVMVolumes(getVMVolumeParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(getVMVolumeResp.Payload) == 0 {
+		return nil, errors.New(VMVolumeNotFound)
+	}
+
+	return getVMVolumeResp.Payload[0], nil
+}
+
+func (svr *TowerVMService) GetLabelsByKey(key string) ([]*models.Label, error) {
+	getLabelParams := clientlabel.NewGetLabelsParams()
+	getLabelParams.RequestBody = &models.GetLabelsRequestBody{
+		Where: &models.LabelWhereInput{
+
+			Key: util.TowerString(key),
+		},
+	}
+	getLabelResp, err := svr.Session.Label.GetLabels(getLabelParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return getLabelResp.Payload, nil
 }

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -60,7 +60,7 @@ type VMService interface {
 	AddLabelsToVM(vmID string, labels []string) (*models.Task, error)
 	GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error)
 	GetVMVolumeByID(volumeID string) (*models.VMVolume, error)
-	GetLabelsByKey(key string) ([]*models.Label, error)
+	GetLabelsByKeyAndValueStarts(key, valueStart string) ([]*models.Label, error)
 }
 
 type NewVMServiceFunc func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error)
@@ -592,14 +592,15 @@ func (svr *TowerVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, e
 	return getVMVolumeResp.Payload[0], nil
 }
 
-func (svr *TowerVMService) GetLabelsByKey(key string) ([]*models.Label, error) {
+func (svr *TowerVMService) GetLabelsByKeyAndValueStarts(key, valueStarts string) ([]*models.Label, error) {
 	getLabelParams := clientlabel.NewGetLabelsParams()
 	getLabelParams.RequestBody = &models.GetLabelsRequestBody{
 		Where: &models.LabelWhereInput{
-
-			Key: util.TowerString(key),
+			Key:             util.TowerString(key),
+			ValueStartsWith: util.TowerString(valueStarts),
 		},
 	}
+
 	getLabelResp, err := svr.Session.Label.GetLabels(getLabelParams)
 	if err != nil {
 		return nil, err

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -66,3 +66,35 @@ func NewTowerLabel() *models.Label {
 		Value: &value,
 	}
 }
+
+func NewTowerVMDisk(vmID, vmVolumeID string) *models.VMDisk {
+	id := strings.ReplaceAll(uuid.New().String(), "-", "")
+	diskType := models.VMDiskTypeDISK
+	return &models.VMDisk{
+		ID: &id,
+		VM: &models.NestedVM{
+			ID: &vmID,
+		},
+		VMVolume: &models.NestedVMVolume{
+			ID: &vmVolumeID,
+		},
+		Type: &diskType,
+	}
+}
+
+func NewTowerLabelWithKeyValue(key, value string) *models.Label {
+	id := strings.ReplaceAll(uuid.New().String(), "-", "")
+
+	return &models.Label{
+		ID:    &id,
+		Key:   &key,
+		Value: &value,
+	}
+}
+
+func NewTowerVMVolume() *models.VMVolume {
+	id := strings.ReplaceAll(uuid.New().String(), "-", "")
+	return &models.VMVolume{
+		ID: &id,
+	}
+}


### PR DESCRIPTION
Changes:
1.  支持在elfMachine删除时，等待ELF CSI 挂载的volume全部卸载完成后，在删除对应的VM

Tests:
1.  vm挂载ELF CSI 创建的volume，删除elfMachine

ks集群
<img width="929" alt="image" src="https://user-images.githubusercontent.com/114376205/200493823-d84b2cbf-850a-477f-a1bf-927e7d07e37a.png">
ELF CSI volume挂载的VM
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/114376205/200494045-9eb37acd-2f8f-42a2-8f5f-5972b51e3cc3.png">
直接删除elfMachine
<img width="661" alt="image" src="https://user-images.githubusercontent.com/114376205/200494468-79f9b4bc-6434-4de7-a183-691b19e2b6e5.png">
cape日志
<img width="765" alt="image" src="https://user-images.githubusercontent.com/114376205/200494607-498feff1-6949-4230-8af5-55a7b1b683c2.png">
删除machine等待volume全部被卸载
<img width="846" alt="image" src="https://user-images.githubusercontent.com/114376205/200496848-dea520b1-3cfe-41e5-a1c4-2d2510643b98.png">
vm对应ELF CSI挂载的volume全部卸载完成，并开始关机
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/114376205/200496753-14d65b3e-f33d-4835-96b5-d9c46c4b7115.png">
machine 成功删除
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/114376205/200497132-ea906974-6aff-4342-9259-985e9dfcfff5.png">
2.  vm挂载ELF CSI 创建的volume，删除ks集群

ks集群
<img width="711" alt="image" src="https://user-images.githubusercontent.com/114376205/200498760-fd168659-d4ad-4e9f-bb24-e1023e866273.png">
ELF CSI volume挂载的VM
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/114376205/200499020-7f27e6dd-cf3e-4bb8-a06a-1adc243d651c.png">

跳过volume detach等待，直接关机删除vm
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/114376205/200499157-be6c2a20-e12b-49f8-8597-2f9895cd140f.png">
