### PR TITLE
Optimize the creation of virtual machines when insufficient memory detected for ELF cluster

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -465,13 +465,13 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			return nil, errors.New("bootstrapData is empty")
 		}
 
-		if ok, canRetry := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
-			if !canRetry {
-				ctx.Logger.V(2).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip creating VM", ctx.ElfCluster.Spec.Cluster))
+		if ok := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
+			if needDetect := needDetectElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); !needDetect {
+				ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip creating VM", ctx.ElfCluster.Spec.Cluster))
 				return nil, nil
 			}
 
-			ctx.Logger.V(2).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, try to create VM", ctx.ElfCluster.Spec.Cluster))
+			ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, try to create VM", ctx.ElfCluster.Spec.Cluster))
 		}
 
 		ctx.Logger.Info("Create VM for ElfMachine")
@@ -579,13 +579,13 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 
 	// The newly created VM may need to powered off
 	if *vm.Status == models.VMStatusSTOPPED {
-		if ok, canRetry := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
-			if !canRetry {
-				ctx.Logger.V(2).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip powering on VM %s", ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Status.VMRef))
+		if ok := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
+			if needDetect := needDetectElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); !needDetect {
+				ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip powering on VM %s", ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Status.VMRef))
 				return nil, nil
 			}
 
-			ctx.Logger.V(2).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, try to power on VM %s", ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Status.VMRef))
+			ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, try to power on VM %s", ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Status.VMRef))
 		}
 
 		task, err := ctx.VMService.PowerOn(ctx.ElfMachine.Status.VMRef)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -466,7 +466,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 		}
 
 		if ok := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
-			if needDetect := needDetectElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); !needDetect {
+			if canRetry := canRetryVMOperation(ctx.ElfCluster.Spec.Cluster); !canRetry {
 				ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip creating VM", ctx.ElfCluster.Spec.Cluster))
 				return nil, nil
 			}
@@ -580,7 +580,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 	// The newly created VM may need to powered off
 	if *vm.Status == models.VMStatusSTOPPED {
 		if ok := isElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); ok {
-			if needDetect := needDetectElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster); !needDetect {
+			if canRetry := canRetryVMOperation(ctx.ElfCluster.Spec.Cluster); !canRetry {
 				ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, skip powering on VM %s", ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Status.VMRef))
 				return nil, nil
 			}

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -1,0 +1,68 @@
+package controllers
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	silenceTime = time.Minute * 5
+)
+
+var clusterStatusMap = make(map[string]*clusterStatus)
+var lock sync.Mutex
+
+type clusterStatus struct {
+	Resources resources
+}
+
+type resources struct {
+	IsMemoryInsufficient bool
+	LastUpdated          time.Time
+	LastRtried           time.Time
+}
+
+// isElfClusterMemoryInsufficient returns whether the ELF cluster has insufficient memory,
+// and whether to allow retry if insufficient memory.
+func isElfClusterMemoryInsufficient(clusterID string) (bool, bool) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if status, ok := clusterStatusMap[clusterID]; ok {
+		if !status.Resources.IsMemoryInsufficient {
+			return false, false
+		}
+
+		if time.Now().Add(-silenceTime).Before(status.Resources.LastUpdated) {
+			return true, false
+		} else {
+			if time.Now().Add(-silenceTime).After(status.Resources.LastRtried) {
+				status.Resources.LastRtried = time.Now()
+				return true, true
+			} else {
+				return true, false
+			}
+		}
+	}
+
+	return false, false
+}
+
+// setElfClusterMemoryInsufficient sets whether the memory is insufficient.
+func setElfClusterMemoryInsufficient(clusterID string, isInsufficient bool) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	resources := resources{
+		IsMemoryInsufficient: isInsufficient,
+		LastUpdated:          time.Now(),
+	}
+
+	if status, ok := clusterStatusMap[clusterID]; ok {
+		if status.Resources.IsMemoryInsufficient != isInsufficient {
+			status.Resources = resources
+		}
+	} else {
+		clusterStatusMap[clusterID] = &clusterStatus{Resources: resources}
+	}
+}

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -55,8 +55,9 @@ func setElfClusterMemoryInsufficient(clusterID string, isInsufficient bool) {
 	}
 }
 
-// needDetectElfClusterMemoryInsufficient returns whether need to detect if insufficient memory.
-func needDetectElfClusterMemoryInsufficient(clusterID string) bool {
+// canRetryVMOperation returns whether virtual machine operations(Create/PowerOn)
+// can be performed.
+func canRetryVMOperation(clusterID string) bool {
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -21,12 +21,15 @@ var _ = Describe("TowerCache", func() {
 
 		setElfClusterMemoryInsufficient(clusterID, true)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, true)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, false)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 
 		resetClusterStatusMap()
 		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
@@ -34,40 +37,47 @@ var _ = Describe("TowerCache", func() {
 
 		setElfClusterMemoryInsufficient(clusterID, false)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, false)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, true)
 		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
 	})
 
