### PR TITLE
Add cluster uid to the placement group name to resolve name conflict caused by duplicate cluster

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -717,7 +717,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		case util.IsCloneVMTask(task):
 			releaseTicketForCreateVM(ctx.ElfMachine.Name)
 		case util.IsVMMigrationTask(task):
-			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine)
+			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
 			if err != nil {
 				return false, err
 			}
@@ -737,7 +737,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 			setElfClusterMemoryInsufficient(ctx.ElfCluster.Spec.Cluster, false)
 			releaseTicketForCreateVM(ctx.ElfMachine.Name)
 		case util.IsVMMigrationTask(task):
-			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine)
+			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
 			if err != nil {
 				return false, err
 			}
@@ -769,7 +769,7 @@ func (r *ElfMachineReconciler) reconcilePlacementGroup(ctx *context.MachineConte
 		return false, err
 	}
 
-	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine)
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
 	if err != nil {
 		return false, err
 	}
@@ -952,7 +952,7 @@ func (r *ElfMachineReconciler) getVMHostForRollingUpdate(ctx *context.MachineCon
 		return "", nil
 	}
 
-	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine)
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -29,7 +29,7 @@ import (
 	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
 
-func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine) (string, error) {
+func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machine *clusterv1.Machine, cluster *clusterv1.Cluster) (string, error) {
 	groupName := ""
 	if machineutil.IsControlPlaneMachine(machine) {
 		kcp, err := machineutil.GetKCPByMachine(ctx, ctrlClient, machine)
@@ -61,7 +61,7 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 		return "", nil
 	}
 
-	return fmt.Sprintf("%s-managed-%s-%s", GetResourcePrefix(), machine.Namespace, groupName), nil
+	return fmt.Sprintf("%s-managed-%s-%s-%s", GetResourcePrefix(), cluster.UID, machine.Namespace, groupName), nil
 }
 
 func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {


### PR DESCRIPTION
### SKS-1237

重名集群导致不同集群共享放置组。

### 测试

![image](https://user-images.githubusercontent.com/19967151/232397741-7bf60d3e-a640-4056-98d9-6bb78b7f151a.png)
