### PR TITLE
Wait for create/update placement group tasks to finish synchronously

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -48,6 +48,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	capeerrors "github.com/smartxworks/cluster-api-provider-elf/pkg/errors"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
@@ -577,33 +578,127 @@ var _ = Describe("ElfMachineReconciler", func() {
 			machine.Spec.Bootstrap = clusterv1.Bootstrap{DataSecretName: &secret.Name}
 		})
 
-		It("should create a new placement group", func() {
+		It("should create a new placement group and add vm to the placement group", func() {
 			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
 			vm.Status = &status
 			task := fake.NewTowerTask()
+			taskStatus := models.TaskStatusSUCCESSED
+			task.Status = &taskStatus
 			withTaskVMPlacementGroup := fake.NewWithTaskVMPlacementGroup(nil, task)
 			elfMachine.Status.VMRef = *vm.LocalID
+			placementGroup := fake.NewVMPlacementGroup(nil)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Times(2).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).NotTo(BeZero())
+			ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+			Expect(ok).To(BeTrue())
 			Expect(err).To(BeZero())
-			elfMachine = &infrav1.ElfMachine{}
-			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(elfMachine.Status.TaskRef).To(Equal(*withTaskVMPlacementGroup.TaskID))
-			Expect(logBuffer.String()).To(ContainSubstring("Waiting for the placement group to be created"))
-			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.JoiningPlacementGroupReason}})
+			Expect(logBuffer.String()).To(ContainSubstring("Create placement group successfully"))
+			Expect(logBuffer.String()).To(ContainSubstring("Update placement group successfully"))
+		})
+
+		It("createPlacementGroup", func() {
+			towerCluster := fake.NewTowerCluster()
+			vm := fake.NewTowerVM()
+			vm.EntityAsyncStatus = nil
+			status := models.VMStatusSTOPPED
+			vm.Status = &status
+			task := fake.NewTowerTask()
+			taskStatus := models.TaskStatusSUCCESSED
+			task.Status = &taskStatus
+			withTaskVMPlacementGroup := fake.NewWithTaskVMPlacementGroup(nil, task)
+			elfMachine.Status.VMRef = *vm.LocalID
+			placementGroup := fake.NewVMPlacementGroup(nil)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			pg, err := reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
+			Expect(err).To(BeZero())
+			Expect(*pg.Name).To(Equal(*placementGroup.Name))
+			Expect(logBuffer.String()).To(ContainSubstring("Create placement group successfully"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			taskStatus = models.TaskStatusFAILED
+			task.Status = &taskStatus
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
+			Expect(pg).To(BeNil())
+			Expect(strings.Contains(err.Error(), "failed to create placement group")).To(BeTrue())
+			Expect(logBuffer.String()).To(ContainSubstring("Create placement group failed"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+
+			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
+			Expect(pg).To(BeNil())
+			Expect(strings.Contains(err.Error(), "failed to wait for placement group")).To(BeTrue())
+		})
+
+		It("addVMsToPlacementGroup", func() {
+			vm := fake.NewTowerVM()
+			vm.EntityAsyncStatus = nil
+			status := models.VMStatusSTOPPED
+			vm.Status = &status
+			task := fake.NewTowerTask()
+			taskStatus := models.TaskStatusSUCCESSED
+			task.Status = &taskStatus
+			elfMachine.Status.VMRef = *vm.LocalID
+			placementGroup := fake.NewVMPlacementGroup(nil)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+
+			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			err := reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
+			Expect(err).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("Update placement group successfully"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			taskStatus = models.TaskStatusFAILED
+			task.Status = &taskStatus
+			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
+			Expect(err).To(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Update placement group failed"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
+			Expect(strings.Contains(err.Error(), "failed to wait for placement group")).To(BeTrue())
 		})
 
 		It("should wait for placement group task done", func() {
@@ -631,35 +726,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.JoiningPlacementGroupReason}})
 		})
 
-		It("should add worker vm to the placement group", func() {
-			towerCluster := fake.NewTowerCluster()
-			vm := fake.NewTowerVM()
-			vm.EntityAsyncStatus = nil
-			status := models.VMStatusSTOPPED
-			vm.Status = &status
-			elfMachine.Status.VMRef = *vm.LocalID
-			task := fake.NewTowerTask()
-			placementGroup := fake.NewVMPlacementGroup(nil)
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfMachineKey := capiutil.ObjectKey(elfMachine)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
-			Expect(result.RequeueAfter).NotTo(BeZero())
-			Expect(err).To(BeZero())
-			elfMachine = &infrav1.ElfMachine{}
-			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
-			Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
-			Expect(logBuffer.String()).To(ContainSubstring("Waiting for the VM to be added to the placement group"))
-			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.JoiningPlacementGroupReason}})
-		})
-
 		It("should handle placement group error", func() {
 			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
@@ -667,14 +733,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			status := models.VMStatusSTOPPED
 			vm.Status = &status
 			elfMachine.Status.VMRef = *vm.LocalID
-			placementGroup := fake.NewVMPlacementGroup(nil)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(nil, errors.New("some error"))
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New("some error"))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -730,6 +794,8 @@ var _ = Describe("ElfMachineReconciler", func() {
 				vm2 := fake.NewTowerVM()
 				vm2.Host = &models.NestedHost{ID: util.TowerString(hostID2)}
 				task := fake.NewTowerTask()
+				taskStatus := models.TaskStatusSUCCESSED
+				task.Status = &taskStatus
 				placementGroup := fake.NewVMPlacementGroup([]string{*vm2.ID})
 				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md, kcp)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -739,14 +805,13 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, gomock.Any()).Return(task, nil)
+				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
-				Expect(ok).To(BeFalse())
+				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
-				Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
-				Expect(logBuffer.String()).To(ContainSubstring("Waiting for the VM to be added to the placement group"))
-				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.JoiningPlacementGroupReason}})
+				Expect(logBuffer.String()).To(ContainSubstring("Update placement group successfully"))
 			})
 
 			It("should not migrate VM when VM is running and kcp.Spec.Replicas != kcp.Status.UpdatedReplicas", func() {

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -105,29 +105,6 @@ var _ = Describe("Placement Group VM Migration Limiter", func() {
 	})
 })
 
