### PR TITLE
Bump CAPI to v1.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.2
-	sigs.k8s.io/cluster-api/test v1.4.2
+	sigs.k8s.io/cluster-api v1.4.3
+	sigs.k8s.io/cluster-api/test v1.4.3
 	sigs.k8s.io/controller-runtime v0.14.6
 )
 
@@ -54,7 +54,7 @@ require (
 	github.com/coredns/caddy v1.1.0 // indirect
 	github.com/coredns/corefile-migration v1.0.20 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPaAiuPgIfVyI3dYE=
 github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -1158,10 +1158,10 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.2 h1:hdIz0Ms2j7YaU1qBK5yF2R8ii0GcGb3jQ7EO6i3tAN8=
-sigs.k8s.io/cluster-api v1.4.2/go.mod h1:IIebZTsqyXU8CHbINV2zuMh0/wykqdr+vEXxQNeteEU=
-sigs.k8s.io/cluster-api/test v1.4.2 h1:uHFtn0SFOFOxIbdahLoYo4kz84yLqCmhbVLV4vsk1gQ=
-sigs.k8s.io/cluster-api/test v1.4.2/go.mod h1:/64ycj3YFMW1BGVtCtfwmlVAXGN0DFTZEkIClh68Svo=
+sigs.k8s.io/cluster-api v1.4.3 h1:QSeKr3qnWPtVp+EMQZQduKoi5WDwUhAtBRreEukkcy0=
+sigs.k8s.io/cluster-api v1.4.3/go.mod h1:/SeFds4NXJ+Gp2etqHyoNuO6yoxTfVq6Zmd2OGxd/qM=
+sigs.k8s.io/cluster-api/test v1.4.3 h1:xXhvOLp5zBKn2Yf4PQckFwxGxFrKgkgUI74ikU5Jh/c=
+sigs.k8s.io/cluster-api/test v1.4.3/go.mod h1:xGTJsJkbXMNmumhErEAH/e7GmnE2sGfm/rcOzJZSdbw=
 sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92KcwQA=
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -27,7 +27,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.19.2
+k8s_version=1.27.1
 goarch=amd64
 goos="unknown"
 

--- a/test/e2e/config/elf-dev.yaml
+++ b/test/e2e/config/elf-dev.yaml
@@ -11,27 +11,27 @@
 # - from the CAPE repository root, `make test-e2e` to build the elf provider image and run e2e tests.
 
 images:
-  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.4.2
+  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.4.3
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.4.2
+  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.4.3
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.4.2
+  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.4.3
     loadBehavior: tryLoad
   - name: k8s.gcr.io/smartxworks/cape-manager:e2e
     loadBehavior: mustLoad
-  - name: quay.io/jetstack/cert-manager-cainjector:v1.11.1
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.12.1
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v1.11.1
+  - name: quay.io/jetstack/cert-manager-webhook:v1.12.1
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v1.11.1
+  - name: quay.io/jetstack/cert-manager-controller:v1.12.1
     loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-    - name: v1.4.2 # Use manifest from source files
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.2/core-components.yaml"
+    - name: v1.4.3 # Use manifest from source files
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.3/core-components.yaml"
       type: "url"
       contract: v1beta1
       files:
@@ -45,8 +45,8 @@ providers:
   files:
   - sourcePath: "../data/capi/metadata.yaml"
   versions:
-  - name: v1.4.2 # Use manifest from source files
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.2/bootstrap-components.yaml"
+  - name: v1.4.3 # Use manifest from source files
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.3/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -60,8 +60,8 @@ providers:
   files:
   - sourcePath: "../data/capi/metadata.yaml"
   versions:
-  - name: v1.4.2 # Use manifest from source files
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.2/control-plane-components.yaml"
+  - name: v1.4.3 # Use manifest from source files
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.3/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     files:


### PR DESCRIPTION
### CAPI [v1.4.3](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.3)

**CAPE**
- Dependency: Update cert-manager to v1.12.1
- Dependency: Update kubebuilder envtest to 1.27.1

**CAPI** 
- clusterctl: Return error on infra cluster and control plane discovery (https://github.com/kubernetes-sigs/cluster-api/pull/8609)
- e2e: Adjust machinepool helper e2e timeout (https://github.com/kubernetes-sigs/cluster-api/pull/8756)
- e2e: test/e2e check for machines being ready after provisioning on Runtime SDK test (https://github.com/kubernetes-sigs/cluster-api/pull/8646)
- e2e: test/framework fix docker pod log collector (https://github.com/kubernetes-sigs/cluster-api/pull/8643)
- KCP: Allow machine rollout if cert reconcile fails (https://github.com/kubernetes-sigs/cluster-api/pull/8737)
- KCP: Prevent KCP to create many private keys for each reconcile (https://github.com/kubernetes-sigs/cluster-api/pull/8619)