### PR TITLE
SKS-645: Remove 'shouldWaitForVMVolumesToBeDetached' when ElfMachine is deleted

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -32,9 +32,6 @@ const (
 
 	// VMDisconnectionTimestampAnnotation is the annotation identifying the VM of ElfMachine disconnection time.
 	VMDisconnectionTimestampAnnotation = "cape.infrastructure.cluster.x-k8s.io/vm-disconnection-timestamp"
-
-	// DefaultELFCSIVMVolumeClusterLabel is the cluster label key of VM Volume which created by ELF CSI in Tower.
-	DefaultELFCSIVMVolumeClusterLabel = "system.cloudtower/elf-csi.k8s-cluster-id"
 )
 
 // ElfMachineSpec defines the desired state of ElfMachine.

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -666,7 +665,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.ID).Return(vm, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(*vm.ID).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -694,7 +692,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.LocalID).Return(vm, nil)
 			mockVMService.EXPECT().ShutDown(*vm.LocalID).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(*vm.LocalID).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -719,7 +716,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			vmNotFoundError := errors.New(service.VMNotFound)
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, vmNotFoundError)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -745,7 +741,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -773,7 +768,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(task, errors.New("some error"))
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
@@ -803,7 +797,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().PowerOff(elfMachine.Status.VMRef).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -833,7 +826,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(nil, errors.New("some error"))
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -856,7 +848,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -882,7 +873,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(nil, errors.New("some error"))
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -907,7 +897,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -935,7 +924,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().PowerOff(elfMachine.Status.VMRef).Return(task, nil)
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -948,178 +936,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(elfMachine.Status.VMRef).To(Equal(*vm.LocalID))
 			Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletingReason}})
