### PR TITLE
SKS-1459: Make sure the CP nodes are placed on different hosts

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -997,13 +997,13 @@ func (r *ElfMachineReconciler) migrateVMForPlacementGroup(ctx *context.MachineCo
 	}
 
 	if *kcp.Spec.Replicas != kcp.Status.UpdatedReplicas {
-		ctx.Logger.Info("KCP rolling update in progress, skip migrate VM", "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+		ctx.Logger.Info("KCP rolling update in progress, skip migrating VM", "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
 
 		return true, nil
 	}
 
 	if ok := acquireTicketForPlacementGroupVMMigration(*placementGroup.Name); !ok {
-		ctx.Logger.V(1).Info("The placement group is performing another VM migration, skip migrate VM", "placementGroup", service.GetTowerString(placementGroup.Name), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+		ctx.Logger.V(1).Info("The placement group is performing another VM migration, skip migrating VM", "placementGroup", service.GetTowerString(placementGroup.Name), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
 
 		return false, nil
 	}

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1094,7 +1094,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
-				Expect(logBuffer.String()).To(ContainSubstring("KCP rolling update in progress, skip migrate VM"))
+				Expect(logBuffer.String()).To(ContainSubstring("KCP rolling update in progress, skip migrating VM"))
 			})
 
 			It("should migrate VM to another host when the VM is running and the host of VM is not in unused hosts", func() {

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -95,6 +95,30 @@ func GetUnavailableHostInfo(hosts []*models.Host, memory int64) map[string]strin
 	return info
 }
 
+func ContainsUnavailableHost(hosts []*models.Host, hostIDs []string, memory int64) bool {
+	if len(hosts) == 0 || len(hostIDs) == 0 {
+		return true
+	}
+
+	hostMap := make(map[string]*models.Host)
+	for i := 0; i < len(hosts); i++ {
+		hostMap[*hosts[i].ID] = hosts[i]
+	}
+
+	for i := 0; i < len(hostIDs); i++ {
+		host, ok := hostMap[hostIDs[i]]
+		if !ok {
+			return true
+		}
+
+		if ok, _ := IsAvailableHost(host, memory); !ok {
+			return true
+		}
+	}
+
+	return false
+}
+
 func GetHostFromList(hostID string, hosts []*models.Host) *models.Host {
 	for i := 0; i < len(hosts); i++ {
 		if *hosts[i].ID == hostID {

--- a/pkg/service/util_test.go
+++ b/pkg/service/util_test.go
@@ -100,3 +100,21 @@ func TestIsAvailableHost(t *testing.T) {
 		g.Expect(message).To(gomega.ContainSubstring("3"))
 	})
 }
+
+func TestContainsUnavailableHost(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("should return false when has unavailable host", func(t *testing.T) {
+		hosts := []*models.Host{{ID: pointer.String("1"), AllocatableMemoryBytes: pointer.Int64(1), Status: models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)}}
+
+		g.Expect(ContainsUnavailableHost(nil, []string{"0"}, 2)).To(gomega.BeTrue())
+
+		g.Expect(ContainsUnavailableHost(hosts, nil, 2)).To(gomega.BeTrue())
+
+		g.Expect(ContainsUnavailableHost(hosts, []string{"0"}, 2)).To(gomega.BeTrue())
+
+		g.Expect(ContainsUnavailableHost(hosts, []string{"1"}, 2)).To(gomega.BeTrue())
+
+		g.Expect(ContainsUnavailableHost(hosts, []string{"1"}, 1)).To(gomega.BeFalse())
+	})
+}

--- a/pkg/util/kcp/kcp.go
+++ b/pkg/util/kcp/kcp.go
@@ -1,0 +1,30 @@
+package kcp
+
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+)
+
+// IsKCPInRollingUpdate returns whether KCP is in rolling update.
+// IMPORTANT: This function can only be used when creating a new Machine.
+//
+// If *kcp.Spec.Replicas > kcp.Status.Replicas, it means KCP is not in rolling update,
+// but scaling out or being created.
+func IsKCPInRollingUpdate(kcp *controlplanev1.KubeadmControlPlane) bool {
+	return *kcp.Spec.Replicas <= kcp.Status.Replicas
+}


### PR DESCRIPTION
### 问题
[[SKS-1459] 应该保证 CP 节点运行在不同的主机](http://jira.smartx.com/browse/SKS-1459)

### 方案
保证所有的 CP 节点必须在不同的主机，如果可用主机数量不够，需要等待有足够的主机再开机。

特例：允许 CP 节点数和可用主机数一样的情况进行升级，会出现两个 CP 节点在同一个主机的中间状态，此时其中一个CP节点并没有加入放置组。

### 测试
测试环境为 3 可用主机 ELF 集群

1.创建 5 CP 集群，只有前 3 个 CP 正常创建，第四个虚拟机创建但未开机，需要等待足够主机
"The placement group is full, wait for enough available hosts"

2.创建 3 CP 集群，正常创建

3.升级 3 CP 集群，正常升级，没有发生虚拟机迁移