### PR TITLE
SKS-1381: Support for finding virtual machine templates through SKSVMTemplateUIDLabel

### DIFF
--- a/pkg/service/consts.go
+++ b/pkg/service/consts.go
@@ -19,4 +19,7 @@ package service
 const (
 	// VMPlacementGroupDescription is the description of vm placement group.
 	VMPlacementGroupDescription = "This is VM placement group created by CAPE, don't delete it!"
+
+	// SKSVMTemplateUIDLabel is the label used to find the virtual machine template.
+	SKSVMTemplateUIDLabel = "system.cloudtower/sks-template-uid"
 )


### PR DESCRIPTION
### [SKS-1381](http://jira.smartx.com/browse/SKS-1381)
优先通过系统标签 system.cloudtower/sks-template-uid 查询虚拟机模板。ID 和虚拟机名称次之。解决虚拟机模板被删除、集群重新关联虚拟机模板丢失的问题。

### 测试
1.为虚拟机模板 rocky-8.6-amd64-k8s-v1.25.9-v1-jhhs1g-template（ID 为 clho99df2o7nj09581xnux8wr） 创建并关联系统标签：system.cloudtower/sks-template-uid:my-sks-template

2.通过 my-sks-template、clho99df2o7nj09581xnux8wr、rocky-8.6-amd64-k8s-v1.25.9-v1-jhhs1g-template 三种方式都可以正常创建集群

<img width="1047" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/43191b86-0de3-424a-8c0f-199905f81938">
