### PR TITLE
Set VM Placement Group for VMs in the same group to support HA

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -59,6 +59,14 @@ const (
 	// WaitingForNetworkAddressesReason (Severity=Info) documents a ElfMachine waiting for the machine network
 	// settings to be reported after machine being powered on.
 	WaitingForNetworkAddressesReason = "WaitingForNetworkAddresses"
+
+	// JoiningPlacementGroupReason documents (Severity=Info) a ElfMachine currently executing the join placement group operation.
+	JoiningPlacementGroupReason = "JoiningPlacementGroup"
+
+	// JoiningPlacementGroupFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// an error while joining placement group; those kind of errors are usually transient and failed provisioning
+	// are automatically re-tried by the controller.
+	JoiningPlacementGroupFailedReason = "JoiningPlacementGroupFailed"
 )
 
 // Conditions and Reasons related to make connections to a Tower. Can currently be used by ElfCluster and ElfMachine

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -150,11 +150,17 @@ type ElfMachineStatus struct {
 	// +optional
 	TaskRef string `json:"taskRef,omitempty"`
 
-	// HostRef is used to lookup the host of the virtual machine.
+	// HostServerRef is used to lookup the host of the virtual machine.
 	// This value is set automatically at runtime and should not be set or
 	// modified by users.
 	// +optional
-	HostRef string `json:"hostRef,omitempty"`
+	HostServerRef string `json:"hostServerRef,omitempty"`
+
+	// HostServerName is the name of host where the virtual machine on.
+	// This value is set automatically at runtime and should not be set or
+	// modified by users.
+	// +optional
+	HostServerName string `json:"hostServerName,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -138,13 +138,23 @@ type ElfMachineStatus struct {
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
 
+	// VMRef is used to lookup the VM.
 	// This value is set automatically at runtime and should not be set or
 	// modified by users.
-	// VMRef is used to lookup the VM.
 	// +optional
 	VMRef string `json:"vmRef,omitempty"`
 
+	// TaskRef is a managed object reference to a Task related to the machine.
+	// This value is set automatically at runtime and should not be set or
+	// modified by users.
+	// +optional
 	TaskRef string `json:"taskRef,omitempty"`
+
+	// HostRef is used to lookup the host of the virtual machine.
+	// This value is set automatically at runtime and should not be set or
+	// modified by users.
+	// +optional
+	HostRef string `json:"hostRef,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -150,13 +150,13 @@ type ElfMachineStatus struct {
 	// +optional
 	TaskRef string `json:"taskRef,omitempty"`
 
-	// HostServerRef is used to lookup the host of the virtual machine.
+	// HostServerRef is the Tower ID of host server where the virtual machine runs on.
 	// This value is set automatically at runtime and should not be set or
 	// modified by users.
 	// +optional
 	HostServerRef string `json:"hostServerRef,omitempty"`
 
-	// HostServerName is the name of host where the virtual machine on.
+	// HostServerName is the name of host server where the virtual machine runs on.
 	// This value is set automatically at runtime and should not be set or
 	// modified by users.
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -269,14 +269,14 @@ spec:
                   the Machine object and/or logged in the controller's output."
                 type: string
               hostServerName:
-                description: HostServerName is the name of host where the virtual
-                  machine on. This value is set automatically at runtime and should
-                  not be set or modified by users.
+                description: HostServerName is the name of host server where the virtual
+                  machine runs on. This value is set automatically at runtime and
+                  should not be set or modified by users.
                 type: string
               hostServerRef:
-                description: HostServerRef is used to lookup the host of the virtual
-                  machine. This value is set automatically at runtime and should not
-                  be set or modified by users.
+                description: HostServerRef is the Tower ID of host server where the
+                  virtual machine runs on. This value is set automatically at runtime
+                  and should not be set or modified by users.
                 type: string
               network:
                 description: Network returns the network status for each of the machine's

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -268,6 +268,11 @@ spec:
                   during the reconciliation of Machines can be added as events to
                   the Machine object and/or logged in the controller's output."
                 type: string
+              hostRef:
+                description: HostRef is used to lookup the host of the virtual machine.
+                  This value is set automatically at runtime and should not be set
+                  or modified by users.
+                type: string
               network:
                 description: Network returns the network status for each of the machine's
                   configured network interfaces.
@@ -299,10 +304,13 @@ spec:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
               taskRef:
+                description: TaskRef is a managed object reference to a Task related
+                  to the machine. This value is set automatically at runtime and should
+                  not be set or modified by users.
                 type: string
               vmRef:
-                description: This value is set automatically at runtime and should
-                  not be set or modified by users. VMRef is used to lookup the VM.
+                description: VMRef is used to lookup the VM. This value is set automatically
+                  at runtime and should not be set or modified by users.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -268,10 +268,15 @@ spec:
                   during the reconciliation of Machines can be added as events to
                   the Machine object and/or logged in the controller's output."
                 type: string
-              hostRef:
-                description: HostRef is used to lookup the host of the virtual machine.
-                  This value is set automatically at runtime and should not be set
-                  or modified by users.
+              hostServerName:
+                description: HostServerName is the name of host where the virtual
+                  machine on. This value is set automatically at runtime and should
+                  not be set or modified by users.
+                type: string
+              hostServerRef:
+                description: HostServerRef is used to lookup the host of the virtual
+                  machine. This value is set automatically at runtime and should not
+                  be set or modified by users.
                 type: string
               network:
                 description: Network returns the network status for each of the machine's

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         env:
-        - name: VM_LABEL_PREFIX
+        - name: TOWER_RESOURCE_PREFIX
           value: cape
         ports:
         - containerPort: 9440

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,11 +28,44 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines
   - machines/status
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -230,7 +230,7 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.ClusterContext) error {
-	if _, err := ctx.VMService.DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-%s-cluster-%s", ctx.Cluster.Namespace, ctx.Cluster.Name)); err != nil {
+	if _, err := ctx.VMService.DeleteVMPlacementGroupsByName(fmt.Sprintf("%s-managed-%s-%s", towerresources.GetResourcePrefix(), ctx.Cluster.Namespace, ctx.Cluster.Name)); err != nil {
 		return err
 	}
 

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -42,7 +42,7 @@ import (
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/label"
+	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )
@@ -237,19 +237,19 @@ func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.Clu
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteLabels(ctx *context.ClusterContext) error {
-	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelClusterName(), ctx.ElfCluster.Name, true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelClusterName(), ctx.ElfCluster.Name, true); err != nil {
 		return err
 	}
 
-	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelVIP(), ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host, true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelVIP(), ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host, true); err != nil {
 		return err
 	}
 
