### PR TITLE
Remove the 'cape-managed' label for VM when there is no clusters

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -225,15 +225,19 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteLabels(ctx *context.ClusterContext) error {
-	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelNamespace(), ctx.ElfCluster.Namespace, true); err != nil {
-		return err
-	}
-
 	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelClusterName(), ctx.ElfCluster.Name, true); err != nil {
 		return err
 	}
 
 	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelVIP(), ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host, true); err != nil {
+		return err
+	}
+
+	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelNamespace(), ctx.ElfCluster.Namespace, true); err != nil {
+		return err
+	}
+
+	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelManaged(), "true", true); err != nil {
 		return err
 	}
 

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -250,7 +250,7 @@ func (r *ElfClusterReconciler) reconcileDeleteLabel(ctx *context.ClusterContext,
 		return err
 	}
 	if labelID != "" {
-		ctx.Logger.Info(fmt.Sprintf("label %s:%s already deleted", key, value), "labelId", labelID)
+		ctx.Logger.Info(fmt.Sprintf("Label %s:%s deleted", key, value), "labelId", labelID)
 	}
 
 	return nil

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -210,9 +210,10 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
-			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
+			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
+			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelManaged(), "true", true).Return("", nil)
 
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfClusterKey := capiutil.ObjectKey(elfCluster)

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -220,7 +220,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("label %s:%s already deleted", label.GetVMLabelClusterName(), elfCluster.Name)))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", label.GetVMLabelClusterName(), elfCluster.Name)))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})
 


### PR DESCRIPTION
SKS-151：删除所有的集群后 managed 标签没有被删除。



集群共用标签放在最后删除，可以进一步提高标签被删除的概率。

![image](https://user-images.githubusercontent.com/19967151/201605678-b836e45b-49c3-4d5f-88df-9a4bbc0f9091.png)

![image](https://user-images.githubusercontent.com/19967151/201605711-63ea94bc-08fa-4119-8087-ac8de69fb745.png)
