### PR TITLE
[WIP] Customize patch to support returning the modified object

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).To(BeNil())
 			Expect(logBuffer.String()).To(ContainSubstring("Cluster infrastructure is not ready yet"))
 			elfMachine = &infrav1.ElfMachine{}
-			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
+			Expect(reconciler.Client.Get(&reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForClusterInfrastructureReason}})
 		})
 
@@ -181,7 +181,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).To(BeNil())
 			Expect(logBuffer.String()).To(ContainSubstring("Waiting for bootstrap data to be available"))
 			elfMachine = &infrav1.ElfMachine{}
-			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
+			Expect(reconciler.Client.Get(&reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForBootstrapDataReason}})
 		})
 

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -21,10 +21,11 @@ import (
 
 	"github.com/go-logr/logr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
+	patchutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/patch"
 )
 
 // MachineContext is a Go context used with a ElfMachine.
@@ -35,7 +36,7 @@ type MachineContext struct {
 	ElfCluster  *infrav1.ElfCluster
 	ElfMachine  *infrav1.ElfMachine
 	Logger      logr.Logger
-	PatchHelper *patch.Helper
+	PatchHelper *patchutil.Helper
 	VMService   service.VMService
 }
 
@@ -45,6 +46,6 @@ func (c *MachineContext) String() string {
 }
 
 // Patch updates the object and its status on the API server.