-var _ = Describe("Placement Group Update Limiter", func() {
-	var groupName string
-
-	BeforeEach(func() {
-		groupName = fake.UUID()
-	})
-
-	It("acquireTicketForUpdatePlacementGroup", func() {
-		Expect(acquireTicketForUpdatePlacementGroup(groupName)).To(BeTrue())
-		Expect(placementGroupStatusMap).To(HaveKey(groupName))
-		releaseTicketForUpdatePlacementGroup(groupName)
-
-		placementGroupStatusMap[groupName] = time.Now()
-		Expect(acquireTicketForUpdatePlacementGroup(groupName)).To(BeFalse())
-		releaseTicketForUpdatePlacementGroup(groupName)
-
-		placementGroupStatusMap[groupName] = time.Now().Add(-placementGroupOperationTimeout)
-		Expect(acquireTicketForUpdatePlacementGroup(groupName)).To(BeTrue())
-		Expect(placementGroupStatusMap).To(HaveKey(groupName))
-		releaseTicketForUpdatePlacementGroup(groupName)
-	})
-})
-
 var _ = Describe("Placement Group Operation Limiter", func() {
 	var groupName string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,5 +23,11 @@ var (
 
 	// DefaultRequeueTimeout is the default time for how long to wait when
 	// requeueing a CAPE operation.
-	DefaultRequeueTimeout = 20 * time.Second
+	DefaultRequeueTimeout = 10 * time.Second
+
+	// WaitTaskInterval is the default interval time polling task.
+	WaitTaskInterval = 1 * time.Second
+
+	// WaitTaskTimeout is the default timeout for waiting for task to complete.
+	WaitTaskTimeout = 3 * time.Second
 )

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -6,6 +6,7 @@ package mock_services
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/smartxworks/cloudtower-go-sdk/v2/models"
@@ -349,4 +350,19 @@ func (m *MockVMService) UpsertLabel(key, value string) (*models.Label, error) {
 func (mr *MockVMServiceMockRecorder) UpsertLabel(key, value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertLabel", reflect.TypeOf((*MockVMService)(nil).UpsertLabel), key, value)
+}
+
+// WaitTask mocks base method.
+func (m *MockVMService) WaitTask(id string, timeout, interval time.Duration) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitTask", id, timeout, interval)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitTask indicates an expected call of WaitTask.
+func (mr *MockVMServiceMockRecorder) WaitTask(id, timeout, interval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTask", reflect.TypeOf((*MockVMService)(nil).WaitTask), id, timeout, interval)
 }


### PR DESCRIPTION
### 把放置组操作改成同步执行

问题：Reconcile ElfMachine 过期数据，导致创建放置组的 taskRef 被删除了，操作放置组的锁不能被释放，创建集群时间增加。

解决：放置组操作 task 的时间在秒级别，通过轮询等待放置组操作 task 完成（3秒），避免了使用 taskRef，从而解决了上述问题。

### 改动
- 放置组异步操作改成同步执行
- 取消了放置组操作锁
- reconcileVMTask 确保 task 处理完成再设置 ctx.ElfMachine.SetTask("")

### 测试
已在 CI 完成 6+ 次 E2E 测试验证。