### PR TITLE
Allow the concurrent creation of Control Plane VMs in different ElfClusters

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -474,9 +474,12 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			ctx.Logger.V(1).Info(fmt.Sprintf("Insufficient memory for ELF cluster %s, try to create VM", ctx.ElfCluster.Spec.Cluster))
 		}
 
-		if ok := acquireTicketForCreateVM(ctx.ElfMachine.Name); !ok {
-			ctx.Logger.V(1).Info(fmt.Sprintf("The number of concurrently created VMs has reached the limit, skip creating VM %s", ctx.ElfMachine.Name))
-			return nil, nil
+		// Only limit the virtual machines of the worker nodes
+		if !util.IsControlPlaneMachine(ctx.ElfMachine) {
+			if ok := acquireTicketForCreateVM(ctx.ElfMachine.Name); !ok {
+				ctx.Logger.V(1).Info(fmt.Sprintf("The number of concurrently created VMs has reached the limit, skip creating VM %s", ctx.ElfMachine.Name))
+				return nil, nil
+			}
 		}
 
 		ctx.Logger.Info("Create VM for ElfMachine")


### PR DESCRIPTION
### SKS-928
取消对 CP 节点虚拟机创建的限流，加速集群的创建过程。
单个ElfCluster中的多个CP节点是逐个按顺序创建的，此PR允许任意ElfCluster中的CP节点VM创建都不受限流约束。

### 测试
并发创建两个 3CP + 20 Workers 集群

第一次
```bash
haijian-limit-test2   v1.23.14   Ready      true    3/3             20/20     10m     calico   smtx-zbs-csi   10.255.160.2:6443
haijian-limit-test3   v1.23.14   Ready      true    3/3             20/20     11m     calico   smtx-zbs-csi   10.255.160.3:6443
```

第二次
```bash
haijian-limit-test2   v1.23.14   Ready      true    3/3             20/20     10m     calico   smtx-zbs-csi   10.255.160.2:6443
haijian-limit-test3   v1.23.14   Ready      true    3/3             20/20     10m     calico   smtx-zbs-csi   10.255.160.3:6443
```

第三次
```bash
haijian-limit-test2   v1.23.14   Ready      true    3/3             20/20     9m36s   calico   smtx-zbs-csi   10.255.160.2:6443
haijian-limit-test3   v1.23.14   Ready      true    3/3             20/20     9m52s   calico   smtx-zbs-csi   10.255.160.3:6443
```

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/19967151/210491665-5702892b-187c-4f1b-8822-1ec454abf49e.png">
