### PR TITLE
SKS-1135: Fix the issue that KCP name exceed 63 characters

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1065,7 +1065,7 @@ func (r *ElfMachineReconciler) reconcileNode(ctx *context.MachineContext, vm *mo
 		return true, nil
 	}
 
-	nodeGroupName := machineutil.GetNodeGroupName(ctx.ElfMachine)
+	nodeGroupName := machineutil.GetNodeGroupName(ctx.Machine)
 	payloads := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1566,7 +1566,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 					node.Labels[infrav1.HostServerIDLabel] == elfMachine.Status.HostServerRef &&
 					node.Labels[infrav1.HostServerNameLabel] == elfMachine.Status.HostServerName &&
 					node.Labels[infrav1.TowerVMIDLabel] == *vm.ID &&
-					node.Labels[infrav1.NodeGroupLabel] == machineutil.GetNodeGroupName(elfMachine)
+					node.Labels[infrav1.NodeGroupLabel] == machineutil.GetNodeGroupName(machine)
 			}, timeout).Should(BeTrue())
 		})
 

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -42,7 +42,7 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 			return placementGroupName, nil
 		}
 
-		groupName = labelsutil.GetControlPlaneNameLabel(machine)
+		groupName = machineutil.GetKCPNameByMachine(machine)
 	} else {
 		md, err := machineutil.GetMDByMachine(ctx, ctrlClient, machine)
 		if err != nil {

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -43,10 +43,6 @@ func GetClusterNameLabelLabel(o metav1.Object) string {
 	return GetLabelValue(o, clusterv1.ClusterNameLabel)
 }
 
-func GetControlPlaneNameLabel(o metav1.Object) string {
-	return GetLabelValue(o, clusterv1.MachineControlPlaneNameLabel)
-}
-
 func GetDeploymentNameLabel(o metav1.Object) string {
 	return GetLabelValue(o, clusterv1.MachineDeploymentNameLabel)
 }

--- a/pkg/util/machine/kcp.go
+++ b/pkg/util/machine/kcp.go
@@ -18,6 +18,7 @@ package machine
 
 import (
 	goctx "context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -35,7 +36,7 @@ func GetKCPNameByMachine(machine *clusterv1.Machine) string {
 			return o.Name
 		}
 	}
-	return ""
+	panic(fmt.Sprintf("Machine %s is not owned by KubeadmControlPlane", machine.GetName()))
 }
 
 func GetKCPByMachine(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (*controlplanev1.KubeadmControlPlane, error) {

--- a/pkg/util/machine/kcp.go
+++ b/pkg/util/machine/kcp.go
@@ -27,8 +27,8 @@ import (
 )
 
 // GetKCPNameByMachine returns the KCP name associated with the Machine.
-// Can not use "cluster.x-k8s.io/control-plane-name" label because
-// it's value will be a hash string when the KCP name exceeds 63 characters.
+// Do not use "cluster.x-k8s.io/control-plane-name" label because
+// its value will be a hashed string of the KCP name when the KCP name exceeds 63 characters.
 func GetKCPNameByMachine(machine *clusterv1.Machine) string {
 	for _, o := range machine.OwnerReferences {
 		if o.Kind == "KubeadmControlPlane" {

--- a/pkg/util/machine/kcp.go
+++ b/pkg/util/machine/kcp.go
@@ -20,7 +20,6 @@ import (
 	goctx "context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -43,10 +42,6 @@ func GetKCPByMachine(ctx goctx.Context, ctrlClient client.Client, machine *clust
 	var kcp controlplanev1.KubeadmControlPlane
 
 	kcpName := GetKCPNameByMachine(machine)
-	if kcpName == "" {
-		return nil, errors.New("failed to get KCP name by Machine OwnerReferences")
-	}
-
 	if err := ctrlClient.Get(ctx, apitypes.NamespacedName{Namespace: machine.Namespace, Name: kcpName}, &kcp); err != nil {
 		return nil, err
 	}

--- a/pkg/util/machine/kcp_test.go
+++ b/pkg/util/machine/kcp_test.go
@@ -38,8 +38,7 @@ func TestGetKCPByMachine(t *testing.T) {
 	})
 
 	_, workerMachine := fake.NewMachineObjects(elfCluster, cluster)
-	t.Run("should return error", func(t *testing.T) {
-		_, err := GetKCPByMachine(ctx, ctx.Client, workerMachine)
-		g.Expect(err).To(gomega.HaveOccurred())
+	t.Run("should panic when failed to get kcp name", func(t *testing.T) {
+		g.Expect(func() { _, _ = GetKCPByMachine(ctx, ctx.Client, workerMachine) }).To(gomega.Panic())
 	})
 }

--- a/pkg/util/machine/kcp_test.go
+++ b/pkg/util/machine/kcp_test.go
@@ -27,14 +27,19 @@ import (
 func TestGetKCPByMachine(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	elfCluster, cluster := fake.NewClusterObjects()
-	_, machine := fake.NewMachineObjects(elfCluster, cluster)
+	_, cpMachine := fake.NewMachineObjects(elfCluster, cluster)
 	kubeadmCP := fake.NewKCP()
-	fake.ToControlPlaneMachine(machine, kubeadmCP)
+	fake.ToControlPlaneMachine(cpMachine, kubeadmCP)
 	ctx := fake.NewControllerManagerContext(kubeadmCP)
-
 	t.Run("should return kcp", func(t *testing.T) {
-		kcp, err := GetKCPByMachine(ctx, ctx.Client, machine)
+		kcp, err := GetKCPByMachine(ctx, ctx.Client, cpMachine)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(kcp.Name).To(gomega.Equal(kubeadmCP.Name))
+	})
+
+	_, workerMachine := fake.NewMachineObjects(elfCluster, cluster)
+	t.Run("should return error", func(t *testing.T) {
+		_, err := GetKCPByMachine(ctx, ctx.Client, workerMachine)
+		g.Expect(err).To(gomega.HaveOccurred())
 	})
 }

--- a/pkg/util/machine/machine.go
+++ b/pkg/util/machine/machine.go
@@ -104,10 +104,10 @@ func IsControlPlaneMachine(machine metav1.Object) bool {
 }
 
 // GetNodeGroupName returns the name of node group that the machine belongs.
-func GetNodeGroupName(machine metav1.Object) string {
+func GetNodeGroupName(machine *clusterv1.Machine) string {
 	nodeGroupName := ""
 	if IsControlPlaneMachine(machine) {
-		nodeGroupName = labelsutil.GetControlPlaneNameLabel(machine)
+		nodeGroupName = GetKCPNameByMachine(machine)
 	} else {
 		nodeGroupName = labelsutil.GetDeploymentNameLabel(machine)
 	}

--- a/test/fake/types.go
+++ b/test/fake/types.go
@@ -195,11 +195,9 @@ func ToControlPlaneMachine(machine metav1.Object, kcp *controlplanev1.KubeadmCon
 	}
 
 	labels[clusterv1.MachineControlPlaneLabel] = ""
-	if kcp != nil {
-		labels[clusterv1.MachineControlPlaneNameLabel] = kcp.Name
-	}
-
 	machine.SetLabels(labels)
+
+	machine.SetOwnerReferences([]metav1.OwnerReference{*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))})
 }
 
 func ToWorkerMachine(machine metav1.Object, md *clusterv1.MachineDeployment) {


### PR DESCRIPTION
问题
-
[\[SKS-1135\] KCP Name 超过 63 字符时，CAPE reconcile ElfMachine 失败 - Jira](http://jira.smartx.com/browse/SKS-1135)
CAPI 允许 KCP 那么超过 63 字符，此时，对应 Machine 上的 `cluster.x-k8s.io/control-plane-name` label 值会变为 哈希值，比如：
``` yaml
cluster.x-k8s.io/control-plane-name: hash_YkvElA_z
```
CAPE 直接通过该 label 获取 KCP name 会发生错误：
```
E0403 13:28:13.354540       1 elfmachine_controller.go:397] cape-controller-manager/elfmachine-controller "msg"="failed to reconcile VM" "error"="KubeadmControlPlane.controlplane.cluster.x-k8s.io \"hash_YkvElA_z\" not found" "elfCluster"="huaqing-sks-test-lllllllllllllllllllllllllllllllll" "elfMachine"="huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpccbvmh" "namespace"="default"
E0403 13:28:13.355101       1 controller.go:326]  "msg"="Reconciler error" "error"="failed to reconcile VM: KubeadmControlPlane.controlplane.cluster.x-k8s.io \"hash_YkvElA_z\" not found" "ElfMachine"={"name":"huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpccbvmh","namespace":"default"} "controller"="elfmachine" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ElfMachine" "name"="huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpccbvmh" "namespace"="default" "reconcileID"="9581b98e-4f4b-4476-b790-cde41accdba8"
```

解决方案
-
不再使用 label `cluster.x-k8s.io/control-plane-name` 反查 KCP name，改为通过 `Machine.metadata.ownerReferences` 反查。
``` yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Machine
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: huaqing-sks-test-lllllllllllllllllllllllllllllllll
    cluster.x-k8s.io/control-plane: ""
    cluster.x-k8s.io/control-plane-name: hash_YkvElA_z
  name: huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpcf246j
  namespace: default
  ownerReferences:
  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: KubeadmControlPlane
    name: huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcp
    uid: ce9e67e5-a9d9-4c89-bd42-dbb730eb5fb8
  uid: 180edadd-301a-4fb9-a1b9-b5a26d3b8b87
```

测试验证
-
集群名为 `huaqing-sks-test-lllllllllllllllllllllllllllllllll`，CP节点组名为 `cpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcp`，组成的 KCP 名长度为 `85`，集群正常：
```
[root@huaqing-dev0 ~]# k get elfmachine
NAME                                                              READY   PROVIDERID                                   IP             HOST         MACHINE                                                           AGE
huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpccbvmh   true    elf://04203b39-1c54-4c3e-bede-66e78af462fb   10.255.64.58   node20-216   huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpcf246j   3h6m
huaqing-sks-test-lllllllllllllllllllllllllllllllll-workerg9jtp7   true    elf://8760b831-5fd8-43e9-bcb4-9b7d3b5ad34b   10.255.64.57   node20-218   huaqing-sks-test-lllllllllllllllllllllllllllllllll-workergwzz74   3h6m

[root@huaqing-dev0 ~]# k get ma
NAME                                                              CLUSTER                                              NODENAME                                                          PROVIDERID                                   PHASE         AGE     VERSION
huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpcf246j   huaqing-sks-test-lllllllllllllllllllllllllllllllll   huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpccbvmh   elf://04203b39-1c54-4c3e-bede-66e78af462fb   Running       3h17m   v1.24.8
huaqing-sks-test-lllllllllllllllllllllllllllllllll-workergwzz74   huaqing-sks-test-lllllllllllllllllllllllllllllllll   huaqing-sks-test-lllllllllllllllllllllllllllllllll-workerg9jtp7   elf://8760b831-5fd8-43e9-bcb4-9b7d3b5ad34b   Running       3h17m   v1.24.8

[root@huaqing-dev0 ~]# k get kcp
NAME                                                                                    CLUSTER                                              INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
huaqing-sks-test-lllllllllllllllllllllllllllllllll-cpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcpcp   huaqing-sks-test-lllllllllllllllllllllllllllllllll   true          true                   1          1       1         0             3h18m   v1.24.8

[root@huaqing-dev0 ~]# k get ksc
NAME                                                 K8SVERSION   SKSVERSION   STATUS   READY   CONTROLPLANES   WORKERS   AGE     CNI      CSI   CONTROLPLANEVIP
huaqing-sks-test-lllllllllllllllllllllllllllllllll   v1.24.8      v1.1.0       Ready    true    1/1             1/1       3h18m   calico         10.255.64.56:6443
```