### PR TITLE
Upgrade kube-vip to v0.5.7

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -121,7 +121,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.4.2
+            image: ghcr.io/kube-vip/kube-vip:v0.5.7
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}


### PR DESCRIPTION
### 问题 SKS-783
ELF Host 重启之后 kube-vip:v0.4.2 未能恢复，导致 K8s 集群失败。

### 解决
升级 kube-vip 到 v0.5.7，持续观察结果。

### 测试
使用 kube-vip v.0.5.7 进行创建、扩缩容、升级集群等操作，操作皆可正常进行。

![image](https://user-images.githubusercontent.com/19967151/205536300-b199c593-8a53-42dd-b007-249546534806.png)

![image](https://user-images.githubusercontent.com/19967151/205536311-8c251e57-1311-44a0-bcc4-476e1f70fd1c.png)
