### PR TITLE
Use UUID to determine whether ELF virtual machine is created

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -400,6 +400,7 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 
 		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
 	}
+
 	// Reconcile the ElfMachine's Labels using the cluster info
 	if len(vm.Labels) == 0 {
 		if ok, err := r.reconcileLabels(ctx, vm); !ok {
@@ -543,9 +544,15 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 		return vm, nil
 	}
 
+	vmLocalID := util.GetTowerString(vm.LocalID)
+	// The ELF VM has not been created
+	if !util.IsUUID(vmLocalID) {
+		return vm, nil
+	}
+
 	// When ELF VM created, set UUID to VMRef
 	if !util.IsUUID(ctx.ElfMachine.Status.VMRef) {
-		ctx.ElfMachine.SetVM(*vm.LocalID)
+		ctx.ElfMachine.SetVM(vmLocalID)
 	}
 
 	// The VM was moved to the recycle bin. Treat the VM as deleted, and will not reconganize it even if it's moved back from the recycle bin.

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -60,3 +60,11 @@ func TowerDisk(diskGiB int32) *int64 {
 func IsVMInRecycleBin(vm *models.VM) bool {
 	return vm.InRecycleBin != nil && *vm.InRecycleBin
 }
+
+func GetTowerString(ptr *string) string {
+	if ptr == nil {
+		return ""
+	}
+
+	return *ptr
+}


### PR DESCRIPTION
### 问题 SKS-668
Tower 创建虚拟机的时候会先填写一个随机的 localId（UUID格式），当 ELF 虚拟机创建之后再更新为 ELF 虚拟机的 ID(UUID格式)，导致 CAPE 错误的认为虚拟机失联了。

### 解决
新版的 Tower 已更新为：当 localId 为 UUID 格式的时候表示 ELF 虚拟机已经成功创建。

### 测试
复现 SKS-668 创建虚拟机任务超时，观察到任务超时的虚拟没有失联，整个集群都成功创建了。

![image](https://user-images.githubusercontent.com/19967151/203717517-de68ef77-115c-413c-9f45-5d82848694b7.png)


```bash
NAME                        READY   PROVIDERID                                   IP             MACHINE                                AGE
elfk8s1-workergroup-97g2s   true    elf://6b44b5f4-bd01-4a5a-9f16-fae73658bc84   10.255.3.124   elfk8s1-workergroup-79bcf8c789-rxgch   9m33s
```
