### PR TITLE
SKS-1273: Delete all related placement groups when deleting a cluster

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -241,7 +241,7 @@ func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.Clu
 
 	withLatestStatusTask, err := ctx.VMService.WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement groups %s deletion task %s done timed out in %s", placementGroupPrefix, *task.ID, config.WaitTaskTimeout)
+		return errors.Wrapf(err, "failed to wait for placement groups deletion task done in %s: namePrefix %s, taskID %s", config.WaitTaskTimeout, placementGroupPrefix, *task.ID)
 	}
 
 	if *withLatestStatusTask.Status == models.TaskStatusFAILED {

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -216,37 +216,37 @@ var _ = Describe("ElfClusterReconciler", func() {
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, errors.New("some error"))
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, errors.New("some error"))
 
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("some error"))
 
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
-			Expect(result).NotTo(BeZero())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Wait for placement groups %s deletion task done timed out", towerresources.GetVMPlacementGroupClusterName(cluster))))
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement groups %s deletion task %s done timed out in %s", towerresources.GetVMPlacementGroupNamePrefix(cluster), *task.ID, config.WaitTaskTimeout)))
 
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
 			withLatestStatusTask := fake.NewTowerTask()
 			*withLatestStatusTask.ID = *task.ID
 			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusFAILED)
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
 
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to delete placement groups %s in task", towerresources.GetVMPlacementGroupClusterName(cluster))))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to delete placement groups %s in task", towerresources.GetVMPlacementGroupNamePrefix(cluster))))
 
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
 			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, false).Return("labelid", nil)
@@ -256,7 +256,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Placement groups %s deleted", towerresources.GetVMPlacementGroupClusterName(cluster))))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Placement groups %s deleted", towerresources.GetVMPlacementGroupNamePrefix(cluster))))
 			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", towerresources.GetVMLabelClusterName(), elfCluster.Name)))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
@@ -203,6 +205,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 		})
 
 		It("should delete labels and remove elfcluster finalizer", func() {
+			task := fake.NewTowerTask()
 			ctrlMgrContext := fake.NewControllerManagerContext(cluster, elfCluster)
 			ctrlContext := &context.ControllerContext{
 				ControllerManagerContext: ctrlMgrContext,
@@ -210,17 +213,50 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(fmt.Sprintf("%s-managed-%s-%s", towerresources.GetResourcePrefix(), cluster.Namespace, cluster.Name)).Return(nil, nil)
+			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			elfClusterKey := capiutil.ObjectKey(elfCluster)
+
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, errors.New("some error"))
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("some error"))
+
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
+			Expect(result).NotTo(BeZero())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Wait for placement groups %s deletion task done timed out", towerresources.GetVMPlacementGroupClusterName(cluster))))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			withLatestStatusTask := fake.NewTowerTask()
+			*withLatestStatusTask.ID = *task.ID
+			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusFAILED)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
+
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to delete placement groups %s in task", towerresources.GetVMPlacementGroupClusterName(cluster))))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupClusterName(cluster)).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, false).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelManaged(), "true", true).Return("", nil)
 
-			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			elfClusterKey := capiutil.ObjectKey(elfCluster)
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Placement groups %s deleted", towerresources.GetVMPlacementGroupClusterName(cluster))))
 			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", towerresources.GetVMLabelClusterName(), elfCluster.Name)))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -228,7 +228,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement groups %s deletion task %s done timed out in %s", towerresources.GetVMPlacementGroupNamePrefix(cluster), *task.ID, config.WaitTaskTimeout)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement groups deletion task done in %s: namePrefix %s, taskID %s", config.WaitTaskTimeout, towerresources.GetVMPlacementGroupNamePrefix(cluster), *task.ID)))
 
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -890,7 +890,7 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 
 	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to wait for placement group %s creation task %s done timed out in %s", placementGroupName, *withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout)
