### PR TITLE
SKS-581: Best effort to delete k8s node before destrying VM

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -275,6 +275,12 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 		return nil
 	}
 
+	// Before destroying VM, attempt to delete kubernetes node.
+	err = r.deleteNode(ctx, *vm.Name)
+	if err != nil {
+		ctx.Logger.V(4).Info("failed to delete node", "elfMachine", *vm.Name, "err", err)
+	}
+
 	ctx.Logger.Info("Destroying VM",
 		"vmRef", ctx.ElfMachine.Status.VMRef, "taskRef", ctx.ElfMachine.Status.TaskRef)
 
@@ -1445,4 +1451,33 @@ func (r *ElfMachineReconciler) isWaitingForStaticIPAllocation(ctx *context.Machi
 	}
 
 	return false
+}
+
+// deleteNode attempts to delete the node corresponding to the VM.
+// This is necessary since CAPI does not set the nodeRef field on the owner Machine object
+// until the node moves to Ready state. Hence, on Machine deletion it is unable to delete
+// the kubernetes node corresponding to the VM.
+func (r *ElfMachineReconciler) deleteNode(ctx *context.MachineContext, nodeName string) error {
+	// When the cluster needs to be deleted, there is no need to delete the k8s node.
+	if ctx.Cluster.DeletionTimestamp != nil {
+		return nil
+	}
+
+	kubeClient, err := util.NewKubeClient(ctx, ctx.Client, ctx.Cluster)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get client for Cluster %s/%s", ctx.Cluster.Namespace, ctx.Cluster.Name)
+	}
+
+	// Attempt to delete the corresponding node.
+	err = kubeClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	// k8s node is already deleted.
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete node %s for Cluster %s/%s", nodeName, ctx.Cluster.Namespace, ctx.Cluster.Name)
+	}
+
+	return nil
 }

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -278,7 +278,7 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 	// Before destroying VM, attempt to delete kubernetes node.
 	err = r.deleteNode(ctx, ctx.ElfMachine.Name)
 	if err != nil {
-		ctx.Logger.Error(err, "")
+		return err
 	}
 
 	ctx.Logger.Info("Destroying VM",
@@ -1460,6 +1460,11 @@ func (r *ElfMachineReconciler) isWaitingForStaticIPAllocation(ctx *context.Machi
 func (r *ElfMachineReconciler) deleteNode(ctx *context.MachineContext, nodeName string) error {
 	// When the cluster needs to be deleted, there is no need to delete the k8s node.
 	if ctx.Cluster.DeletionTimestamp != nil {
+		return nil
+	}
+
+	// when the control plane is not ready, there is no need to delete the k8s node.
+	if !ctx.Cluster.Status.ControlPlaneReady {
 		return nil
 	}
 

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -278,7 +278,7 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 	// Before destroying VM, attempt to delete kubernetes node.
 	err = r.deleteNode(ctx, ctx.ElfMachine.Name)
 	if err != nil {
-		ctx.Logger.V(4).Info("failed to delete node", "err", err)
+		ctx.Logger.Error(err, "")
 	}
 
 	ctx.Logger.Info("Destroying VM",
@@ -1476,7 +1476,7 @@ func (r *ElfMachineReconciler) deleteNode(ctx *context.MachineContext, nodeName 
 	}
 
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete node %s for Cluster %s/%s", nodeName, ctx.Cluster.Namespace, ctx.Cluster.Name)
+		return errors.Wrapf(err, "failed to delete K8s node %s for Cluster %s/%s", nodeName, ctx.Cluster.Namespace, ctx.Cluster.Name)
 	}
 
 	return nil

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -276,9 +276,9 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx *context.MachineContext) er
 	}
 
 	// Before destroying VM, attempt to delete kubernetes node.
-	err = r.deleteNode(ctx, *vm.Name)
+	err = r.deleteNode(ctx, ctx.ElfMachine.Name)
 	if err != nil {
-		ctx.Logger.V(4).Info("failed to delete node", "elfMachine", *vm.Name, "err", err)
+		ctx.Logger.V(4).Info("failed to delete node", "err", err)
 	}
 
 	ctx.Logger.Info("Destroying VM",

--- a/test/helpers/cluster.go
+++ b/test/helpers/cluster.go
@@ -55,3 +55,21 @@ func GetKubeConfigSecret(testEnv *TestEnvironment, namespace, clusterName string
 	}
 	return &secret, nil
 }
+
+// DeleteKubeConfigSecret delete the workload cluster kubeconfig secret.
+func DeleteKubeConfigSecret(testEnv *TestEnvironment, namespace, clusterName string) error {
+	deleteSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      capisecret.Name(clusterName, capisecret.Kubeconfig),
+		},
+	}
+
+	if err := testEnv.Delete(goctx.Background(), deleteSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to delete kubeconfig secret %s/%s", deleteSecret.Namespace, deleteSecret.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
## 问题

[SKS-581] 优化升级3CP+3Worker集群的时间 - Jira http://jira.smartx.com/browse/SKS-581

## 根因

问题分析文档： https://docs.google.com/document/d/1EZYfWDe_y-XqBoMyBgHiXMRa7sTwSfZy3-5QtfnDltk/edit#

该PR为修复Pod驱逐成功后，Pod仍然存在，致使Machine缩容过慢的问题。

## 修复
仿照这个CAPV 在CAPE中在删除Machine之前保证删除K8s Node [🐛 Delete node explicitly upon deletion of vm by aartij17 · Pull Request #1551 · kubernetes-sigs/cluster-api-provider-vsphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1551)

## 测试

### 正常Machine删除

强制关机VM
<img width="1326" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/cdeffad3-3935-4d36-ac04-df8980f690ee">


node删除完成
<img width="677" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/c1930142-13bf-4c14-a896-42a1e1f263f4">


之后开始删除VM

<img width="1347" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/a6c48eca-3141-4f92-a418-bfdbfc865cf8">

CAPI日志
06:04:04.573725 开始删除ELFMachine
06:04:35.451257  k8s节点已经找不到，表明已经被CAPE删除
06:04:35.463335 还在等待ELFMachine删除完成

表明，k8s节点在ELFMachine删除时就已经被CAPE删除
```
I0606 06:04:04.573725       1 machine_controller.go:645] "Drain successful" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=c55f1875-d6ee-4ea6-854a-cd07d47ea1ed MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="hw-sks-test-1.24.13-03-workergroup-v7fhv"
I0606 06:04:04.682939       1 machine_controller.go:413] "Waiting for infrastructure to be deleted" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=c55f1875-d6ee-4ea6-854a-cd07d47ea1ed MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" ElfMachine="default/hw-sks-test-1.24.13-03-workergroup-v7fhv"


I0606 06:04:35.382246       1 machine_controller.go:413] "Waiting for infrastructure to be deleted" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=ba25e56c-4e1a-47cc-937e-907c3a9d9503 MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" ElfMachine="default/hw-sks-test-1.24.13-03-workergroup-v7fhv"
I0606 06:04:35.392853       1 machine_controller.go:340] "Draining node" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=753f0b88-c2dc-4a65-ba35-ab570294477a MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="hw-sks-test-1.24.13-03-workergroup-v7fhv"
E0606 06:04:35.451257       1 machine_controller.go:598] "Could not find node from noderef, it may have already been deleted" err="nodes \"hw-sks-test-1.24.13-03-workergroup-v7fhv\" not found" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=753f0b88-c2dc-4a65-ba35-ab570294477a MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="hw-sks-test-1.24.13-03-workergroup-v7fhv"
E0606 06:04:35.451556       1 machine_controller.go:665] "Could not find node from noderef, it may have already been deleted" err="Node \"hw-sks-test-1.24.13-03-workergroup-v7fhv\" not found" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=753f0b88-c2dc-4a65-ba35-ab570294477a MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="hw-sks-test-1.24.13-03-workergroup-v7fhv"
I0606 06:04:35.463335       1 machine_controller.go:413] "Waiting for infrastructure to be deleted" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s-g2dmc" reconcileID=753f0b88-c2dc-4a65-ba35-ab570294477a MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xsqp4s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" ElfMachine="default/hw-sks-test-1.24.13-03-workergroup-v7fhv"
```



### k8s node not ready场景下删除Machine

创建1+3集群

<img width="710" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/1bfa9536-0152-4b5a-84dc-b394fb674d80">


在worker节点未ready情况下删除Machine

<img width="946" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/5da01b0d-37cc-4f17-9f3b-0b57a50be1cf">

k8s node被CAPE删除

<img width="733" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/31f9a2d9-f36a-4b74-ada1-080a2cc6df6c">


CAPI 没有执行delete k8s node，因为k8s node还没有ready
```
I0606 06:29:50.126655       1 machine_controller.go:318] "Deleting Kubernetes Node associated with Machine is not allowed" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" reconcileID=68d32253-eaa1-43fc-88bc-c698b5eaf3c0 MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="" cause="noderef is nil"
I0606 06:29:50.143038       1 machine_controller.go:422] "Waiting for bootstrap to be deleted" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" reconcileID=68d32253-eaa1-43fc-88bc-c698b5eaf3c0 MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" KubeadmConfig="default/hw-sks-test-1.24.13-03-workergroup-9qpf7"
I0606 06:29:50.194251       1 machine_controller.go:318] "Deleting Kubernetes Node associated with Machine is not allowed" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" reconcileID=a9ba4977-404a-4ab2-8ed0-3fe43eb10f93 MachineSet="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s" MachineDeployment="default/hw-sks-test-1.24.13-03-workergroup" Cluster="default/hw-sks-test-1.24.13-03" Node="" cause="noderef is nil"
E0606 06:29:50.276835       1 controller.go:329] "Reconciler error" err="machines.cluster.x-k8s.io \"hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk\" not found" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="default/hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" namespace="default" name="hw-sks-test-1.24.13-03-workergroup-797f95db85xn988s-krrpk" reconcileID=a9ba4977-404a-4ab2-8ed0-3fe43eb10f93
```


### 正常删除KSC集群

创建1+3集群

<img width="863" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/a9640db0-b7bc-4023-a7c5-0bf851369110">

删除集群

<img width="866" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/2126da3a-2a50-4665-9b89-71840f5764fd">

期间不会删除k8s节点

<img width="861" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/745910e4-2e0a-4e2e-b032-6a4cb2312add">


### 1+3集群 CP Machine删除

创建1+3集群

<img width="774" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/c2064e53-ab6c-48bb-b9f1-9da29bbd6948">

删除CP Machine 

<img width="727" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/5d3ecab3-87e1-4213-842c-3653e4713233">

删除k8s节点失败，但是并不影响VM删除

```
I0606 07:04:29.591846       1 elfmachine_controller.go:281] cape-controller-manager/elfmachine-controller "msg"="failed to delete node" "elfCluster"="hw-sks-test-1.24.13-03" "elfMachine"="hw-sks-test-1.24.13-03-controlplane-c8nr7" "err"="failed to delete node hw-sks-test-1.24.13-03-controlplane-c8nr7 for Cluster default/hw-sks-test-1.24.13-03: Delete \"https://10.255.26.33:6443/api/v1/nodes/hw-sks-test-1.24.13-03-controlplane-c8nr7?timeout=10s\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)" "namespace"="default"
```

<img width="1407" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/4cd156ec-5d08-4a5f-a571-172fadb5e5a2">


### 升级 3+3 KSC集群 CP节点

升级CP节点

```
  operation:
    startTime: "2023-06-06T16:43:32Z"
    timeout: 39m0s
    type: Update

```

升级CP节点完成

```
  conditions:
  - lastTransitionTime: "2023-06-06T16:56:57Z"
    status: "True"
    type: ControlPlaneRollingUpdated
```


