### PR TITLE
SKS-1140: Delete the labels of the cluster when the cluster is deleted

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -238,11 +238,11 @@ func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.Clu
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteLabels(ctx *context.ClusterContext) error {
-	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelClusterName(), ctx.ElfCluster.Name, true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelClusterName(), ctx.ElfCluster.Name, false); err != nil {
 		return err
 	}
 
-	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelVIP(), ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host, true); err != nil {
+	if err := r.reconcileDeleteLabel(ctx, towerresources.GetVMLabelVIP(), ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host, false); err != nil {
 		return err
 	}
 

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -211,8 +211,8 @@ var _ = Describe("ElfClusterReconciler", func() {
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
 			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("%s-managed-%s-%s", towerresources.GetResourcePrefix(), cluster.Namespace, cluster.Name)).Return(nil, nil)
-			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
-			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, true).Return("labelid", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, false).Return("labelid", nil)
+			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, false).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelManaged(), "true", true).Return("", nil)
 

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -547,6 +547,8 @@ func (svr *TowerVMService) UpsertLabel(key, value string) (*models.Label, error)
 }
 
 // DeleteLabel deletes a label.
+// If strict is false, delete the label directly.
+// If strict is true, delete the label only if no virtual machine references the label.
 func (svr *TowerVMService) DeleteLabel(key, value string, strict bool) (string, error) {
 	deleteLabelParams := clientlabel.NewDeleteLabelParams()
 	deleteLabelParams.RequestBody = &models.LabelDeletionParams{


### PR DESCRIPTION
### Fix

问题：删除集群，对应的标签 cluster-name 和 vip 未被清理。

解决：之前相关的删除逻辑加入了计数判断，但是目前的计数是不准确的。在删除集群的时候直接删除集群关联的标签即可。

### 测试
经过多次删除集群测试，上述没有被删除的标签都被删除了。