### PR TITLE
SKS-1264: Add osType for ElfMachineTemplate to set VM operation system type

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -48,6 +48,12 @@ type ElfMachineSpec struct {
 	// Template is the name or ID of the template used to clone new machines.
 	Template string `json:"template"`
 
+	// OSType is the operation system type of the virtual machine.
+	// +kubebuilder:validation:Enum=LINUX;WINDOWS
+	// +kubebuilder:default=LINUX
+	// +optional
+	OSType string `json:"osType,omitempty"`
+
 	// Network is the network configuration for this machin's VM.
 	// +optional
 	Network NetworkSpec `json:"network,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -165,6 +165,13 @@ spec:
                   to distribute CPUs in this VM.
                 format: int32
                 type: integer
+              osType:
+                default: LINUX
+                description: OSType is the operation system type of the virtual machine.
+                enum:
+                - LINUX
+                - WINDOWS
+                type: string
               providerID:
                 description: ProviderID is the virtual machine's UUID formatted as
                   elf://f0f6f65d-0786-4170-9ab9-d02187a61ad6

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
@@ -150,6 +150,14 @@ spec:
                           which to distribute CPUs in this VM.
                         format: int32
                         type: integer
+                      osType:
+                        default: LINUX
+                        description: OSType is the operation system type of the virtual
+                          machine.
+                        enum:
+                        - LINUX
+                        - WINDOWS
+                        type: string
                       providerID:
                         description: ProviderID is the virtual machine's UUID formatted
                           as elf://f0f6f65d-0786-4170-9ab9-d02187a61ad6

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -222,6 +222,7 @@ func (svr *TowerVMService) Clone(
 		Ha:          util.TowerBool(elfMachine.Spec.HA),
 		IsFullCopy:  util.TowerBool(isFullCopy),
 		TemplateID:  template.ID,
+		GuestOsType: models.NewVMGuestsOperationSystem(models.VMGuestsOperationSystem(elfMachine.Spec.OSType)),
 		VMNics:      nics,
 		DiskOperate: &models.VMDiskOperate{
 			NewDisks: &models.VMDiskParams{


### PR DESCRIPTION
### 支持指定虚拟机操作系统类型

当前 Tower 和 ELF 不会自动设置虚拟机的 GuestOsType，需要在创建虚拟机的时候指定。

为 ElfMachineSpec 新增 OSType 字段描述 GuestOsType，Tower 目前只支持 LINUX 和 WINDOWS。LINUX 为默认值，这样已有的逻辑不需要修改。


### 测试
![image (5)](https://user-images.githubusercontent.com/19967151/233553135-3d47c300-8607-44cf-807d-aafea3214851.png)
![image (4)](https://user-images.githubusercontent.com/19967151/233553140-70e91aca-1ffb-4fe4-96ff-46e7306e5794.png)

需要注意：目前如果创建的虚拟机是 LINUX 系统，但是填写了 WINDOWS，会被自动改成 LINUX。暂未找到原因，不过不影响 CAPE 当前的需求。
