### PR TITLE
SKS-1353: Delete the placement group when the MachineDeployment is deleted

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -234,7 +234,7 @@ func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.Clu
 	if err := ctx.VMService.DeleteVMPlacementGroupsByName(placementGroupPrefix); err != nil {
 		return err
 	} else {
-		ctx.Logger.Info(fmt.Sprintf("Placement groups %s deleted", placementGroupPrefix))
+		ctx.Logger.Info(fmt.Sprintf("Placement groups with name prefix %s deleted", placementGroupPrefix))
 	}
 
 	return nil

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -232,23 +231,12 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 
 func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.ClusterContext) error {
 	placementGroupPrefix := towerresources.GetVMPlacementGroupNamePrefix(ctx.Cluster)
-	task, err := ctx.VMService.DeleteVMPlacementGroupsByName(placementGroupPrefix)
+	task, err := ctx.VMService.SynchDeleteVMPlacementGroupsByName(placementGroupPrefix)
 	if err != nil {
 		return err
-	} else if task == nil {
-		return nil
+	} else if task != nil {
+		ctx.Logger.Info(fmt.Sprintf("Placement groups %s deleted", placementGroupPrefix), "taskID", *task.ID)
 	}
-
-	withLatestStatusTask, err := ctx.VMService.WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval)
-	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement groups deletion task done in %s: namePrefix %s, taskID %s", config.WaitTaskTimeout, placementGroupPrefix, *task.ID)
-	}
-
-	if *withLatestStatusTask.Status == models.TaskStatusFAILED {
-		return errors.Errorf("failed to delete placement groups %s in task %s", placementGroupPrefix, *withLatestStatusTask.ID)
-	}
-
-	ctx.Logger.Info(fmt.Sprintf("Placement groups %s deleted", placementGroupPrefix), "taskID", *withLatestStatusTask.ID)
 
 	return nil
 }

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -231,11 +231,10 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 
 func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.ClusterContext) error {
 	placementGroupPrefix := towerresources.GetVMPlacementGroupNamePrefix(ctx.Cluster)
-	task, err := ctx.VMService.SynchDeleteVMPlacementGroupsByName(placementGroupPrefix)
-	if err != nil {
+	if err := ctx.VMService.DeleteVMPlacementGroupsByName(placementGroupPrefix); err != nil {
 		return err
-	} else if task != nil {
-		ctx.Logger.Info(fmt.Sprintf("Placement groups %s deleted", placementGroupPrefix), "taskID", *task.ID)
+	} else {
+		ctx.Logger.Info(fmt.Sprintf("Placement groups %s deleted", placementGroupPrefix))
 	}
 
 	return nil

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -215,7 +215,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 
-			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, errors.New("some error"))
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(errors.New("some error"))
 
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
@@ -224,7 +224,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
 			task.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
-			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, false).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -233,7 +233,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Placement groups %s deleted", towerresources.GetVMPlacementGroupNamePrefix(cluster))))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Placement groups with name prefix %s deleted", towerresources.GetVMPlacementGroupNamePrefix(cluster))))
 			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Label %s:%s deleted", towerresources.GetVMLabelClusterName(), elfCluster.Name)))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
 		})

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -40,7 +40,6 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
@@ -216,38 +215,16 @@ var _ = Describe("ElfClusterReconciler", func() {
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, errors.New("some error"))
+			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, errors.New("some error"))
 
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
 
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("some error"))
-
-			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
-			Expect(result).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement groups deletion task done in %s: namePrefix %s, taskID %s", config.WaitTaskTimeout, towerresources.GetVMPlacementGroupNamePrefix(cluster), *task.ID)))
-
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
-			withLatestStatusTask := fake.NewTowerTask()
-			*withLatestStatusTask.ID = *task.ID
-			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusFAILED)
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
-
-			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
-			Expect(result).To(BeZero())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to delete placement groups %s in task", towerresources.GetVMPlacementGroupNamePrefix(cluster))))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			withLatestStatusTask.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
-			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(withLatestStatusTask, nil)
+			task.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
+			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(towerresources.GetVMPlacementGroupNamePrefix(cluster)).Return(task, nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelClusterName(), elfCluster.Name, true).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelVIP(), elfCluster.Spec.ControlPlaneEndpoint.Host, false).Return("labelid", nil)
 			mockVMService.EXPECT().DeleteLabel(towerresources.GetVMLabelNamespace(), elfCluster.Namespace, true).Return("", nil)

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -912,8 +912,8 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 
 // deletePlacementGroup deletes the placement group when the MachineDeployment is deleted
 // and the cluster is not deleted.
+// If the cluster is deleted, all placement groups are deleted by the ElfCluster controller.
 func (r *ElfMachineReconciler) deletePlacementGroup(ctx *context.MachineContext) (bool, error) {
-	// If the cluster is deleted, all placement groups are deleted by the ElfCluster controller.
 	if !ctx.Cluster.DeletionTimestamp.IsZero() || machineutil.IsControlPlaneMachine(ctx.Machine) {
 		return true, nil
 	}

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1494,13 +1494,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			machineContext = newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			machineContext.VMService = mockVMService
-			task := fake.NewTowerTask()
 			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			placementGroup := fake.NewVMPlacementGroup([]string{})
 			placementGroup.Name = util.TowerString(placementGroupName)
 			mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
-			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(placementGroupName).Return(task, nil)
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(placementGroupName).Return(nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			ok, err = reconciler.deletePlacementGroup(machineContext)
@@ -1522,7 +1521,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).To(HaveOccurred())
 
 			mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
-			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(placementGroupName).Return(task, errors.New("error"))
+			mockVMService.EXPECT().DeleteVMPlacementGroupsByName(placementGroupName).Return(errors.New("error"))
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			ok, err = reconciler.deletePlacementGroup(machineContext)
 			Expect(ok).To(BeFalse())

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1449,6 +1449,85 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletingReason}})
 		})
