### PR TITLE
SKS-581: Updating kube-vip configuration to speed up vip leader switching

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -124,11 +124,11 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_leaseduration
-              value: "15"
+              value: "5"
             - name: vip_renewdeadline
-              value: "10"
+              value: "3"
             - name: vip_retryperiod
-              value: "2"
+              value: "1"
             image: ghcr.io/kube-vip/kube-vip:v0.5.12
             imagePullPolicy: IfNotPresent
             name: kube-vip


### PR DESCRIPTION
## 问题

[SKS-581] 优化升级3CP+3Worker集群的时间 - Jira http://jira.smartx.com/browse/SKS-581

升级过程中，kube-vip leader切换过慢，导致CAPI驱逐节点上的pod时，偶现访问CP VIP异常

```
I0614 07:34:33.421791       1 machine_controller.go:340] "Draining node" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk/sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-fns8p" namespace="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk" name="sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-fns8p" reconcileID=02cfddaf-194b-4f80-b8ab-a3a5ec5287fe KubeadmControlPlane="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk/sks-e2e-test-6d2dnk-k8s-upgrade-controlplane" Cluster="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk/sks-e2e-test-6d2dnk-k8s-upgrade" Node="sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-bz892"
E0614 07:34:43.586211       1 controller.go:329] "Reconciler error" err="unable to get node sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-bz892: Get \"https://10.255.24.8:6443/api/v1/nodes/sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-bz892?timeout=10s\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk/sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-fns8p" namespace="sks-e2e-huangwei-sks-581-kubevip-config-101-lgergk" name="sks-e2e-test-6d2dnk-k8s-upgrade-controlplane-fns8p" reconcileID=02cfddaf-194b-4f80-b8ab-a3a5ec5287fe
```

## 根因

kube-vip leader切换过慢，会导致切换过程中，访问CP VIP异常。

## 修复

调整 `cluster-template.yaml ` kube-vip配置  `vip_leaseduration 15=>5，vip_renewdeadline 10=>3， vip_retryperiod 3=>1`

## 测试

经过多次KSC E2E CI验证，工作正常，且升级过程中apiserver连接闪断后能在数秒内恢复连接：https://jenkins.caas.smtx.io/job/kubesmart/job/huangwei%252Fsks-581-kubevip-config/