-		})
-
-		It("should wait for vm volume which create by ELF CSI to be detached", func() {
-			vm := fake.NewTowerVM()
-			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
-			volume.Labels = []*models.NestedLabel{{
-				ID: towerLabel.ID,
-			}}
-			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelByID(*towerLabel.ID).Return(towerLabel, nil)
-			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(volume, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).NotTo(BeZero())
-			Expect(err).To(BeZero())
-			Expect(logBuffer.String()).To(ContainSubstring("Waiting for 1 VM volumes which created by ELF CSI to be detached"))
-		})
-
-		It("should return error when get VM Disk failed", func() {
-			vm := fake.NewTowerVM()
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return(nil, errors.New("failed to get VM Disk"))
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get VM Disk"))
-		})
-
-		It("should return error when get labels which created by ELF CSI failed", func() {
-			vm := fake.NewTowerVM()
-			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
-			volume.Labels = []*models.NestedLabel{{
-				ID: towerLabel.ID,
-			}}
-			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetLabelByID(*towerLabel.ID).Return(nil, errors.New("failed to get label"))
-			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(volume, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get label"))
-		})
-
-		It("should return error when get VM volume failed", func() {
-			vm := fake.NewTowerVM()
-			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
-			volume.Labels = []*models.NestedLabel{{
-				ID: towerLabel.ID,
-			}}
-			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(nil, errors.New("failed to get volume"))
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get volume"))
-		})
-
-		It("should delete when VM Disk VM Volume is nil", func() {
-			vm := fake.NewTowerVM()
-			volume := fake.NewTowerVMVolume()
-			towerLabel := fake.NewTowerLabelWithKeyValue(infrav1.DefaultELFCSIVMVolumeClusterLabel, fmt.Sprintf("test.%s.%s.%s", cluster.Namespace, cluster.Name, uuid.NewString()))
-			volume.Labels = []*models.NestedLabel{{
-				ID: towerLabel.ID,
-			}}
-			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
-			vmDisk.VMVolume = nil
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("VM already deleted"))
-			elfMachine = &infrav1.ElfMachine{}
-			err = reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
-
-		It("should delete when vm volume which create by ELF CSI has been detached", func() {
-			vm := fake.NewTowerVM()
-			volume := fake.NewTowerVMVolume()
-			vmDisk := fake.NewTowerVMDisk(*vm.ID, *volume.ID)
-
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
-			mockVMService.EXPECT().GetVMDisksByVMID(elfMachine.Status.VMRef).Return([]*models.VMDisk{vmDisk}, nil)
-			mockVMService.EXPECT().GetVMVolumeByID(*volume.ID).Return(volume, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("VM already deleted"))
-			elfMachine = &infrav1.ElfMachine{}
-			err = reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
-
-		It("should skip wait for vm volume which create by ELF CSI to be detached when cluster is being deleted", func() {
-			vm := fake.NewTowerVM()
-			cluster.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
-			elfMachine.Status.VMRef = *vm.LocalID
-			elfCluster.Spec.VMGracefulShutdown = false
-			cluster.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
-
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, errors.New(service.VMNotFound))
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("VM already deleted"))
-			elfMachine = &infrav1.ElfMachine{}
-			err = reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -33,8 +33,6 @@ const (
 	LabelCreateFailed  = "LABEL_CREATE_FAILED"
 	LabelAddFailed     = "LABEL_ADD_FAILED"
 	CloudInitError     = "VM_CLOUD_INIT_CONFIG_ERROR"
-	VMVolumeNotFound   = "VM_VOLUME_NOT_FOUND"
-	LabelNotFound      = "LABEL_NOT_FOUND"
 )
 
 func IsVMNotFound(err error) bool {
@@ -55,10 +53,6 @@ func IsTaskNotFound(err error) bool {
 
 func IsCloudInitConfigError(message string) bool {
 	return strings.Contains(message, CloudInitError)
-}
-
-func IsLabelNotFound(err error) bool {
-	return strings.Contains(err.Error(), LabelNotFound)
 }
 
 // FormatCloudInitError parses useful error message from orignal tower error message.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -156,21 +156,6 @@ func (mr *MockVMServiceMockRecorder) GetHost(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHost", reflect.TypeOf((*MockVMService)(nil).GetHost), id)
 }
 
-// GetLabelByID mocks base method.
-func (m *MockVMService) GetLabelByID(labelID string) (*models.Label, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLabelByID", labelID)
-	ret0, _ := ret[0].(*models.Label)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLabelByID indicates an expected call of GetLabelByID.
-func (mr *MockVMServiceMockRecorder) GetLabelByID(labelID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelByID", reflect.TypeOf((*MockVMService)(nil).GetLabelByID), labelID)
-}
-
 // GetTask mocks base method.
 func (m *MockVMService) GetTask(id string) (*models.Task, error) {
 	m.ctrl.T.Helper()
@@ -186,21 +171,6 @@ func (mr *MockVMServiceMockRecorder) GetTask(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockVMService)(nil).GetTask), id)
 }
 
-// GetVMDisksByVMID mocks base method.
-func (m *MockVMService) GetVMDisksByVMID(vmID string) ([]*models.VMDisk, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVMDisksByVMID", vmID)
-	ret0, _ := ret[0].([]*models.VMDisk)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVMDisksByVMID indicates an expected call of GetVMDisksByVMID.
-func (mr *MockVMServiceMockRecorder) GetVMDisksByVMID(vmID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMDisksByVMID", reflect.TypeOf((*MockVMService)(nil).GetVMDisksByVMID), vmID)
-}
-
 // GetVMTemplate mocks base method.
 func (m *MockVMService) GetVMTemplate(id string) (*models.ContentLibraryVMTemplate, error) {
 	m.ctrl.T.Helper()
@@ -214,21 +184,6 @@ func (m *MockVMService) GetVMTemplate(id string) (*models.ContentLibraryVMTempla
 func (mr *MockVMServiceMockRecorder) GetVMTemplate(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMTemplate", reflect.TypeOf((*MockVMService)(nil).GetVMTemplate), id)
-}
-
-// GetVMVolumeByID mocks base method.
-func (m *MockVMService) GetVMVolumeByID(volumeID string) (*models.VMVolume, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVMVolumeByID", volumeID)
-	ret0, _ := ret[0].(*models.VMVolume)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVMVolumeByID indicates an expected call of GetVMVolumeByID.
-func (mr *MockVMServiceMockRecorder) GetVMVolumeByID(volumeID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMVolumeByID", reflect.TypeOf((*MockVMService)(nil).GetVMVolumeByID), volumeID)
 }
 
 // GetVlan mocks base method.

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -66,35 +66,3 @@ func NewTowerLabel() *models.Label {
 		Value: &value,
 	}
 }
-
-func NewTowerVMDisk(vmID, vmVolumeID string) *models.VMDisk {
-	id := strings.ReplaceAll(uuid.New().String(), "-", "")
-	diskType := models.VMDiskTypeDISK
-	return &models.VMDisk{
-		ID: &id,
-		VM: &models.NestedVM{
-			ID: &vmID,
-		},
-		VMVolume: &models.NestedVMVolume{
-			ID: &vmVolumeID,
-		},
-		Type: &diskType,
-	}
-}
-
-func NewTowerLabelWithKeyValue(key, value string) *models.Label {
-	id := strings.ReplaceAll(uuid.New().String(), "-", "")
-
-	return &models.Label{
-		ID:    &id,
-		Key:   &key,
-		Value: &value,
-	}
-}
-
-func NewTowerVMVolume() *models.VMVolume {
-	id := strings.ReplaceAll(uuid.New().String(), "-", "")
-	return &models.VMVolume{
-		ID: &id,
-	}
-}


### PR DESCRIPTION
问题：
[SKS-645] VM异常场景下，capi machine配置nodeDrainTimeout， 替换节点失败 - Jira http://jira.smartx.com/browse/SKS-645

问题根因：
STS Pod在k8s node status not ready的场景下，无法正常删除，无法触发ELF CSI volume detach，进而影响ELF Machine的删除

修复方案：
[[SKS-645]K8s节点失联处理的设计文档](https://docs.google.com/document/d/19-GjuJT29Q8GwxpLw2aS7lEVPyQYohrArjROzHlz2kw/edit#)

测试：

测试步骤:

 1. 创建一个安装ELF CSI，logging,monitoring开启的sks集群
 2. 删除worker node hw-sks-test-1.23-elf-op-3-workergroup-mp6hj 的网卡
 3. K8s node hw-sks-test-1.23-elf-op-3-workergroup-mp6hj显示not ready
 4. delete Machine hw-sks-test-1.23-elf-op-3-workergroup-d475b4648-clmld
```
I1122 12:34:43.659300       1 machine_controller.go:318] "Draining node" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" machine="default/hw-sks-test-1.23-elf-op-3-workergroup-d475b4648-clmld" namespace="default" name="hw-sks-test-1.23-elf-op-3-workergroup-d475b4648-clmld" reconcileID=3bc4a4b0-a5f4-4af7-90d1-790a12941ac2 cluster="hw-sks-test-1.23-elf-op-3" node="hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
```
 5. 等待10分钟后，开始删除ELF Machin A
```
I1122 12:45:03.174737       1 elfmachine_controller.go:288] cape-controller-manager/elfmachine-controller "msg"="Reconciling ElfMachine delete" "elfCluster"="hw-sks-test-1.23-elf-op-3" "elfMachine"="hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" "namespace"="default"
```
 6. ELF Machine 删除完成
```
I1122 12:45:44.828629       1 elfmachine_controller.go:232] cape-controller-manager/elfmachine-controller "msg"="VM already deleted" "elfCluster"="hw-sks-test-1.23-elf-op-3" "elfMachine"="hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" "namespace"="default"
E1122 12:45:44.841205       1 elfmachine_controller.go:215] cape-controller-manager/elfmachine-controller "msg"="patch failed" "error"="elfmachines.infrastructure.cluster.x-k8s.io \"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj\" not found" "elfCluster"="hw-sks-test-1.23-elf-op-3" "namespace"="default" "elfMachine"="infrastructure.cluster.x-k8s.io/v1beta1, Kind=ElfMachine default/hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
E1122 12:45:44.841842       1 controller.go:326]  "msg"="Reconciler error" "error"="elfmachines.infrastructure.cluster.x-k8s.io \"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj\" not found" "controller"="elfmachine" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ElfMachine" "elfMachine"={"name":"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj","namespace":"default"} "name"="hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" "namespace"="default" "reconcileID"="d5dc082e-8ccb-4b22-9fbb-fa53cd673df4"
```
7.  7分钟后触发ELF CSI ControllerUnpublishVolume
```
I1122 12:52:39.070054       8 driver.go:127] start call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nmnhseyf0858z8f30fyn" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
I1122 12:52:39.264263       8 driver.go:127] start call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nz9zsj7i0858ljo1ctdb" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
I1122 12:52:39.402452       8 controller.go:500] VM Volume clas6nz9zsj7i0858ljo1ctdb is already unpublished in VM hw-sks-test-1.23-elf-op-3-workergroup-mp6hj, skip unpublish
I1122 12:52:39.402505       8 driver.go:136] call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nz9zsj7i0858ljo1ctdb" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" , resp
I1122 12:52:39.402459       8 controller.go:500] VM Volume clas6nmnhseyf0858z8f30fyn is already unpublished in VM hw-sks-test-1.23-elf-op-3-workergroup-mp6hj, skip unpublish
I1122 12:52:39.402646       8 driver.go:136] call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nmnhseyf0858z8f30fyn" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" , resp
I1122 12:52:39.475094       8 driver.go:127] start call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nygqsiyu08588kanwxu0" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
I1122 12:52:39.480222       8 driver.go:127] start call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nmnhseyf0858z8f30fyn" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj"
I1122 12:52:39.526765       8 controller.go:500] VM Volume clas6nmnhseyf0858z8f30fyn is already unpublished in VM hw-sks-test-1.23-elf-op-3-workergroup-mp6hj, skip unpublish
I1122 12:52:39.526808       8 driver.go:136] call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nmnhseyf0858z8f30fyn" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" , resp
I1122 12:52:39.535524       8 controller.go:500] VM Volume clas6nygqsiyu08588kanwxu0 is already unpublished in VM hw-sks-test-1.23-elf-op-3-workergroup-mp6hj, skip unpublish
I1122 12:52:39.535551       8 driver.go:136] call /csi.v1.Controller/ControllerUnpublishVolume, req volume_id:"clas6nygqsiyu08588kanwxu0" node_id:"hw-sks-test-1.23-elf-op-3-workergroup-mp6hj" , resp
```
 8.  KSC集群App正常
```
➜  elf-csi-op KUBECONFIG=~/.kube/1.23-config-elf-op-3 kubectl get App -A
NAMESPACE    NAME               DESCRIPTION           SINCE-DEPLOY   AGE
sks-system   calico             Reconcile succeeded   64s            77m
sks-system   elasticcurator     Reconcile succeeded   3m20s          72m
sks-system   elasticsearch      Reconcile succeeded   3m20s          72m
sks-system   kibana             Reconcile succeeded   63s            72m
sks-system   kube-prometheus    Reconcile succeeded   28s            72m
sks-system   logging-operator   Reconcile succeeded   2m34s          72m
sks-system   smtx-elf-csi       Reconcile succeeded   2m52s          77m
```