### PR TITLE
Add more task details for vm task logs

### DIFF
--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -68,3 +68,11 @@ func GetTowerString(ptr *string) string {
 
 	return *ptr
 }
+
+func GetTowerTaskStatus(ptr *models.TaskStatus) string {
+	if ptr == nil {
+		return ""
+	}
+
+	return string(*ptr)
+}


### PR DESCRIPTION
### 问题
SKS-678

当前 vm task 相关的日志输出信息较少，需要到 Tower 查看更多的信息。

需要针对 task 不同的状态，输出不同相关的字段信息。

### 测试

任务进行中，增加 taskDescription
```yaml
"msg"="Waiting for VM task done" "elfCluster"="elfk8s1" "elfMachine"="elfk8s1-control-plane-w2t2x" "namespace"="default" "taskDescription"="Power off VM elfk8s1-control-plane-w2t2x" "taskRef"="claqh27ck4ys81tud504w4vkc" "taskStatus"="PENDING" "vmRef"="79a9e899-2524-497a-9c00-67e272558d1b"
```

任务失败，增加 taskErrorCode、taskDescription
```yaml
"error"="VM task failed" "elfCluster"="elfk8s1" "elfMachine"="elfk8s1-control-plane-gzbsg" "namespace"="default" "taskDescription"="Create a VM elfk8s1-control-plane-gzbsg from a VM template Rocky-k8s-1.22.13-0831-2" "taskErrorCode"="CREATE_VM_FORM_TEMPLATE_FAILED" "taskErrorMessage"="Cannot unwrap Ok value of Result.Err.\r\ncode: CREATE_VM_FORM_TEMPLATE_FAILED\r\nmessage: {\"data\":{},\"ec\":\"VM_CLOUD_INIT_CONFIG_ERROR\",\"error\":{\"msg\":\"[VM_CLOUD_INIT_CONFIG_ERROR]The gateway [192.168.31.211] is unreachable. \"}}" "taskRef"="claqh8ehp4zv91tudc714enmc" "vmRef"="claqh8ehgvz1l0958m4zsm5z0"
```

任务成功，增加 taskDescription
```yaml
"msg"="VM task successful" "elfCluster"="elfk8s1" "elfMachine"="elfk8s1-control-plane-dlsld" "namespace"="default" "taskDescription"="Create a VM elfk8s1-control-plane-dlsld from a VM template Rocky-k8s-1.22.13-0831-2" "taskRef"="claqfq2pa4jtc1tud9ultfgkb" "vmRef"="claqfq2p1glhv09580u7lq63a"
```