-	It("should return isMemoryInsufficient", func() {
+	It("should return whether memory is insufficient", func() {
 		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
 		Expect(clusterStatusMap[clusterID]).To(BeNil())
 
-		ok, canRetry := isElfClusterMemoryInsufficient(clusterID)
-		Expect(ok).To(BeFalse())
-		Expect(canRetry).To(BeFalse())
+		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, false)
-		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
-		Expect(ok).To(BeFalse())
-		Expect(canRetry).To(BeFalse())
+		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
-		Expect(ok).To(BeTrue())
-		Expect(canRetry).To(BeFalse())
+		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeTrue())
+	})
 
-		clusterStatusMap[clusterID].Resources.LastUpdated = clusterStatusMap[clusterID].Resources.LastUpdated.Add(-silenceTime)
-		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
-		Expect(ok).To(BeTrue())
-		Expect(canRetry).To(BeTrue())
+	It("should return whether need to detect", func() {
+		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
+		Expect(clusterStatusMap[clusterID]).To(BeNil())
 
-		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
-		Expect(ok).To(BeTrue())
-		Expect(canRetry).To(BeFalse())
+		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, true)
+		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+
+		clusterStatusMap[clusterID].Resources.LastDetected = clusterStatusMap[clusterID].Resources.LastDetected.Add(-silenceTime)
+		clusterStatusMap[clusterID].Resources.LastRetried = clusterStatusMap[clusterID].Resources.LastRetried.Add(-silenceTime)
+		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeTrue())
+
+		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
 	})
 })
 

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -65,19 +65,19 @@ var _ = Describe("TowerCache", func() {
 		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
 		Expect(clusterStatusMap[clusterID]).To(BeNil())
 
-		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
 
 		clusterStatusMap[clusterID].Resources.LastDetected = clusterStatusMap[clusterID].Resources.LastDetected.Add(-silenceTime)
 		clusterStatusMap[clusterID].Resources.LastRetried = clusterStatusMap[clusterID].Resources.LastRetried.Add(-silenceTime)
-		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeTrue())
+		Expect(canRetryVMOperation(clusterID)).To(BeTrue())
 
-		Expect(needDetectElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
 	})
 })
 

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -1,0 +1,76 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
+)
+
+var _ = Describe("TowerCache", func() {
+	var clusterID string
+
+	BeforeEach(func() {
+		clusterID = fake.UUID()
+		resetClusterStatusMap()
+	})
+
+	It("should set memoryInsufficient", func() {
+		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
+		Expect(clusterStatusMap[clusterID]).To(BeNil())
+
+		setElfClusterMemoryInsufficient(clusterID, true)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+
+		setElfClusterMemoryInsufficient(clusterID, true)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+
+		resetClusterStatusMap()
+		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
+		Expect(clusterStatusMap[clusterID]).To(BeNil())
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, true)
+		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
+	})
+
+	It("should return isMemoryInsufficient", func() {
+		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
+		Expect(clusterStatusMap[clusterID]).To(BeNil())
+
+		ok, canRetry := isElfClusterMemoryInsufficient(clusterID)
+		Expect(ok).To(BeFalse())
+		Expect(canRetry).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
+		Expect(ok).To(BeFalse())
+		Expect(canRetry).To(BeFalse())
+
+		setElfClusterMemoryInsufficient(clusterID, true)
+		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
+		Expect(ok).To(BeTrue())
+		Expect(canRetry).To(BeFalse())
+
+		clusterStatusMap[clusterID].Resources.LastUpdated = clusterStatusMap[clusterID].Resources.LastUpdated.Add(-silenceTime)
+		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
+		Expect(ok).To(BeTrue())
+		Expect(canRetry).To(BeTrue())
+
+		ok, canRetry = isElfClusterMemoryInsufficient(clusterID)
+		Expect(ok).To(BeTrue())
+		Expect(canRetry).To(BeFalse())
+	})
+})
+
+func resetClusterStatusMap() {
+	clusterStatusMap = make(map[string]*clusterStatus)
+}

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -33,7 +33,7 @@ const (
 	LabelCreateFailed       = "LABEL_CREATE_FAILED"
 	LabelAddFailed          = "LABEL_ADD_FAILED"
 	CloudInitError          = "VM_CLOUD_INIT_CONFIG_ERROR"
-	MemoryInsufficientError = "[VM_SCHEDULE_FAILED]EmptyCandidateHostsException::HostAvailableMemoryFilter"
+	MemoryInsufficientError = "HostAvailableMemoryFilter"
 )
 
 func IsVMNotFound(err error) bool {

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -23,16 +23,17 @@ import (
 
 // error codes.
 const (
-	ClusterNotFound    = "CLUSTER_NOT_FOUND"
-	HostNotFound       = "HOST_NOT_FOUND"
-	VMTemplateNotFound = "VM_TEMPLATE_NOT_FOUND"
-	VMNotFound         = "VM_NOT_FOUND"
-	VMDuplicate        = "VM_DUPLICATE"
-	TaskNotFound       = "TASK_NOT_FOUND"
-	VlanNotFound       = "VLAN_NOT_FOUND"
-	LabelCreateFailed  = "LABEL_CREATE_FAILED"
-	LabelAddFailed     = "LABEL_ADD_FAILED"
-	CloudInitError     = "VM_CLOUD_INIT_CONFIG_ERROR"
+	ClusterNotFound         = "CLUSTER_NOT_FOUND"
+	HostNotFound            = "HOST_NOT_FOUND"
+	VMTemplateNotFound      = "VM_TEMPLATE_NOT_FOUND"
+	VMNotFound              = "VM_NOT_FOUND"
+	VMDuplicate             = "VM_DUPLICATE"
+	TaskNotFound            = "TASK_NOT_FOUND"
+	VlanNotFound            = "VLAN_NOT_FOUND"
+	LabelCreateFailed       = "LABEL_CREATE_FAILED"
+	LabelAddFailed          = "LABEL_ADD_FAILED"
+	CloudInitError          = "VM_CLOUD_INIT_CONFIG_ERROR"
+	MemoryInsufficientError = "[VM_SCHEDULE_FAILED]EmptyCandidateHostsException::HostAvailableMemoryFilter"
 )
 
 func IsVMNotFound(err error) bool {
@@ -70,4 +71,8 @@ func FormatCloudInitError(message string) string {
 	msg = strings.TrimSpace(msg)
 
 	return msg
+}
+
+func IsMemoryInsufficientError(message string) bool {
+	return strings.Contains(message, MemoryInsufficientError)
 }

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"strings"
+
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 )
 
@@ -75,4 +77,12 @@ func GetTowerTaskStatus(ptr *models.TaskStatus) string {
 	}
 
 	return string(*ptr)
+}
+
+func IsCloneVMTask(task *models.Task) bool {
+	return strings.Contains(GetTowerString(task.Description), "Create a VM")
+}
+
+func IsPowerOnVMTask(task *models.Task) bool {
+	return strings.Contains(GetTowerString(task.Description), "Start VM")
 }

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -25,9 +25,17 @@ import (
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )
 
+func ID() string {
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
+}
+
+func UUID() string {
+	return uuid.New().String()
+}
+
 func NewTowerVM() *models.VM {
-	id := strings.ReplaceAll(uuid.New().String(), "-", "")
-	localID := uuid.New().String()
+	id := ID()
+	localID := UUID()
 	status := models.VMStatusRUNNING
 
 	return &models.VM{


### PR DESCRIPTION
### 问题 SKS-579
当 ELF 集群内存不足，CAPE 会一直重试创建虚拟机。
当 ELF 内存不足的时候，优化创建虚拟机的逻辑。

### 解决

当检测到 ELF 集群继续资源不足，在 CAPE 设置内存内存不足的标记，这样在该 ELF 集群创建虚拟机的任务就不再继续重试（一直到标记取消）。
设置间隔五分钟，超过了五分钟之后，每隔五分钟允许一次创建虚拟机的尝试。如果尝试成功会取消内存资源不足的标记，这样其他创建虚拟机的任务会继续进行。

内存不足的时候也可能导致虚拟机不能正常开机，这部分也需要处理。

**存在的问题：**

1. 资源不足的标记需要使用锁，带来了性能开销
2. 每次 CAPE 刚启动的时候还是会并发的创建虚拟机
3. 当 ELF 内存资源不足标记取消之后，其他任务会继续并发创建，不能准确预判还有多少资源

### 测试
创建一个 1 CP + 多 Worker 集群，资源只够创建部分节点，显示其他的 Worker 因为资源不足等待创建。五分钟后有一个 Worker 节点尝试创建。

释放该 ELF 内存资源后，其他 Worker 恢复正常创建。

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/19967151/205202299-60aebcf1-2d4e-4be8-926b-c53d9c99ebee.png">

