### PR TITLE
Support the max concurrent number of virtual machine creation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
         - --leader-elect
         - --logtostderr
         - --v=4
+        - --max-concurrent-vm-creations=20
         image: docker.io/smartxworks/cape-manager:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -30,9 +30,9 @@ const (
 var vmStatusMap = make(map[string]time.Time)
 var limiterLock sync.Mutex
 
-// canCreateVM returns whether virtual machine create operation
+// acquireTicketForCreateVM returns whether virtual machine create operation
 // can be performed.
-func canCreateVM(vmName string) bool {
+func acquireTicketForCreateVM(vmName string) bool {
 	limiterLock.Lock()
 	defer limiterLock.Unlock()
 
@@ -53,8 +53,8 @@ func canCreateVM(vmName string) bool {
 	return true
 }
 
-// releaseVM releases the virtual machine being created.
-func releaseVM(vmName string) {
+// releaseTicketForCreateVM releases the virtual machine being created.
+func releaseTicketForCreateVM(vmName string) {
 	limiterLock.Lock()
 	defer limiterLock.Unlock()
 

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
+)
+
+const (
+	creationTimeout = time.Minute * 6
+)
+
+var vmStatusMap = make(map[string]time.Time)
+var limiterLock sync.Mutex
+
+// canCreateVM returns whether virtual machine create operation
+// can be performed.
+func canCreateVM(vmName string) bool {
+	limiterLock.Lock()
+	defer limiterLock.Unlock()
+
+	if len(vmStatusMap) >= config.MaxConcurrentVMCreations {
+		for name, timestamp := range vmStatusMap {
+			if !time.Now().Before(timestamp.Add(creationTimeout)) {
+				delete(vmStatusMap, name)
+			}
+		}
+	}
+
+	if len(vmStatusMap) >= config.MaxConcurrentVMCreations {
+		return false
+	}
+
+	vmStatusMap[vmName] = time.Now()
+
+	return true
+}
+
+// releaseVM releases the virtual machine being created.
+func releaseVM(vmName string) {
+	limiterLock.Lock()
+	defer limiterLock.Unlock()
+
+	delete(vmStatusMap, vmName)
+}

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
+	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
+)
+
+var _ = Describe("VMLimiter", func() {
+	var vmName string
+
+	BeforeEach(func() {
+		vmName = fake.UUID()
+		resetVMStatusMap()
+	})
+
+	It("canCreateVM", func() {
+		Expect(canCreateVM(vmName)).To(BeTrue())
+		Expect(vmStatusMap).To(HaveKey(vmName))
+
+		for i := 0; i < config.MaxConcurrentVMCreations-1; i++ {
+			vmStatusMap[fake.UUID()] = time.Now()
+		}
+		Expect(canCreateVM(vmName)).To(BeFalse())
+
+		resetVMStatusMap()
+		for i := 0; i < config.MaxConcurrentVMCreations; i++ {
+			vmStatusMap[fake.UUID()] = time.Now().Add(-creationTimeout)
+		}
+		Expect(canCreateVM(vmName)).To(BeTrue())
+		Expect(vmStatusMap).To(HaveKey(vmName))
+		Expect(len(vmStatusMap)).To(Equal(1))
+	})
+
+	It("releaseVM", func() {
+		Expect(vmStatusMap).NotTo(HaveKey(vmName))
+		Expect(canCreateVM(vmName)).To(BeTrue())
+		Expect(vmStatusMap).To(HaveKey(vmName))
+		releaseVM(vmName)
+		Expect(vmStatusMap).NotTo(HaveKey(vmName))
+	})
+})
+
+func resetVMStatusMap() {
+	vmStatusMap = make(map[string]time.Time)
+}

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -34,29 +34,29 @@ var _ = Describe("VMLimiter", func() {
 		resetVMStatusMap()
 	})
 
-	It("canCreateVM", func() {
-		Expect(canCreateVM(vmName)).To(BeTrue())
+	It("acquireTicketForCreateVM", func() {
+		Expect(acquireTicketForCreateVM(vmName)).To(BeTrue())
 		Expect(vmStatusMap).To(HaveKey(vmName))
 
 		for i := 0; i < config.MaxConcurrentVMCreations-1; i++ {
 			vmStatusMap[fake.UUID()] = time.Now()
 		}
-		Expect(canCreateVM(vmName)).To(BeFalse())
+		Expect(acquireTicketForCreateVM(vmName)).To(BeFalse())
 
 		resetVMStatusMap()
 		for i := 0; i < config.MaxConcurrentVMCreations; i++ {
 			vmStatusMap[fake.UUID()] = time.Now().Add(-creationTimeout)
 		}
-		Expect(canCreateVM(vmName)).To(BeTrue())
+		Expect(acquireTicketForCreateVM(vmName)).To(BeTrue())
 		Expect(vmStatusMap).To(HaveKey(vmName))
 		Expect(len(vmStatusMap)).To(Equal(1))
 	})
 
-	It("releaseVM", func() {
+	It("releaseTicketForCreateVM", func() {
 		Expect(vmStatusMap).NotTo(HaveKey(vmName))
-		Expect(canCreateVM(vmName)).To(BeTrue())
+		Expect(acquireTicketForCreateVM(vmName)).To(BeTrue())
 		Expect(vmStatusMap).To(HaveKey(vmName))
-		releaseVM(vmName)
+		releaseTicketForCreateVM(vmName)
 		Expect(vmStatusMap).NotTo(HaveKey(vmName))
 	})
 })

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	ctrlsig "sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/smartxworks/cluster-api-provider-elf/controllers"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/manager"
 	"github.com/smartxworks/cluster-api-provider-elf/version"
@@ -96,6 +97,11 @@ func main() {
 		":9440",
 		"The address the health endpoint binds to.",
 	)
+	flag.IntVar(
+		&config.MaxConcurrentVMCreations,
+		"max-concurrent-vm-creations",
+		config.MaxConcurrentVMCreations,
+		"The maximum number of concurrent virtual machine creations.")
 
 	flag.Parse()
 

--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -30,4 +30,5 @@ const (
 	VMDiskName = "disk"
 )
 
+// MaxConcurrentVMCreations is the maximum number of concurrent virtual machine creations.
 var MaxConcurrentVMCreations = 20

--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -29,3 +29,5 @@ const (
 	// VMDiskName is the default disk name in a VM.
 	VMDiskName = "disk"
 )
+
+var MaxConcurrentVMCreations = 20


### PR DESCRIPTION
### SKS-928 限制并发创建虚拟机数
ELF 集群在同时创建大量的虚拟机可能会带来一些性能问题导致创建虚拟机任务失败，或者出现重名虚拟机。

### 解决
CAPE 支持限制并发创建虚拟机数量，减少对 ELF API产生的压力和性能影响。

### 测试
并发创建两个 3CP + 20 Workers 集群

第一次测试
```bash
haijian-elf-test38   v1.23.14   Ready      true    3/3             20/20     7m41s   calico   smtx-zbs-csi   10.255.160.2:6443
haijian-elf-test37   v1.23.14   Ready      true    3/3             20/20     9m18s   calico   smtx-zbs-csi   10.255.160.3:6443
```

第二次测试
```bash
haijian-elf-test2    v1.23.14   Ready      true    3/3             20/20     8m13s   calico   smtx-zbs-csi   10.255.160.3:6443
haijian-elf-test1    v1.23.14   Ready      true    3/3             20/20     8m23s   calico   smtx-zbs-csi   10.255.160.2:6443
```

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/19967151/210056587-e31f24c9-2738-4efb-a8af-f93d6abb6057.png">
