### PR TITLE
Set ElfMachine to failure status when the VM was moved to the Tower recycle bin

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -391,20 +391,16 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 	}
 
 	vm, err := r.reconcileVM(ctx)
-	if err != nil {
-		if service.IsVMNotFound(err) {
-			if ctx.ElfMachine.IsFailed() {
-				return reconcile.Result{}, nil
-			}
+	if ctx.ElfMachine.IsFailed() {
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		ctx.Logger.Error(err, "failed to reconcile VM")
 
+		if service.IsVMNotFound(err) {
 			return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
 		}
 
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile VM")
-	}
-
-	if ctx.ElfMachine.IsFailed() {
-		return reconcile.Result{}, nil
 	}
 
 	if vm == nil || *vm.Status != models.VMStatusRUNNING || !util.IsUUID(ctx.ElfMachine.Status.VMRef) {

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -560,9 +560,9 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 		ctx.ElfMachine.SetVM(*vm.LocalID)
 	}
 
-	// The VM was moved to the recycle bin
-	if vm.InRecycleBin != nil && *vm.InRecycleBin {
-		message := fmt.Sprintf("The VM %s was moved to the recycle bin.", ctx.ElfMachine.Status.VMRef)
+	// The VM was moved to the recycle bin. Treat the VM as deleted, and will not reconganize it even if it's moved back from the recycle bin.
+	if util.IsVMInRecycleBin(vm) {
+		message := fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", ctx.ElfMachine.Status.VMRef)
 		ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
 		ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(message)
 		ctx.ElfMachine.SetVM("")

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -380,8 +380,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(err.Error()).To(ContainSubstring("failed to create VM for ElfMachine"))
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(result.RequeueAfter).NotTo(BeZero())
+			Expect(err).To(BeNil())
+			Expect(logBuffer.String()).To(ContainSubstring("failed to create VM for ElfMachine"))
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(elfMachine.Status.VMRef).To(Equal(""))
@@ -406,12 +408,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(err.Error()).To(ContainSubstring("failed to create VM for ElfMachine"))
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(err).Should(BeNil())
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(elfMachine.Status.VMRef).To(Equal(""))
 			Expect(elfMachine.Status.TaskRef).To(Equal(""))
+			Expect(elfMachine.IsFailed()).To(BeTrue())
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.TaskFailureReason}})
 		})
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -361,7 +361,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).Should(BeNil())
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(*elfMachine.Status.FailureReason).To(Equal(capierrors.UpdateMachineError))
-			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("The VM %s was moved to the recycle bin.", *vm.LocalID)))
+			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", *vm.LocalID)))
 			Expect(elfMachine.HasVM()).To(BeFalse())
 		})
 

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -38,7 +38,7 @@ const (
 )
 
 func IsVMNotFound(err error) bool {
-	return err.Error() == VMNotFound
+	return strings.Contains(err.Error(), VMNotFound)
 }
 
 func IsVMDuplicate(err error) bool {
@@ -50,7 +50,7 @@ func IsShutDownTimeout(message string) bool {
 }
 
 func IsTaskNotFound(err error) bool {
-	return err.Error() == TaskNotFound
+	return strings.Contains(err.Error(), TaskNotFound)
 }
 
 func IsCloudInitConfigError(message string) bool {
@@ -58,7 +58,7 @@ func IsCloudInitConfigError(message string) bool {
 }
 
 func IsLabelNotFound(err error) bool {
-	return err.Error() == LabelNotFound
+	return strings.Contains(err.Error(), LabelNotFound)
 }
 
 // FormatCloudInitError parses useful error message from orignal tower error message.

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package util
 
+import (
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+)
+
 func TowerInt32(v int) *int32 {
 	val := int32(v)
 
@@ -51,4 +55,8 @@ func TowerDisk(diskGiB int32) *int64 {
 	disk = disk * 1024 * 1024 * 1024
 
 	return &disk
+}
+
+func IsVMInRecycleBin(vm *models.VM) bool {
+	return vm.InRecycleBin != nil && *vm.InRecycleBin
 }


### PR DESCRIPTION
测试
1.创建集群
2.关闭 CAPE 服务
3.关闭其中一个虚拟机，并移到回收站
![image](https://user-images.githubusercontent.com/19967151/201293354-2a4ebec2-49ed-474b-8ff8-37a373ba5d2b.png)

4.启动 CAPE 服务，未发现在回收站的虚拟机被开机

5.删除集群或删除在回收站虚拟机对应的 Machine，在回收站的虚拟机没有被删除
![image](https://user-images.githubusercontent.com/19967151/201293442-1131bfae-6686-454d-b302-010c0aa93022.png)
