### PR TITLE
Read ElfMachines directly from API server to avoid data consistency problems caused by expired cache

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -114,7 +114,7 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ct
 func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	// Get the ElfMachine resource for this request.
 	var elfMachine infrav1.ElfMachine
-	if err := r.Client.Get(r, req.NamespacedName, &elfMachine); err != nil {
+	if err := r.APIReader.Get(r, req.NamespacedName, &elfMachine); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Logger.Info("ElfMachine not found, won't reconcile", "key", req.NamespacedName)
 

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -53,6 +53,9 @@ type ControllerManagerContext struct {
 	// Client is the controller manager's client.
 	Client client.Client
 
+	// APIReader is used to get/list resources directly via the API server to avoid outdated cache.
+	APIReader client.Reader
+
 	// Logger is the controller manager's logger.
 	Logger logr.Logger
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -66,6 +66,7 @@ func New(opts Options) (Manager, error) {
 		LeaderElectionNamespace: opts.LeaderElectionNamespace,
 		MaxConcurrentReconciles: opts.MaxConcurrentReconciles,
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Logger:                  opts.Logger.WithName(opts.PodName),
 		Scheme:                  opts.Scheme,
 	}


### PR DESCRIPTION
### 改动
问题：client-go 的缓存数据会带来数据一致性的问题，ElfMachineReconciler 从缓存读取过期的 ElfMachine 数据会导致 taskRef 被覆盖（放置组操作必须加锁避免并发操作），这导致锁需要超时自动释放，创建集群时间增加。

解决：ElfMachine 直接从 API server 读取最新的数据。