-	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelNamespace(), ctx.ElfCluster.Namespace, true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelNamespace(), ctx.ElfCluster.Namespace, true); err != nil {
 		return err
 	}
 
-	if err := r.reconcileDeleteLabel(ctx, label.GetVMLabelManaged(), "true", true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelManaged(), "true", true); err != nil {
 		return err
 	}
 

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -45,6 +45,7 @@ import (
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
 
 var (
@@ -199,7 +200,7 @@ func (r *ElfClusterReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_
 func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconcile.Result, error) {
 	ctx.Logger.Info("Reconciling ElfCluster delete")
 
-	elfMachines, err := util.GetElfMachinesInCluster(ctx, ctx.Client, ctx.ElfCluster.Namespace, ctx.ElfCluster.Name)
+	elfMachines, err := machineutil.GetElfMachinesInCluster(ctx, ctx.Client, ctx.ElfCluster.Namespace, ctx.ElfCluster.Name)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err,
 			"Unable to list ElfMachines part of ElfCluster %s/%s", ctx.ElfCluster.Namespace, ctx.ElfCluster.Name)

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -229,7 +229,7 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.ClusterContext) error {
-	if _, err := ctx.VMService.DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-cluster-%s", ctx.Cluster.Name)); err != nil {
+	if _, err := ctx.VMService.DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-%s-cluster-%s", ctx.Cluster.Namespace, ctx.Cluster.Name)); err != nil {
 		return err
 	}
 

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-%s-cluster-%s", cluster.Namespace, cluster.Name)).Return(nil, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("%s-managed-%s-%s", towerresources.GetResourcePrefix(), cluster.Namespace, cluster.Name)).Return(nil, nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -40,7 +40,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/label"
+	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service/mock_services"
 	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
@@ -211,17 +211,17 @@ var _ = Describe("ElfClusterReconciler", func() {
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
 			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-%s-cluster-%s", cluster.Namespace, cluster.Name)).Return(nil, nil)
-			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
-			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
-			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
-			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelManaged(), "true", true).Return("", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelManaged(), "true", true).Return("", nil)
 
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", label.GetVMLabelClusterName(), elfCluster.Name)))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", towerresources.GetVMLabelClusterName(), elfCluster.Name)))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})
 

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-cluster-%s", cluster.Name)).Return(nil, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-%s-cluster-%s", cluster.Namespace, cluster.Name)).Return(nil, nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -210,6 +210,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("cape-cluster-%s", cluster.Name)).Return(nil, nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(label.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -917,7 +917,7 @@ func (r *ElfMachineReconciler) reconcilePlacementGroup(ctx *context.MachineConte
 	return true, nil
 }
 
-// getVMHostForRollingUpdate returns the host server for a virtual machine during rolling update.
+// getVMHostForRollingUpdate returns the target host server id for a virtual machine during rolling update.
 // During KCP rolling update, machines will be deleted in the order of creation.
 // Find the latest created machine in the placement group,
 // and set the host where the machine is located to the first machine created by KCP rolling update.
@@ -932,8 +932,8 @@ func (r *ElfMachineReconciler) getVMHostForRollingUpdate(ctx *context.MachineCon
 		return "", err
 	}
 
-	// *kcp.Spec.Replicas > kcp.Status.Replicas means KCP is rolling update.
 	if *kcp.Spec.Replicas > kcp.Status.Replicas {
+		// It means KCP is not in rolling update, but scaling out or being created. Then simply return.
 		return "", nil
 	}
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service/mock_services"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
 )
 
@@ -948,7 +949,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).To(BeZero())
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(*elfMachine.Spec.ProviderID).Should(Equal(util.ConvertUUIDToProviderID(*vm.LocalID)))
+			Expect(*elfMachine.Spec.ProviderID).Should(Equal(machineutil.ConvertUUIDToProviderID(*vm.LocalID)))
 		})
 	})
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -525,7 +525,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.PoweringOnFailedReason}})
 		})
 
-		It("should handle power on task failed", func() {
+		It(" handle power on task failure", func() {
 			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
@@ -602,7 +602,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.JoiningPlacementGroupReason}})
 		})
 
-		It("should wait placement group task done", func() {
+		It("should wait for placement group task done", func() {
 			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
@@ -781,7 +781,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(logBuffer.String()).To(ContainSubstring("KCP rolling update in progress, skip migrate VM"))
 			})
 
-			It("should migrate VM when VM is running and host where VM in is not in unused hosts", func() {
+			It("should migrate VM to another host when the VM is running and the host of VM is not in unused hosts", func() {
 				towerCluster := fake.NewTowerCluster()
 				towerCluster.HostNum = util.TowerInt32(2)
 				hostID1 := fake.UUID()
@@ -841,7 +841,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			err := reconciler.reconcileVMHost(machineContext)
+			err := reconciler.reconcileVMHostForRollingUpdate(machineContext)
 			Expect(err).To(BeZero())
 			Expect(elfMachine.Spec.Host).To(BeEmpty())
 		})
@@ -856,7 +856,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(util.GetVMPlacementGroupName(machine)).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			err := reconciler.reconcileVMHost(machineContext)
+			err := reconciler.reconcileVMHostForRollingUpdate(machineContext)
 			Expect(err).To(BeZero())
 			Expect(elfMachine.Spec.Host).To(BeEmpty())
 		})
@@ -875,7 +875,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(util.GetVMPlacementGroupName(machine)).Return(placementGroup, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			err := reconciler.reconcileVMHost(machineContext)
+			err := reconciler.reconcileVMHostForRollingUpdate(machineContext)
 			Expect(err).To(BeZero())
 			Expect(elfMachine.Spec.Host).To(BeEmpty())
 		})
@@ -921,7 +921,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(util.GetVMPlacementGroupName(machine)).Return(placementGroup, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			err := reconciler.reconcileVMHost(machineContext)
+			err := reconciler.reconcileVMHostForRollingUpdate(machineContext)
 			Expect(err).To(BeZero())
 			Expect(elfMachine.Spec.Host).To(Equal(hostID))
 		})

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -72,9 +72,11 @@ func releaseTicketForCreateVM(vmName string) {
 	delete(vmStatusMap, vmName)
 }
 