-func (c *MachineContext) Patch() error {
+func (c *MachineContext) Patch() (client.Object, error) {
 	return c.PatchHelper.Patch(c, c.ElfMachine)
 }

--- a/pkg/util/patch/options.go
+++ b/pkg/util/patch/options.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+// Option is some configuration that modifies options for a patch request.
+type Option interface {
+	// ApplyToHelper applies this configuration to the given Helper options.
+	ApplyToHelper(*HelperOptions)
+}
+
+// HelperOptions contains options for patch options.
+type HelperOptions struct {
+	// IncludeStatusObservedGeneration sets the status.observedGeneration field
+	// on the incoming object to match metadata.generation, only if there is a change.
+	IncludeStatusObservedGeneration bool
+
+	// ForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+	// This option should only ever be set in controller managing the object being patched.
+	ForceOverwriteConditions bool
+
+	// OwnedConditions defines condition types owned by the controller.
+	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	OwnedConditions []clusterv1.ConditionType
+}
+
+// WithForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+// This option should only ever be set in controller managing the object being patched.
+type WithForceOverwriteConditions struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithForceOverwriteConditions) ApplyToHelper(in *HelperOptions) {
+	in.ForceOverwriteConditions = true
+}
+
+// WithStatusObservedGeneration sets the status.observedGeneration field
+// on the incoming object to match metadata.generation, only if there is a change.
+type WithStatusObservedGeneration struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
+	in.IncludeStatusObservedGeneration = true
+}
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type WithOwnedConditions struct {
+	Conditions []clusterv1.ConditionType
+}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithOwnedConditions) ApplyToHelper(in *HelperOptions) {
+	in.OwnedConditions = w.Conditions
+}

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// Helper is a utility for ensuring the proper patching of objects.
+type Helper struct {
+	client       client.Client
+	gvk          schema.GroupVersionKind
+	beforeObject client.Object
+	before       *unstructured.Unstructured
+	after        *unstructured.Unstructured
+	changes      map[string]bool
+
+	isConditionsSetter bool
+}
+
+// NewHelper returns an initialized Helper.
+func NewHelper(obj client.Object, crClient client.Client) (*Helper, error) {
+	// Return early if the object is nil.
+	if capiutil.IsNil(obj) {
+		return nil, errors.New("helper could not be created: object is nil")
+	}
+
+	// Get the GroupVersionKind of the object,
+	// used to validate against later on.
+	gvk, err := apiutil.GVKForObject(obj, crClient.Scheme())
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the object to unstructured to compare against our before copy.
+	unstructuredObj, err := toUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the object satisfies the Cluster API conditions contract.
+	_, canInterfaceConditions := obj.(conditions.Setter)
+
+	return &Helper{
+		client:             crClient,
+		gvk:                gvk,
+		before:             unstructuredObj,
+		beforeObject:       obj.DeepCopyObject().(client.Object),
+		isConditionsSetter: canInterfaceConditions,
+	}, nil
+}
+
+// Patch will attempt to patch the given object, including its status.
+func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) (client.Object, error) {
+	// Return early if the object is nil.
+	if capiutil.IsNil(obj) {
+		return nil, errors.New("Patch could not be completed: object is nil")
+	}
+
+	// Get the GroupVersionKind of the object that we want to patch.
+	gvk, err := apiutil.GVKForObject(obj, h.client.Scheme())
+	if err != nil {
+		return nil, err
+	}
+	if gvk != h.gvk {
+		return nil, errors.Errorf("unmatched GroupVersionKind, expected %q got %q", h.gvk, gvk)
+	}
+
+	// Calculate the options.
+	options := &HelperOptions{}
+	for _, opt := range opts {
+		opt.ApplyToHelper(options)
+	}
+
+	// Convert the object to unstructured to compare against our before copy.
+	h.after, err = toUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if the object has status.
+	if unstructuredHasStatus(h.after) {
+		if options.IncludeStatusObservedGeneration {
+			// Set status.observedGeneration if we're asked to do so.
+			if err := unstructured.SetNestedField(h.after.Object, h.after.GetGeneration(), "status", "observedGeneration"); err != nil {
+				return nil, err
+			}
+
+			// Restore the changes back to the original object.
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(h.after.Object, obj); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Calculate and store the top-level field changes (e.g. "metadata", "spec", "status") we have before/after.
+	h.changes, err = h.calculateChanges(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Patch the conditions first.
+	//
+	// Given that we pass in metadata.resourceVersion to perform a 3-way-merge conflict resolution,
+	// patching conditions first avoids an extra loop if spec or status patch succeeds first
+	// given that causes the resourceVersion to mutate.
+	patchConditionsObj, patchConditionsErr := h.patchStatusConditions(ctx, obj, options.ForceOverwriteConditions, options.OwnedConditions)
+
+	// Then proceed to patch the rest of the object.
+	patchObj, patchErr := h.patch(ctx, obj)
+	patchStatusObj, patchStatusErr := h.patchStatus(ctx, obj)
+
+	newObj := obj
+	if patchConditionsObj != nil {
+		newObj = patchConditionsObj
+	}
+	if patchObj != nil && patchObj.GetResourceVersion() > newObj.GetResourceVersion() {
+		newObj = patchObj
+	}
+	if patchStatusObj != nil && patchStatusObj.GetResourceVersion() > newObj.GetResourceVersion() {
+		newObj = patchStatusObj
+	}
+
+	// Issue patches and return errors in an aggregate.
+	return newObj, kerrors.NewAggregate([]error{
+		patchConditionsErr,
+		patchErr,
+		patchStatusErr,
+	})
+}
+
+// patch issues a patch for metadata and spec.
+func (h *Helper) patch(ctx context.Context, obj client.Object) (client.Object, error) {
+	if !h.shouldPatch("metadata") && !h.shouldPatch("spec") {
+		return obj, nil
+	}
+
+	beforeObject, afterObject, err := h.calculatePatch(obj, specPatch)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := h.client.Patch(ctx, afterObject, client.MergeFrom(beforeObject)); err != nil {
+		return nil, err
+	}
+
+	return afterObject, nil
+}
+
+// patchStatus issues a patch if the status has changed.
+func (h *Helper) patchStatus(ctx context.Context, obj client.Object) (client.Object, error) {
+	if !h.shouldPatch("status") {
+		return obj, nil
+	}
+	beforeObject, afterObject, err := h.calculatePatch(obj, statusPatch)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = h.client.Status().Patch(ctx, afterObject, client.MergeFrom(beforeObject)); err != nil {
+		return nil, err
+	}
+
+	return afterObject, nil
+}
+
+// patchStatusConditions issues a patch if there are any changes to the conditions slice under
+// the status subresource. This is a special case and it's handled separately given that
+// we allow different controllers to act on conditions of the same object.
+//
+// This method has an internal backoff loop. When a conflict is detected, the method
+// asks the Client for the a new version of the object we're trying to patch.
+//
+// Condition changes are then applied to the latest version of the object, and if there are
+// no unresolvable conflicts, the patch is sent again.
+func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []clusterv1.ConditionType) (client.Object, error) {
+	// Nothing to do if the object isn't a condition patcher.
+	if !h.isConditionsSetter {
+		return obj, nil
+	}
+
+	// Make sure our before/after objects satisfy the proper interface before continuing.
+	//
+	// NOTE: The checks and error below are done so that we don't panic if any of the objects don't satisfy the
+	// interface any longer, although this shouldn't happen because we already check when creating the patcher.
+	before, ok := h.beforeObject.(conditions.Getter)
+	if !ok {
+		return nil, errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", before.GetObjectKind())
+	}
+	after, ok := obj.(conditions.Getter)
+	if !ok {
+		return nil, errors.Errorf("object %s doesn't satisfy conditions.Getter, cannot patch", after.GetObjectKind())
+	}
+
+	// Store the diff from the before/after object, and return early if there are no changes.
+	diff, err := conditions.NewPatch(
+		before,
+		after,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "object can not be patched")
+	}
+	if diff.IsZero() {
+		return obj, nil
+	}
+
+	// Make a copy of the object and store the key used if we have conflicts.
+	key := client.ObjectKeyFromObject(after)
+
+	// Define and start a backoff loop to handle conflicts
+	// between controllers working on the same object.
+	//
+	// This has been copied from https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/controller/controller_utils.go#L86-L88.
+	backoff := wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Jitter:   1.0,
+	}
+
+	// Start the backoff loop and return errors if any.
+	var latest conditions.Setter
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		latest, ok = before.DeepCopyObject().(conditions.Setter)
+		if !ok {
+			return false, errors.Errorf("object %s doesn't satisfy conditions.Setter, cannot patch", latest.GetObjectKind())
+		}
+
+		// Get a new copy of the object.
+		if err := h.client.Get(ctx, key, latest); err != nil {
+			return false, err
+		}
+
+		// Create the condition patch before merging conditions.
+		conditionsPatch := client.MergeFromWithOptions(latest.DeepCopyObject().(conditions.Setter), client.MergeFromWithOptimisticLock{})
+
+		// Set the condition patch previously created on the new object.
+		if err := diff.Apply(latest, conditions.WithForceOverwrite(forceOverwrite), conditions.WithOwnedConditions(ownedConditions...)); err != nil {
+			return false, err
+		}
+
+		// Issue the patch.
+		err := h.client.Status().Patch(ctx, latest, conditionsPatch)
+		switch {
+		case apierrors.IsConflict(err):
+			// Requeue.
+			return false, nil
+		case err != nil:
+			return false, err
+		default:
+			return true, nil
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return latest, err
+}
+
+// calculatePatch returns the before/after objects to be given in a controller-runtime patch, scoped down to the absolute necessary.
+func (h *Helper) calculatePatch(afterObj client.Object, focus patchType) (client.Object, client.Object, error) {
+	// Get a shallow unsafe copy of the before/after object in unstructured form.
+	before := unsafeUnstructuredCopy(h.before, focus, h.isConditionsSetter)
+	after := unsafeUnstructuredCopy(h.after, focus, h.isConditionsSetter)
+
+	// We've now applied all modifications to local unstructured objects,
+	// make copies of the original objects and convert them back.
+	beforeObj := h.beforeObject.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(before.Object, beforeObj); err != nil {
+		return nil, nil, err
+	}
+	afterObj = afterObj.DeepCopyObject().(client.Object)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(after.Object, afterObj); err != nil {
+		return nil, nil, err
+	}
+	return beforeObj, afterObj, nil
+}
+
+func (h *Helper) shouldPatch(in string) bool {
+	return h.changes[in]
+}
+
+// calculate changes tries to build a patch from the before/after objects we have
+// and store in a map which top-level fields (e.g. `metadata`, `spec`, `status`, etc.) have changed.
+func (h *Helper) calculateChanges(after client.Object) (map[string]bool, error) {
+	// Calculate patch data.
+	patch := client.MergeFrom(h.beforeObject)
+	diff, err := patch.Data(after)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to calculate patch data")
+	}
+
+	// Unmarshal patch data into a local map.
+	patchDiff := map[string]interface{}{}
+	if err := json.Unmarshal(diff, &patchDiff); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal patch data into a map")
+	}
+
+	// Return the map.
+	res := make(map[string]bool, len(patchDiff))
+	for key := range patchDiff {
+		res[key] = true
+	}
+	return res, nil
+}