+		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {
@@ -916,7 +916,7 @@ func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContex
 	taskID := *task.ID
 	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group %s updation task %s done timed out in %s", *placementGroup.Name, taskID, config.WaitTaskTimeout)
+		return errors.Wrapf(err, "failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, taskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -653,8 +653,8 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
 			Expect(pg).To(BeNil())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("Wait for placement group creation task done timed out"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group %s creation task %s done timed out in %s", *placementGroup.Name, *withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout)))
 		})
 
 		It("addVMsToPlacementGroup", func() {
@@ -675,8 +675,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			ok, err := reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
-			Expect(ok).To(BeTrue())
+			err := reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(err).To(BeZero())
 			Expect(logBuffer.String()).To(ContainSubstring("Updating placement group succeeded"))
 
@@ -688,8 +687,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			ok, err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
-			Expect(ok).To(BeFalse())
+			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(strings.Contains(err.Error(), "failed to update placement group")).To(BeTrue())
 
 			logBuffer = new(bytes.Buffer)
@@ -698,10 +696,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			ok, err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
-			Expect(ok).To(BeFalse())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("Wait for placement group updation task done timed out"))
+			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group %s updation task %s done timed out in %s", *placementGroup.Name, *task.ID, config.WaitTaskTimeout)))
 		})
 
 		It("should wait for placement group task done", func() {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -654,7 +654,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
 			Expect(pg).To(BeNil())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group %s creation task %s done timed out in %s", *placementGroup.Name, *withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, *withTaskVMPlacementGroup.TaskID)))
 		})
 
 		It("addVMsToPlacementGroup", func() {
@@ -698,7 +698,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group %s updation task %s done timed out in %s", *placementGroup.Name, *task.ID, config.WaitTaskTimeout)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, *task.ID)))
 		})
 
 		It("should wait for placement group task done", func() {

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -61,7 +61,11 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 		return "", nil
 	}
 
-	return fmt.Sprintf("%s-managed-%s-%s-%s", GetResourcePrefix(), cluster.UID, machine.Namespace, groupName), nil
+	return fmt.Sprintf("%s-%s", GetVMPlacementGroupClusterName(cluster), groupName), nil
+}
+
+func GetVMPlacementGroupClusterName(cluster *clusterv1.Cluster) string {
+	return fmt.Sprintf("%s-managed-%s-%s", GetResourcePrefix(), cluster.UID, cluster.Namespace)
 }
 
 func GetVMPlacementGroupPolicy(machine *clusterv1.Machine) models.VMVMPolicy {

--- a/pkg/resources/placement_group.go
+++ b/pkg/resources/placement_group.go
@@ -61,10 +61,10 @@ func GetVMPlacementGroupName(ctx goctx.Context, ctrlClient client.Client, machin
 		return "", nil
 	}
 
-	return fmt.Sprintf("%s-%s", GetVMPlacementGroupClusterName(cluster), groupName), nil
+	return fmt.Sprintf("%s-%s", GetVMPlacementGroupNamePrefix(cluster), groupName), nil
 }
 
-func GetVMPlacementGroupClusterName(cluster *clusterv1.Cluster) string {
+func GetVMPlacementGroupNamePrefix(cluster *clusterv1.Cluster) string {
 	return fmt.Sprintf("%s-managed-%s-%s", GetResourcePrefix(), cluster.UID, cluster.Namespace)
 }
 


### PR DESCRIPTION
### 问题
[[SKS-1273] 改进：删除集群的时候应该确保删除相关放置组 - Jira](http://jira.smartx.com/browse/SKS-1273)

删除放置组是一个异步的 task（正常秒级别完成，参考创建放置组）。为了保证删除放置组的可靠性，改成异步等待放置组任务完成。

### 测试

1.创建 1CP + 1Worker 集群，观察到创建了两个放置组
![image (7)](https://user-images.githubusercontent.com/19967151/233580980-db762e0d-6dad-465e-80d9-ef97b2ec1c1b.png)

2.删除集群后，观察到放置组已经被删除
![image (8)](https://user-images.githubusercontent.com/19967151/233581027-b0426a53-c78e-4184-bf47-c60b86fb7031.png)