+
+		It("should delete placement group when the deployment is deleted", func() {
+			cluster.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			machineContext.VMService = mockVMService
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err := reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster.DeletionTimestamp = nil
+			fake.ToControlPlaneMachine(machine, kcp)
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			fake.ToWorkerMachine(machine, md)
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			machineContext = newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			md.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			machineContext = newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			machineContext.VMService = mockVMService
+			task := fake.NewTowerTask()
+			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			placementGroup := fake.NewVMPlacementGroup([]string{})
+			placementGroup.Name = util.TowerString(placementGroupName)
+			mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(placementGroupName).Return(task, nil)
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			md.DeletionTimestamp = nil
+			md.Spec.Replicas = pointer.Int32(0)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New("error"))
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+
+			mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+			mockVMService.EXPECT().SynchDeleteVMPlacementGroupsByName(placementGroupName).Return(task, errors.New("error"))
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			ok, err = reconciler.deletePlacementGroup(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Context("Reconcile static IP allocation", func() {

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -352,6 +352,21 @@ func (mr *MockVMServiceMockRecorder) ShutDown(uuid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutDown", reflect.TypeOf((*MockVMService)(nil).ShutDown), uuid)
 }
 
+// SynchDeleteVMPlacementGroupsByName mocks base method.
+func (m *MockVMService) SynchDeleteVMPlacementGroupsByName(placementGroupName string) (*models.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SynchDeleteVMPlacementGroupsByName", placementGroupName)
+	ret0, _ := ret[0].(*models.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SynchDeleteVMPlacementGroupsByName indicates an expected call of SynchDeleteVMPlacementGroupsByName.
+func (mr *MockVMServiceMockRecorder) SynchDeleteVMPlacementGroupsByName(placementGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchDeleteVMPlacementGroupsByName", reflect.TypeOf((*MockVMService)(nil).SynchDeleteVMPlacementGroupsByName), placementGroupName)
+}
+
 // UpsertLabel mocks base method.
 func (m *MockVMService) UpsertLabel(key, value string) (*models.Label, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -128,12 +128,11 @@ func (mr *MockVMServiceMockRecorder) DeleteLabel(key, value, strict interface{})
 }
 
 // DeleteVMPlacementGroupsByName mocks base method.
-func (m *MockVMService) DeleteVMPlacementGroupsByName(placementGroupName string) (*models.Task, error) {
+func (m *MockVMService) DeleteVMPlacementGroupsByName(placementGroupName string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVMPlacementGroupsByName", placementGroupName)
-	ret0, _ := ret[0].(*models.Task)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // DeleteVMPlacementGroupsByName indicates an expected call of DeleteVMPlacementGroupsByName.
@@ -350,21 +349,6 @@ func (m *MockVMService) ShutDown(uuid string) (*models.Task, error) {
 func (mr *MockVMServiceMockRecorder) ShutDown(uuid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutDown", reflect.TypeOf((*MockVMService)(nil).ShutDown), uuid)
-}
-
-// SynchDeleteVMPlacementGroupsByName mocks base method.
-func (m *MockVMService) SynchDeleteVMPlacementGroupsByName(placementGroupName string) (*models.Task, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SynchDeleteVMPlacementGroupsByName", placementGroupName)
-	ret0, _ := ret[0].(*models.Task)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SynchDeleteVMPlacementGroupsByName indicates an expected call of SynchDeleteVMPlacementGroupsByName.
-func (mr *MockVMServiceMockRecorder) SynchDeleteVMPlacementGroupsByName(placementGroupName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchDeleteVMPlacementGroupsByName", reflect.TypeOf((*MockVMService)(nil).SynchDeleteVMPlacementGroupsByName), placementGroupName)
 }
 
 // UpsertLabel mocks base method.

--- a/test/fake/types.go
+++ b/test/fake/types.go
@@ -152,7 +152,7 @@ func NewMD() *clusterv1.MachineDeployment {
 			Name:      names.SimpleNameGenerator.GenerateName("md-"),
 			Namespace: Namespace,
 		},
-		Spec:   clusterv1.MachineDeploymentSpec{},
+		Spec:   clusterv1.MachineDeploymentSpec{Replicas: pointer.Int32(1)},
 		Status: clusterv1.MachineDeploymentStatus{},
 	}
 }
@@ -210,6 +210,7 @@ func ToWorkerMachine(machine metav1.Object, md *clusterv1.MachineDeployment) {
 	if md != nil {
 		labels[clusterv1.MachineDeploymentNameLabel] = md.Name
 	}
+	delete(labels, clusterv1.MachineControlPlaneLabel)
 
 	machine.SetLabels(labels)
 }


### PR DESCRIPTION
### 问题
MD 被删除的时候关联的放置组需要被删除

### 方案
删除 ElfMachine 前，判断关联的 MD 是否被删除，如果 MD 被删除，先删除关联的放置组再删除 ElfMachine。

SKS 删除 MD 的时候会先缩容为 0 再删除 MD。判断 MD 被删除的条件为：MD 有 DeletionTimestamp 值，或者  *md.Spec.Replicas == 0

### 测试

1.创建包含两个工作节点组的集群：workergroup1、workergroup2
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/e6b08c36-8951-4ec8-9432-97a77c57170d)

2.删除节点组 workergroup2，相关的放置组也被删除
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/881ae7df-4dd4-4364-9703-3066d79ee954)

![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/3a603cf1-d033-4c13-b140-f3031bd11d39)