--- a/pkg/util/patch/utils.go
+++ b/pkg/util/patch/utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type patchType string
+
+func (p patchType) Key() string {
+	return strings.Split(string(p), ".")[0]
+}
+
+const (
+	specPatch   patchType = "spec"
+	statusPatch patchType = "status"
+)
+
+var (
+	preserveUnstructuredKeys = map[string]bool{
+		"kind":       true,
+		"apiVersion": true,
+		"metadata":   true,
+	}
+)
+
+func unstructuredHasStatus(u *unstructured.Unstructured) bool {
+	_, ok := u.Object["status"]
+	return ok
+}
+
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	// If the incoming object is already unstructured, perform a deep copy first
+	// otherwise DefaultUnstructuredConverter ends up returning the inner map without
+	// making a copy.
+	if _, ok := obj.(runtime.Unstructured); ok {
+		obj = obj.DeepCopyObject()
+	}
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: rawMap}, nil
+}
+
+// unsafeUnstructuredCopy returns a shallow copy of the unstructured object given as input.
+// It copies the common fields such as `kind`, `apiVersion`, `metadata` and the patchType specified.
+//
+// It's not safe to modify any of the keys in the returned unstructured object, the result should be treated as read-only.
+func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, isConditionsSetter bool) *unstructured.Unstructured {
+	// Create the return focused-unstructured object with a preallocated map.
+	res := &unstructured.Unstructured{Object: make(map[string]interface{}, len(obj.Object))}
+
+	// Ranges over the keys of the unstructured object, think of this as the very top level of an object
+	// when submitting a yaml to kubectl or a client.
+	// These would be keys like `apiVersion`, `kind`, `metadata`, `spec`, `status`, etc.
+	for key := range obj.Object {
+		value := obj.Object[key]
+
+		// Perform a shallow copy only for the keys we're interested in, or the ones that should be always preserved.
+		if key == focus.Key() || preserveUnstructuredKeys[key] {
+			res.Object[key] = value
+		}
+
+		// If we've determined that we're able to interface with conditions.Setter interface,
+		// when dealing with the status patch, remove the status.conditions sub-field from the object.
+		if isConditionsSetter && focus == statusPatch {
+			// NOTE: Removing status.conditions changes the incoming object! This is safe because the condition patch
+			// doesn't use the unstructured fields, and it runs before any other patch.
+			//
+			// If we want to be 100% safe, we could make a copy of the incoming object before modifying it, although
+			// copies have a high cpu and high memory usage, therefore we intentionally choose to avoid extra copies
+			// given that the ordering of operations and safety is handled internally by the patch helper.
+			unstructured.RemoveNestedField(res.Object, "status", "conditions")
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
### 脏数据处理

问题：当前 client-go 的缓存读写机制，会带来缓存数据过期，导致 reconcile 过期数据带来旧数据覆盖新数据的问题。

解决：通过在 controller 记录 ElfMachine 的最新 resourceVersion 比对，每次 patch 成功就更新本地的 resourceVersion。在 reconcile 的时候可以对比本地的 resourceVersion 和 从缓存获取的 resourceVersion，如果缓存的 resourceVersion 小于 本地的 resourceVersion，则不允许 reconcile。

改动：patch 改造了原来 CAPI 的 patch 工具，从而支持在 patch 之后返回更新后的 resourceVersion，更新本地的 resourceVersion。
- Patch(ctx context.Context, obj client.Object, opts ...Option) 增加返回修改后的 obj
- patchStatusConditions(ctx context.Context, obj client.Object, forceOverwrite bool, ownedConditions []clusterv1.ConditionType) 增加返回修改后的 obj
- patch(ctx context.Context, obj client.Object) 增加返回修改后的 obj
- patchStatus(ctx context.Context, obj client.Object) 增加返回修改后的 obj