-// acquireTicketForUpdateVM returns whether virtual machine update operation
+// acquireTicketForUpdatingVM returns whether virtual machine update operation
 // can be performed.
-func acquireTicketForUpdateVM(vmName string) bool {
+// Tower API currently does not have a concurrency limit for operations on the same virtual machine,
+// which may cause task to fail.
+func acquireTicketForUpdatingVM(vmName string) bool {
 	vmOperationLock.Lock()
 	defer vmOperationLock.Unlock()
 

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -68,16 +68,16 @@ var _ = Describe("VM Operation Limiter", func() {
 		vmName = fake.UUID()
 	})
 
-	It("acquireTicketForUpdateVM", func() {
-		Expect(acquireTicketForUpdateVM(vmName)).To(BeTrue())
+	It("acquireTicketForUpdatingVM", func() {
+		Expect(acquireTicketForUpdatingVM(vmName)).To(BeTrue())
 		Expect(vmOperationMap).To(HaveKey(vmName))
 
-		Expect(acquireTicketForUpdateVM(vmName)).To(BeFalse())
-		acquireTicketForUpdateVM(vmName)
+		Expect(acquireTicketForUpdatingVM(vmName)).To(BeFalse())
+		acquireTicketForUpdatingVM(vmName)
 		resetVMOperationMap()
 
 		vmOperationMap[vmName] = time.Now().Add(-vmOperationRateLimit)
-		Expect(acquireTicketForUpdateVM(vmName)).To(BeTrue())
+		Expect(acquireTicketForUpdatingVM(vmName)).To(BeTrue())
 		Expect(vmOperationMap).To(HaveKey(vmName))
 		Expect(len(vmOperationMap)).To(Equal(1))
 		resetVMOperationMap()

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -124,7 +124,6 @@ var _ = Describe("Placement Group Update Limiter", func() {
 		placementGroupStatusMap[groupName] = time.Now().Add(-placementGroupOperationTimeout)
 		Expect(acquireTicketForUpdatePlacementGroup(groupName)).To(BeTrue())
 		Expect(placementGroupStatusMap).To(HaveKey(groupName))
-		Expect(len(placementGroupStatusMap)).To(Equal(1))
 		releaseTicketForUpdatePlacementGroup(groupName)
 	})
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,8 @@ package config
 import "time"
 
 var (
+	ProviderNameShort = "cape"
+
 	// DefaultRequeueTimeout is the default time for how long to wait when
 	// requeueing a CAPE operation.
 	DefaultRequeueTimeout = 20 * time.Second

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -23,6 +23,7 @@ import (
 	cgscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
@@ -46,6 +47,7 @@ func New(opts Options) (Manager, error) {
 	_ = clusterv1.AddToScheme(opts.Scheme)
 	_ = infrav1.AddToScheme(opts.Scheme)
 	_ = bootstrapv1.AddToScheme(opts.Scheme)
+	_ = controlplanev1.AddToScheme(opts.Scheme)
 	// +kubebuilder:scaffold:scheme
 
 	// Build the controller manager.

--- a/pkg/resources/label.go
+++ b/pkg/resources/label.go
@@ -14,17 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package label
+package resources
 
 import (
 	"fmt"
-
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 )
 
 // Tower labels for VMs created by CAPE.
 const (
-	VMLabelPrefix      = "VM_LABEL_PREFIX"
 	VMLabelManaged     = "managed"
 	VMLabelNamespace   = "namespace"
 	VMLabelClusterName = "cluster-name"
@@ -32,21 +29,17 @@ const (
 )
 
 func GetVMLabelManaged() string {
-	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelManaged)
-}
-
-func GetVMLabelPrefix() string {
-	return util.GetEnv(VMLabelPrefix, "cape")
+	return fmt.Sprintf("%s-%s", GetResourcePrefix(), VMLabelManaged)
 }
 
 func GetVMLabelNamespace() string {
-	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelNamespace)
+	return fmt.Sprintf("%s-%s", GetResourcePrefix(), VMLabelNamespace)
 }
 
 func GetVMLabelClusterName() string {
-	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelClusterName)
+	return fmt.Sprintf("%s-%s", GetResourcePrefix(), VMLabelClusterName)
 }
 
 func GetVMLabelVIP() string {
-	return fmt.Sprintf("%s-%s", GetVMLabelPrefix(), VMLabelVIP)
+	return fmt.Sprintf("%s-%s", GetResourcePrefix(), VMLabelVIP)
 }

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -24,15 +24,15 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 	annotationsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/annotations"
 	labelsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
 
 func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (string, error) {
 	groupName := ""
-	if util.IsControlPlaneMachine(machine) {
-		kcp, err := util.GetKCPByMachine(ctx, ctrlClient, machine)
+	if machineutil.IsControlPlaneMachine(machine) {
+		kcp, err := machineutil.GetKCPByMachine(ctx, ctrlClient, machine)
 		if err != nil {
 			return "", err
 		}
@@ -44,7 +44,7 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 
 		groupName = labelsutil.GetControlPlaneLabel(machine)
 	} else {
-		md, err := util.GetMDByMachine(ctx, ctrlClient, machine)
+		md, err := machineutil.GetMDByMachine(ctx, ctrlClient, machine)
 		if err != nil {
 			return "", err
 		}
@@ -65,7 +65,7 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 }
 
 func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {
-	if util.IsControlPlaneMachine(machine) {
+	if machineutil.IsControlPlaneMachine(machine) {
 		return models.VMVMPolicyMUSTDIFFERENT
 	}
 

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	goctx "context"
+	"fmt"
+
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
+	annotationsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/annotations"
+	labelsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
+)
+
+func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (string, error) {
+	groupName := ""
+	if util.IsControlPlaneMachine(machine) {
+		kcp, err := util.GetKCPByMachine(ctx, ctrlClient, machine)
+		if err != nil {
+			return "", err
+		}
+
+		placementGroupName := annotationsutil.GetPlacementGroupName(kcp)
+		if placementGroupName != "" {
+			return placementGroupName, nil
+		}
+
+		groupName = labelsutil.GetControlPlaneLabel(machine)
+	} else {
+		md, err := util.GetMDByMachine(ctx, ctrlClient, machine)
+		if err != nil {
+			return "", err
+		}
+
+		placementGroupName := annotationsutil.GetPlacementGroupName(md)
+		if placementGroupName != "" {
+			return placementGroupName, nil
+		}
+
+		groupName = labelsutil.GetDeploymentNameLabel(machine)
+	}
+
+	if groupName == "" {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%s-managed-%s-cluster-%s-group", GetResourcePrefix(), machine.Namespace, groupName), nil
+}
+
+func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {
+	if util.IsControlPlaneMachine(machine) {
+		return models.VMVMPolicyMUSTDIFFERENT
+	}
+
+	return models.VMVMPolicyPREFERDIFFERENT
+}

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -61,7 +61,7 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 		return "", nil
 	}
 
-	return fmt.Sprintf("%s-managed-%s-cluster-%s-group", GetResourcePrefix(), machine.Namespace, groupName), nil
+	return fmt.Sprintf("%s-managed-%s-%s", GetResourcePrefix(), machine.Namespace, groupName), nil
 }
 
 func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package resources
 
-import (
-	"time"
-)
+import "github.com/smartxworks/cluster-api-provider-elf/pkg/util"
 
+// Tower resources.
 const (
-	// VMDisconnectionTimeout is the time allowed for the virtual machine to be disconnected.
-	// The virtual machine will be marked as deleted after the timeout.
-	VMDisconnectionTimeout = 1 * time.Minute
+	TowerResourcePrefix = "TOWER_RESOURCE_PREFIX"
 )
 
-// Annotations.
-const (
-	// PlacementGroupNameAnnotation is the annotation identifying the name of placement group.
-	PlacementGroupNameAnnotation = "cape.infrastructure.cluster.x-k8s.io/placement-group-name"
-)
+func GetResourcePrefix() string {
+	return util.GetEnv(TowerResourcePrefix, "cape")
+}

--- a/pkg/service/consts.go
+++ b/pkg/service/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+const (
+	// VMPlacementGroupDescription is the description of vm placement group.
+	VMPlacementGroupDescription = "This is vm placement group create by CAPE, don't delete it!"
+)

--- a/pkg/service/consts.go
+++ b/pkg/service/consts.go
@@ -18,5 +18,5 @@ package service
 
 const (
 	// VMPlacementGroupDescription is the description of vm placement group.
-	VMPlacementGroupDescription = "This is vm placement group create by CAPE, don't delete it!"
+	VMPlacementGroupDescription = "This is VM placement group created by CAPE, don't delete it!"
 )

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -23,17 +23,18 @@ import (
 
 // error codes.
 const (
-	ClusterNotFound         = "CLUSTER_NOT_FOUND"
-	HostNotFound            = "HOST_NOT_FOUND"
-	VMTemplateNotFound      = "VM_TEMPLATE_NOT_FOUND"
-	VMNotFound              = "VM_NOT_FOUND"
-	VMDuplicate             = "VM_DUPLICATE"
-	TaskNotFound            = "TASK_NOT_FOUND"
-	VlanNotFound            = "VLAN_NOT_FOUND"
-	LabelCreateFailed       = "LABEL_CREATE_FAILED"
-	LabelAddFailed          = "LABEL_ADD_FAILED"
-	CloudInitError          = "VM_CLOUD_INIT_CONFIG_ERROR"
-	MemoryInsufficientError = "HostAvailableMemoryFilter"
+	ClusterNotFound          = "CLUSTER_NOT_FOUND"
+	HostNotFound             = "HOST_NOT_FOUND"
+	VMTemplateNotFound       = "VM_TEMPLATE_NOT_FOUND"
+	VMNotFound               = "VM_NOT_FOUND"
+	VMDuplicate              = "VM_DUPLICATE"
+	TaskNotFound             = "TASK_NOT_FOUND"
+	VlanNotFound             = "VLAN_NOT_FOUND"
+	VMPlacementGroupNotFound = "VM_PLACEMENT_GROUP_NOT_FOUND"
+	LabelCreateFailed        = "LABEL_CREATE_FAILED"
+	LabelAddFailed           = "LABEL_ADD_FAILED"
+	CloudInitError           = "VM_CLOUD_INIT_CONFIG_ERROR"
+	MemoryInsufficientError  = "HostAvailableMemoryFilter"
 )
 
 func IsVMNotFound(err error) bool {
@@ -50,6 +51,10 @@ func IsShutDownTimeout(message string) bool {
 
 func IsTaskNotFound(err error) bool {
 	return strings.Contains(err.Error(), TaskNotFound)
+}
+
+func IsVMPlacementGroupNotFound(err error) bool {
+	return strings.Contains(err.Error(), VMPlacementGroupNotFound)
 }
 
 func IsCloudInitConfigError(message string) bool {

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -67,18 +67,18 @@ func (mr *MockVMServiceMockRecorder) AddVMsToPlacementGroup(placementGroup, vmID
 }
 
 // Clone mocks base method.
-func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, machine *v1beta10.Machine, elfMachine *v1beta1.ElfMachine, bootstrapData string) (*models.WithTaskVM, error) {
+func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, machine *v1beta10.Machine, elfMachine *v1beta1.ElfMachine, bootstrapData, host string) (*models.WithTaskVM, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clone", elfCluster, machine, elfMachine, bootstrapData)
+	ret := m.ctrl.Call(m, "Clone", elfCluster, machine, elfMachine, bootstrapData, host)
 	ret0, _ := ret[0].(*models.WithTaskVM)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Clone indicates an expected call of Clone.
-func (mr *MockVMServiceMockRecorder) Clone(elfCluster, machine, elfMachine, bootstrapData interface{}) *gomock.Call {
+func (mr *MockVMServiceMockRecorder) Clone(elfCluster, machine, elfMachine, bootstrapData, host interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockVMService)(nil).Clone), elfCluster, machine, elfMachine, bootstrapData)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockVMService)(nil).Clone), elfCluster, machine, elfMachine, bootstrapData, host)
 }
 
 // CreateVMPlacementGroup mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -51,6 +51,21 @@ func (mr *MockVMServiceMockRecorder) AddLabelsToVM(vmID, labels interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLabelsToVM", reflect.TypeOf((*MockVMService)(nil).AddLabelsToVM), vmID, labels)
 }
 
+// AddVMsToPlacementGroup mocks base method.
+func (m *MockVMService) AddVMsToPlacementGroup(placementGroup *models.VMPlacementGroup, vmIDs []string) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddVMsToPlacementGroup", placementGroup, vmIDs)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddVMsToPlacementGroup indicates an expected call of AddVMsToPlacementGroup.
+func (mr *MockVMServiceMockRecorder) AddVMsToPlacementGroup(placementGroup, vmIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVMsToPlacementGroup", reflect.TypeOf((*MockVMService)(nil).AddVMsToPlacementGroup), placementGroup, vmIDs)
+}
+
 // Clone mocks base method.
 func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, machine *v1beta10.Machine, elfMachine *v1beta1.ElfMachine, bootstrapData string) (*models.WithTaskVM, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +79,21 @@ func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, machine *v1beta10.
 func (mr *MockVMServiceMockRecorder) Clone(elfCluster, machine, elfMachine, bootstrapData interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockVMService)(nil).Clone), elfCluster, machine, elfMachine, bootstrapData)
+}
+
+// CreateVMPlacementGroup mocks base method.
+func (m *MockVMService) CreateVMPlacementGroup(name, clusterID string, vmPolicy models.VMVMPolicy) (*models.WithTaskVMPlacementGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVMPlacementGroup", name, clusterID, vmPolicy)
+	ret0, _ := ret[0].(*models.WithTaskVMPlacementGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVMPlacementGroup indicates an expected call of CreateVMPlacementGroup.
+func (mr *MockVMServiceMockRecorder) CreateVMPlacementGroup(name, clusterID, vmPolicy interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVMPlacementGroup", reflect.TypeOf((*MockVMService)(nil).CreateVMPlacementGroup), name, clusterID, vmPolicy)
 }
 
 // Delete mocks base method.
@@ -94,6 +124,36 @@ func (m *MockVMService) DeleteLabel(key, value string, strict bool) (string, err
 func (mr *MockVMServiceMockRecorder) DeleteLabel(key, value, strict interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLabel", reflect.TypeOf((*MockVMService)(nil).DeleteLabel), key, value, strict)
+}
+
+// DeleteVMPlacementGroupsByName mocks base method.
+func (m *MockVMService) DeleteVMPlacementGroupsByName(placementGroupName string) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVMPlacementGroupsByName", placementGroupName)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteVMPlacementGroupsByName indicates an expected call of DeleteVMPlacementGroupsByName.
+func (mr *MockVMServiceMockRecorder) DeleteVMPlacementGroupsByName(placementGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVMPlacementGroupsByName", reflect.TypeOf((*MockVMService)(nil).DeleteVMPlacementGroupsByName), placementGroupName)
+}
+
+// FindByIDs mocks base method.
+func (m *MockVMService) FindByIDs(ids []string) ([]*models.VM, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByIDs", ids)
+	ret0, _ := ret[0].([]*models.VM)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByIDs indicates an expected call of FindByIDs.
+func (mr *MockVMServiceMockRecorder) FindByIDs(ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDs", reflect.TypeOf((*MockVMService)(nil).FindByIDs), ids)
 }
 
 // Get mocks base method.
@@ -171,6 +231,21 @@ func (mr *MockVMServiceMockRecorder) GetTask(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockVMService)(nil).GetTask), id)
 }
 
+// GetVMPlacementGroup mocks base method.
+func (m *MockVMService) GetVMPlacementGroup(name string) (*models.VMPlacementGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMPlacementGroup", name)
+	ret0, _ := ret[0].(*models.VMPlacementGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMPlacementGroup indicates an expected call of GetVMPlacementGroup.
+func (mr *MockVMServiceMockRecorder) GetVMPlacementGroup(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMPlacementGroup", reflect.TypeOf((*MockVMService)(nil).GetVMPlacementGroup), name)
+}
+
 // GetVMTemplate mocks base method.
 func (m *MockVMService) GetVMTemplate(id string) (*models.ContentLibraryVMTemplate, error) {
 	m.ctrl.T.Helper()
@@ -199,6 +274,21 @@ func (m *MockVMService) GetVlan(id string) (*models.Vlan, error) {
 func (mr *MockVMServiceMockRecorder) GetVlan(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVlan", reflect.TypeOf((*MockVMService)(nil).GetVlan), id)
+}
+
+// Migrate mocks base method.
+func (m *MockVMService) Migrate(vmID, hostID string) (*models.WithTaskVM, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Migrate", vmID, hostID)
+	ret0, _ := ret[0].(*models.WithTaskVM)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Migrate indicates an expected call of Migrate.
+func (mr *MockVMServiceMockRecorder) Migrate(vmID, hostID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockVMService)(nil).Migrate), vmID, hostID)
 }
 
 // PowerOff mocks base method.

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -605,9 +605,7 @@ func (svr *TowerVMService) CreateVMPlacementGroup(name, clusterID string, vmPoli
 		Enabled:             util.TowerBool(true),
 		Description:         util.TowerString(VMPlacementGroupDescription),
 		VMHostMustEnabled:   util.TowerBool(false),
-		VMHostMustPolicy:    util.TowerBool(true),
 		VMHostPreferEnabled: util.TowerBool(false),
-		VMHostPreferPolicy:  util.TowerBool(true),
 		VMVMPolicyEnabled:   util.TowerBool(true),
 		VMVMPolicy:          &vmPolicy,
 	}}

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -42,7 +42,7 @@ type VMService interface {
 	Clone(elfCluster *infrav1.ElfCluster,
 		machine *clusterv1.Machine,
 		elfMachine *infrav1.ElfMachine,
-		bootstrapData string) (*models.WithTaskVM, error)
+		bootstrapData, host string) (*models.WithTaskVM, error)
 	Migrate(vmID, hostID string) (*models.WithTaskVM, error)
 	Delete(uuid string) (*models.Task, error)
 	PowerOff(uuid string) (*models.Task, error)
@@ -86,7 +86,7 @@ func (svr *TowerVMService) Clone(
 	elfCluster *infrav1.ElfCluster,
 	machine *clusterv1.Machine,
 	elfMachine *infrav1.ElfMachine,
-	bootstrapData string) (*models.WithTaskVM, error) {
+	bootstrapData, host string) (*models.WithTaskVM, error) {
 	cluster, err := svr.GetCluster(elfCluster.Spec.Cluster)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,9 @@ func (svr *TowerVMService) Clone(
 	}
 
 	hostID := "AUTO_SCHEDULE"
-	if elfMachine.Spec.Host != "" {
+	if host != "" {
+		hostID = host
+	} else if elfMachine.Spec.Host != "" {
 		host, err := svr.GetHost(elfMachine.Spec.Host)
 		if err != nil {
 			return nil, err

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package annotations
 
 import (
-	"time"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 )
 
-const (
-	// VMDisconnectionTimeout is the time allowed for the virtual machine to be disconnected.
-	// The virtual machine will be marked as deleted after the timeout.
-	VMDisconnectionTimeout = 1 * time.Minute
-)
+func GetPlacementGroupName(o metav1.Object) string {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
 
-// Annotations.
-const (
-	// PlacementGroupNameAnnotation is the annotation identifying the name of placement group.
-	PlacementGroupNameAnnotation = "cape.infrastructure.cluster.x-k8s.io/placement-group-name"
-)
+	return annotations[infrav1.PlacementGroupNameAnnotation]
+}

--- a/pkg/util/kcp.go
+++ b/pkg/util/kcp.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	goctx "context"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	labelutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
+)
+
+func GetKCPByMachine(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (*controlplanev1.KubeadmControlPlane, error) {
+	var kcp controlplanev1.KubeadmControlPlane
+	if err := ctrlClient.Get(ctx, apitypes.NamespacedName{Namespace: machine.Namespace, Name: labelutil.GetControlPlaneLabel(machine)}, &kcp); err != nil {
+		return nil, err
+	}
+
+	return &kcp, nil
+}

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -22,7 +22,12 @@ import (
 )
 
 func GetControlPlaneLabel(o metav1.Object) string {
-	val, ok := o.GetLabels()[clusterv1.MachineControlPlaneNameLabel]
+	labels := o.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	val, ok := labels[clusterv1.MachineControlPlaneNameLabel]
 	if !ok {
 		return ""
 	}
@@ -31,7 +36,12 @@ func GetControlPlaneLabel(o metav1.Object) string {
 }
 
 func GetDeploymentNameLabel(o metav1.Object) string {
-	val, ok := o.GetLabels()[clusterv1.MachineDeploymentLabelName]
+	labels := o.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	val, ok := labels[clusterv1.MachineDeploymentLabelName]
 	if !ok {
 		return ""
 	}

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func GetControlPlaneLabel(o metav1.Object) string {
+	val, ok := o.GetLabels()[clusterv1.MachineControlPlaneNameLabel]
+	if !ok {
+		return ""
+	}
+
+	return val
+}
+
+func GetDeploymentNameLabel(o metav1.Object) string {
+	val, ok := o.GetLabels()[clusterv1.MachineDeploymentLabelName]
+	if !ok {
+		return ""
+	}
+
+	return val
+}

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -22,26 +22,24 @@ import (
 )
 
 func GetControlPlaneLabel(o metav1.Object) string {
-	labels := o.GetLabels()
-	if labels == nil {
-		return ""
-	}
-
-	val, ok := labels[clusterv1.MachineControlPlaneNameLabel]
-	if !ok {
-		return ""
-	}
-
-	return val
+	return GetLabelValue(o, clusterv1.MachineControlPlaneNameLabel)
 }
 
 func GetDeploymentNameLabel(o metav1.Object) string {
+	return GetLabelValue(o, clusterv1.MachineDeploymentLabelName)
+}
+
+func GetClusterNameLabel(o metav1.Object) string {
+	return GetLabelValue(o, clusterv1.ClusterLabelName)
+}
+
+func GetLabelValue(o metav1.Object, label string) string {
 	labels := o.GetLabels()
 	if labels == nil {
 		return ""
 	}
 
-	val, ok := labels[clusterv1.MachineDeploymentLabelName]
+	val, ok := labels[label]
 	if !ok {
 		return ""
 	}

--- a/pkg/util/machine/kcp.go
+++ b/pkg/util/machine/kcp.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package machine
 
 import (
 	goctx "context"

--- a/pkg/util/machine/kcp_test.go
+++ b/pkg/util/machine/kcp_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
+)
+
+func TestGetKCPByMachine(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	elfCluster, cluster := fake.NewClusterObjects()
+	_, machine := fake.NewMachineObjects(elfCluster, cluster)
+	kubeadmCP := fake.NewKCP()
+	fake.ToControlPlaneMachine(machine, kubeadmCP)
+	ctx := fake.NewControllerManagerContext(kubeadmCP)
+
+	t.Run("should return kcp", func(t *testing.T) {
+		kcp, err := GetKCPByMachine(ctx, ctx.Client, machine)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(kcp.Name).To(gomega.Equal(kubeadmCP.Name))
+	})
+}

--- a/pkg/util/machine/md.go
+++ b/pkg/util/machine/md.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	goctx "context"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	labelutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
+)
+
+func GetMDByMachine(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (*clusterv1.MachineDeployment, error) {
+	var md clusterv1.MachineDeployment
+	if err := ctrlClient.Get(ctx, apitypes.NamespacedName{Namespace: machine.Namespace, Name: labelutil.GetDeploymentNameLabel(machine)}, &md); err != nil {
+		return nil, err
+	}
+
+	return &md, nil
+}

--- a/pkg/util/machine/md_test.go
+++ b/pkg/util/machine/md_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
+)
+
+func TestGetMDByMachine(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	elfCluster, cluster := fake.NewClusterObjects()
+	_, machine := fake.NewMachineObjects(elfCluster, cluster)
+	machineDeployment := fake.NewMD()
+	fake.ToWorkerMachine(machine, machineDeployment)
+	ctx := fake.NewControllerManagerContext(machineDeployment)
+
+	t.Run("should return md", func(t *testing.T) {
+		md, err := GetMDByMachine(ctx, ctx.Client, machine)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(md.Name).To(gomega.Equal(machineDeployment.Name))
+	})
+}

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	labelutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
 )
 
 const (
@@ -45,6 +47,15 @@ const (
 
 // ErrNoMachineIPAddr indicates that no valid IP addresses were found in a machine context.
 var ErrNoMachineIPAddr = errors.New("no IP addresses found for machine")
+
+func GetMDByMachine(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (*clusterv1.MachineDeployment, error) {
+	var md clusterv1.MachineDeployment
+	if err := ctrlClient.Get(ctx, apitypes.NamespacedName{Namespace: machine.Namespace, Name: labelutil.GetDeploymentNameLabel(machine)}, &md); err != nil {
+		return nil, err
+	}
+
+	return &md, nil
+}
 
 // GetElfMachinesInCluster gets a cluster's ElfMachine resources.
 func GetElfMachinesInCluster(

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -17,9 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	labelsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
 )
 
 func TowerInt32(v int) *int32 {
@@ -71,6 +75,14 @@ func GetTowerString(ptr *string) string {
 	return *ptr
 }
 
+func GetTowerInt32(ptr *int32) int32 {
+	if ptr == nil {
+		return 0
+	}
+
+	return *ptr
+}
+
 func GetTowerTaskStatus(ptr *models.TaskStatus) string {
 	if ptr == nil {
 		return ""
@@ -85,4 +97,35 @@ func IsCloneVMTask(task *models.Task) bool {
 
 func IsPowerOnVMTask(task *models.Task) bool {
 	return strings.Contains(GetTowerString(task.Description), "Start VM")
+}
+
+func IsVMMigrationTask(task *models.Task) bool {
+	return strings.Contains(GetTowerString(task.Description), "performing a live migration")
+}
+
+func IsPlacementGroupTask(task *models.Task) bool {
+	return strings.Contains(GetTowerString(task.Description), "VM placement group") // Update VM placement group
+}
+
+func GetVMPlacementGroupName(machine *clusterv1.Machine) string {
+	groupName := ""
+	if IsControlPlaneMachine(machine) {
+		groupName = labelsutil.GetControlPlaneLabel(machine)
+	} else {
+		groupName = labelsutil.GetDeploymentNameLabel(machine)
+	}
+
+	if groupName == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("cape-cluster-%s-group", groupName)
+}
+
+func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {
+	if IsControlPlaneMachine(machine) {
+		return models.VMVMPolicyMUSTDIFFERENT
+	}
+
+	return models.VMVMPolicyPREFERDIFFERENT
 }

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -17,13 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-
-	labelsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
 )
 
 func TowerInt32(v int) *int32 {
@@ -105,27 +101,4 @@ func IsVMMigrationTask(task *models.Task) bool {
 
 func IsPlacementGroupTask(task *models.Task) bool {
 	return strings.Contains(GetTowerString(task.Description), "VM placement group") // Update VM placement group
-}
-
-func GetVMPlacementGroupName(machine *clusterv1.Machine) string {
-	groupName := ""
-	if IsControlPlaneMachine(machine) {
-		groupName = labelsutil.GetControlPlaneLabel(machine)
-	} else {
-		groupName = labelsutil.GetDeploymentNameLabel(machine)
-	}
-
-	if groupName == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("cape-%s-cluster-%s-group", machine.Namespace, groupName)
-}
-
-func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {
-	if IsControlPlaneMachine(machine) {
-		return models.VMVMPolicyMUSTDIFFERENT
-	}
-
-	return models.VMVMPolicyPREFERDIFFERENT
 }

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -119,7 +119,7 @@ func GetVMPlacementGroupName(machine *clusterv1.Machine) string {
 		return ""
 	}
 
-	return fmt.Sprintf("cape-cluster-%s-group", groupName)
+	return fmt.Sprintf("cape-%s-cluster-%s-group", machine.Namespace, groupName)
 }
 
 func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	capiutil "sigs.k8s.io/cluster-api/util"
 
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
 
 var _ = Describe("CAPE HA e2e test", func() {
@@ -88,7 +88,7 @@ var _ = Describe("CAPE HA e2e test", func() {
 
 		Logf("Shut down VM")
 		ShutDownVM(ctx, ShutDownVMInput{
-			UUID:               util.ConvertProviderIDToUUID(machines[0].Spec.ProviderID),
+			UUID:               machineutil.ConvertProviderIDToUUID(machines[0].Spec.ProviderID),
 			VMService:          vmService,
 			WaitVMJobIntervals: e2eConfig.GetIntervals(specName, "wait-vm-job"),
 		})
@@ -107,7 +107,7 @@ var _ = Describe("CAPE HA e2e test", func() {
 		Byf("Wait for control plane nodes ready")
 		Logf("Powering on VM")
 		PowerOnVM(ctx, PowerOnVMInput{
-			UUID:               util.ConvertProviderIDToUUID(machines[0].Spec.ProviderID),
+			UUID:               machineutil.ConvertProviderIDToUUID(machines[0].Spec.ProviderID),
 			VMService:          vmService,
 			WaitVMJobIntervals: e2eConfig.GetIntervals(specName, "wait-vm-job"),
 		})

--- a/test/fake/controller_manager_context.go
+++ b/test/fake/controller_manager_context.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	cgscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -53,6 +54,7 @@ func NewControllerManagerContext(initObjects ...runtime.Object) *context.Control
 	scheme := runtime.NewScheme()
 	_ = cgscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
 	_ = infrav1.AddToScheme(scheme)
 
 	return &context.ControllerManagerContext{

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -33,6 +33,16 @@ func UUID() string {
 	return uuid.New().String()
 }
 
+func NewTowerCluster() *models.Cluster {
+	id := ID()
+	localID := UUID()
+
+	return &models.Cluster{
+		ID:      &id,
+		LocalID: &localID,
+	}
+}
+
 func NewTowerVM() *models.VM {
 	id := ID()
 	localID := UUID()
@@ -72,5 +82,28 @@ func NewTowerLabel() *models.Label {
 		ID:    &id,
 		Key:   &key,
 		Value: &value,
+	}
+}
+
+func NewVMPlacementGroup(vmIDs []string) *models.VMPlacementGroup {
+	id := ID()
+	localID := UUID()
+	vms := make([]*models.NestedVM, 0, len(vmIDs))
+	for i := 0; i < len(vmIDs); i++ {
+		vms = append(vms, &models.NestedVM{ID: util.TowerString(vmIDs[i])})
+	}
+
+	return &models.VMPlacementGroup{
+		ID:      &id,
+		Name:    &id,
+		LocalID: &localID,
+		Vms:     vms,
+	}
+}
+
+func NewWithTaskVMPlacementGroup(placementGroup *models.VMPlacementGroup, task *models.Task) *models.WithTaskVMPlacementGroup {
+	return &models.WithTaskVMPlacementGroup{
+		Data:   placementGroup,
+		TaskID: task.ID,
 	}
 }

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -21,8 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
-
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
+	"k8s.io/utils/pointer"
 )
 
 func ID() string {
@@ -52,7 +51,7 @@ func NewTowerVM() *models.VM {
 		ID:                &id,
 		LocalID:           &localID,
 		Status:            &status,
-		EntityAsyncStatus: (*models.EntityAsyncStatus)(util.TowerString("CREATING")),
+		EntityAsyncStatus: (*models.EntityAsyncStatus)(pointer.StringPtr("CREATING")),
 	}
 }
 
@@ -90,7 +89,7 @@ func NewVMPlacementGroup(vmIDs []string) *models.VMPlacementGroup {
 	localID := UUID()
 	vms := make([]*models.NestedVM, 0, len(vmIDs))
 	for i := 0; i < len(vmIDs); i++ {
-		vms = append(vms, &models.NestedVM{ID: util.TowerString(vmIDs[i])})
+		vms = append(vms, &models.NestedVM{ID: &vmIDs[i]})
 	}
 
 	return &models.VMPlacementGroup{

--- a/test/fake/types.go
+++ b/test/fake/types.go
@@ -146,6 +146,17 @@ func NewKCP() *controlplanev1.KubeadmControlPlane {
 	}
 }
 
+func NewMD() *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.SimpleNameGenerator.GenerateName("md-"),
+			Namespace: Namespace,
+		},
+		Spec:   clusterv1.MachineDeploymentSpec{},
+		Status: clusterv1.MachineDeploymentStatus{},
+	}
+}
+
 func InitClusterOwnerReferences(ctrlContext *context.ControllerContext,
 	elfCluster *infrav1.ElfCluster, cluster *clusterv1.Cluster) {
 	By("setting the OwnerRef on the ElfCluster")
@@ -186,6 +197,20 @@ func ToControlPlaneMachine(machine metav1.Object, kcp *controlplanev1.KubeadmCon
 	labels[clusterv1.MachineControlPlaneLabelName] = ""
 	if kcp != nil {
 		labels[clusterv1.MachineControlPlaneNameLabel] = kcp.Name
+	}
+
+	machine.SetLabels(labels)
+}
+
+func ToWorkerMachine(machine metav1.Object, md *clusterv1.MachineDeployment) {
+	labels := machine.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[clusterv1.MachineDeploymentLabelName] = ""
+	if md != nil {
+		labels[clusterv1.MachineDeploymentLabelName] = md.Name
 	}
 
 	machine.SetLabels(labels)

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,6 +80,7 @@ func init() {
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(admissionv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(controlplanev1.AddToScheme(scheme))
 	utilruntime.Must(infrav1.AddToScheme(scheme))
 
 	// Get the root of the current file to use in CRD paths.


### PR DESCRIPTION
### 增强集群 HA

使用虚拟机放置组提升集群 HA，CP 节点使用 “必须放置在不同主机上” 放置组策略；Worker 节点使用 “优先放置在不同主机上” 放置组策略。更多请参考设计文档。

### 改动
- 增加放置组
- 调整 reconcileVM 逻辑过于复杂，拆出来 getVM() 和 和 reconcileVMStatus
- 增加 acquireTicketForUpdateVM 处理 Tower 接口并发操作虚拟机带来的任务失败问题
- 增加 releaseTicketForUpdatePlacementGroup 避免并发更新放置组
- 增加 acquireTicketForPlacementGroupOperation 避免并发操作放置组（查询、更新等）

### 测试

#### 升级相关

1.  CP + 1 Worker 集群创建和升级 （CP 节点数小于主机数）

2.  3 CP + 10 Worker 集群创建和升级（CP 节点数等于主机数）
升级前
<img width="615" alt="image" src="https://user-images.githubusercontent.com/19967151/224635422-9d38828a-1f1b-4337-8663-5a67548aa444.png">

<img width="618" alt="image" src="https://user-images.githubusercontent.com/19967151/224634037-0d979f34-3ecf-40b1-b3c0-fb517b68991b.png">

升级中最新版本的 CP 节点和旧版本中最新的 CP 节点的主机一致。
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/19967151/224634309-562272f4-2191-44e2-9f29-6568b20a9cea.png">

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/19967151/224634376-27397676-e25c-46de-ad97-ec1fe43ed548.png">

升级后

没有发现虚拟机迁移，没有出现错误 Task，放置组也按照策略生效，符合预期。

CP 节点
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/19967151/224636896-cecd1436-e200-4eb9-ae74-704333c85c10.png">

<img width="618" alt="image" src="https://user-images.githubusercontent.com/19967151/224636825-9cf55471-e6bd-43d5-8a23-52e0257e38bd.png">

Worker 节点
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/19967151/224638132-2f855264-2cfc-47cd-942c-69d5a7b35e4a.png">

<img width="609" alt="image" src="https://user-images.githubusercontent.com/19967151/224638085-9f98da15-835e-4f4b-815e-d0c8d331f7d2.png">

3. 5 CP + 10 Worker 集群创建和升级（CP 节点数大于等于主机数）

#### 1.0 版本兼容
使用 CAPE 1.0 创建 3 CP + 3 Workers 集群，然后再切换到当前代码，观察变化。

1. 3 个 CP 在不同主机，不会发生虚拟机迁移

CAPE 1.0
<img width="613" alt="image" src="https://user-images.githubusercontent.com/19967151/224641458-e5f7a22c-4488-4480-acfc-444c42e0518c.png">

<img width="610" alt="image" src="https://user-images.githubusercontent.com/19967151/224641529-8de58112-2c7f-4061-888d-7caecfa88adf.png">

<img width="608" alt="image" src="https://user-images.githubusercontent.com/19967151/224641596-ff1e5aa8-5c8c-43db-9b1d-4277eb11e83c.png">

切换到当前代码

CP 节点
发生两次热迁移
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/19967151/224642463-f55f612f-0458-43cf-8730-68c45c638f96.png">

<img width="605" alt="image" src="https://user-images.githubusercontent.com/19967151/224642266-8946a82f-19f2-4bb7-af9c-4d5577d0460f.png">

Worker 节点

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/19967151/224642748-ff604540-2814-49f5-805c-50073a71ff6d.png">


<img width="606" alt="image" src="https://user-images.githubusercontent.com/19967151/224642569-0e68a82c-06df-4bcb-8ad6-491247bec7ad.png">


2. 3 个 CP 在相同的主机，发生两次虚拟机迁移


3. 2 个 CP 在相同主机，另外一个 CP 独自在一台主机，可能发生一次或两次虚拟机迁移
