### PR TITLE
Add error code for ElfMachine fails

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -50,7 +50,7 @@ import (
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
-	selferrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
+	capeerrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/label"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
@@ -512,7 +512,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			}
 
 			// If the machine was not found by UUID and timed out it means that it got deleted directly
-			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.RemoveFromInfrastructureError)
+			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capeerrors.RemovedFromInfrastructureError)
 			ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("Unable to find VM by UUID %s. The VM was removed from infrastructure.", ctx.ElfMachine.Status.VMRef))
 			ctx.Logger.Error(err, fmt.Sprintf("failed to get VM by UUID %s in %s", ctx.ElfMachine.Status.VMRef, infrav1.VMDisconnectionTimeout.String()), "message", ctx.ElfMachine.Status.FailureMessage)
 
@@ -560,7 +560,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 	// The VM was moved to the recycle bin. Treat the VM as deleted, and will not reconganize it even if it's moved back from the recycle bin.
 	if util.IsVMInRecycleBin(vm) {
 		message := fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", ctx.ElfMachine.Status.VMRef)
-		ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.InRecycleBinError)
+		ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capeerrors.MovedToRecycleBinError)
 		ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(message)
 		ctx.ElfMachine.SetVM("")
 		ctx.Logger.Error(stderrors.New(message), "")
@@ -623,7 +623,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.TaskFailureReason, clusterv1.ConditionSeverityInfo, errorMessage)
 
 		if service.IsCloudInitConfigError(errorMessage) {
-			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.CloudInitConfigError)
+			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capeerrors.CloudInitConfigError)
 			ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("VM cloud-init config error: %s", service.FormatCloudInitError(errorMessage)))
 		}
 

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -50,6 +50,7 @@ import (
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	selferrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/label"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
@@ -511,7 +512,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			}
 
 			// If the machine was not found by UUID and timed out it means that it got deleted directly
-			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
+			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.RemoveFromInfrastructureError)
 			ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("Unable to find VM by UUID %s. The VM was removed from infrastructure.", ctx.ElfMachine.Status.VMRef))
 			ctx.Logger.Error(err, fmt.Sprintf("failed to get VM by UUID %s in %s", ctx.ElfMachine.Status.VMRef, infrav1.VMDisconnectionTimeout.String()), "message", ctx.ElfMachine.Status.FailureMessage)
 
@@ -559,7 +560,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 	// The VM was moved to the recycle bin. Treat the VM as deleted, and will not reconganize it even if it's moved back from the recycle bin.
 	if util.IsVMInRecycleBin(vm) {
 		message := fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", ctx.ElfMachine.Status.VMRef)
-		ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
+		ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.InRecycleBinError)
 		ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(message)
 		ctx.ElfMachine.SetVM("")
 		ctx.Logger.Error(stderrors.New(message), "")
@@ -622,7 +623,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.TaskFailureReason, clusterv1.ConditionSeverityInfo, errorMessage)
 
 		if service.IsCloudInitConfigError(errorMessage) {
-			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.CreateMachineError)
+			ctx.ElfMachine.Status.FailureReason = capierrors.MachineStatusErrorPtr(selferrors.CloudInitConfigError)
 			ctx.ElfMachine.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("VM cloud-init config error: %s", service.FormatCloudInitError(errorMessage)))
 		}
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -46,7 +46,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
-	selferrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
+	capeerrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service/mock_services"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
@@ -340,7 +340,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.RemoveFromInfrastructureError))
+			Expect(*elfMachine.Status.FailureReason).To(Equal(capeerrors.RemovedFromInfrastructureError))
 			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("Unable to find VM by UUID %s. The VM was removed from infrastructure.", elfMachine.Status.VMRef)))
 		})
 
@@ -360,7 +360,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(result.RequeueAfter).To(BeZero())
 			Expect(err).Should(BeNil())
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.InRecycleBinError))
+			Expect(*elfMachine.Status.FailureReason).To(Equal(capeerrors.MovedToRecycleBinError))
 			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", *vm.LocalID)))
 			Expect(elfMachine.HasVM()).To(BeFalse())
 		})
@@ -416,7 +416,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(elfMachine.Status.VMRef).To(Equal(""))
 			Expect(elfMachine.Status.TaskRef).To(Equal(""))
 			Expect(elfMachine.IsFailed()).To(BeTrue())
-			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.CloudInitConfigError))
+			Expect(*elfMachine.Status.FailureReason).To(Equal(capeerrors.CloudInitConfigError))
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.TaskFailureReason}})
 		})
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -46,6 +46,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	selferrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service/mock_services"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
@@ -339,7 +340,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(*elfMachine.Status.FailureReason).To(Equal(capierrors.UpdateMachineError))
+			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.RemoveFromInfrastructureError))
 			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("Unable to find VM by UUID %s. The VM was removed from infrastructure.", elfMachine.Status.VMRef)))
 		})
 
@@ -359,7 +360,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(result.RequeueAfter).To(BeZero())
 			Expect(err).Should(BeNil())
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(*elfMachine.Status.FailureReason).To(Equal(capierrors.UpdateMachineError))
+			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.InRecycleBinError))
 			Expect(*elfMachine.Status.FailureMessage).To(Equal(fmt.Sprintf("The VM %s was moved to the Tower recycle bin by users, so treat it as deleted.", *vm.LocalID)))
 			Expect(elfMachine.HasVM()).To(BeFalse())
 		})
@@ -415,6 +416,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(elfMachine.Status.VMRef).To(Equal(""))
 			Expect(elfMachine.Status.TaskRef).To(Equal(""))
 			Expect(elfMachine.IsFailed()).To(BeTrue())
+			Expect(*elfMachine.Status.FailureReason).To(Equal(selferrors.CloudInitConfigError))
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.TaskFailureReason}})
 		})
 

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -24,9 +24,9 @@ const (
 	// CloudInitConfigError indicates an error occurred while configuring cloud-init.
 	CloudInitConfigError capierrors.MachineStatusError = "CloudInitConfigError"
 
-	// RemoveFromInfrastructureError indicates an error that the VM could not be found from the infrastructure.
-	RemoveFromInfrastructureError capierrors.MachineStatusError = "RemoveFromInfrastructure"
+	// RemovedFromInfrastructureError indicates an error that the VM could not be found from the infrastructure.
+	RemovedFromInfrastructureError capierrors.MachineStatusError = "RemovedFromInfrastructure"
 
-	// InRecycleBinError indicates an error that the VM was moved to the recycle bin.
-	InRecycleBinError capierrors.MachineStatusError = "InRecycleBin"
+	// MovedToRecycleBinError indicates an error that the VM was moved to the recycle bin.
+	MovedToRecycleBinError capierrors.MachineStatusError = "MovedToRecycleBin"
 )

--- a/pkg/errors/consts.go
+++ b/pkg/errors/consts.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+const (
+	// CloudInitConfigError indicates an error occurred while configuring cloud-init.
+	CloudInitConfigError capierrors.MachineStatusError = "CloudInitConfigError"
+
+	// RemoveFromInfrastructureError indicates an error that the VM could not be found from the infrastructure.
+	RemoveFromInfrastructureError capierrors.MachineStatusError = "RemoveFromInfrastructure"
+
+	// InRecycleBinError indicates an error that the VM was moved to the recycle bin.
+	InRecycleBinError capierrors.MachineStatusError = "InRecycleBin"
+)


### PR DESCRIPTION
增加 3 个 elfMachine failed 的错误码，用于填入 `elfMachine.status.failureReason` ：
* `CloudInitConfigError`
* `RemoveFromInfrastructure`
* `InRecycleBin`