### PR TITLE
[WIP] Optimize node feedback

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1050,6 +1050,12 @@ func (r *ElfMachineReconciler) reconcileNode(ctx *context.MachineContext, vm *mo
 
 	node, err := kubeClient.CoreV1().Nodes().Get(ctx, ctx.ElfMachine.Name, metav1.GetOptions{})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Logger.Info("Node not found, skip setting providerID and labels")
+
+			return false, nil
+		}
+
 		return false, errors.Wrapf(err, "failed to get node %s for setting providerID and labels", ctx.ElfMachine.Name)
 	}
 


### PR DESCRIPTION
### 优化 Node 节点部署失败相关（讨论是否需要优化）

背景：https://smartx1.slack.com/archives/C037V8QMKQA/p1682471305655029

当前 CAPE 需要在节点部署成功后设置 providerID 和相关标签。如果节点部署时候，CAPE 会获取不到该节点，导致无法设值。并一直重试报错。

![image](https://user-images.githubusercontent.com/19967151/234788478-5b0ada73-f358-4732-ba0f-b179bc770dc6.png)

节点部署状态大概可以分这些情况：

1. 节点部署失败
- 1.1 没有 MHC：会一直尝试获取该节点，KSC 操作超时后会收集到该节点部署失败
- 1.2 配置了 MHC：在节点被替换之前会一直尝试获取该节点

2. 节点部署成功
- 2.1 集群不可访问：集群故障或网络原因，无法获取节点
- 2.2 节点被移除了(包括直接移除节点或者虚拟机)：CAPE 和 CAPI 会自动检测到，并设置 failure，之后 SKS 的错误信息收集机制会收集到 FailureMessage
- 2.2.1 没有 MHC：用户会看到 KSC failed 和节点丢失的信息
- 2.2.2  配置了 MHC：节点自动替换

问题：
- 是否需要设置最大的节点创建超时时间，超过该时间如果节点没有部署成功就不再执行某些逻辑，例如不再执行 reconcileNode？减少一些不必要的日志和错误信息。
- 是否需要设置创建节点超时的 FailureMessage？涉及 KSC 错误收集

