### PR TITLE
TOWER-8664: Delay creation of placement group when duplicate placement group is encountered

### DIFF
--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -28,7 +28,8 @@ const (
 	creationTimeout           = time.Minute * 6
 	vmOperationRateLimit      = time.Second * 6
 	vmMigrationTimeout        = time.Minute * 20
-	placementGroupSilenceTime = time.Minute * 6
+	placementGroupSilenceTime = time.Minute * 30
+	placementGroupCreationKey = "%s:creation"
 )
 
 var vmStatusMap = make(map[string]time.Time)
@@ -144,7 +145,7 @@ func setPlacementGroupDuplicate(groupName string) {
 	placementGroupOperationLock.Lock()
 	defer placementGroupOperationLock.Unlock()
 
-	placementGroupOperationMap[fmt.Sprintf("%s:creation", groupName)] = time.Now()
+	placementGroupOperationMap[fmt.Sprintf(placementGroupCreationKey, groupName)] = time.Now()
 }
 
 // canCreatePlacementGroup returns whether placement group creation can be performed.
@@ -152,7 +153,7 @@ func canCreatePlacementGroup(groupName string) bool {
 	placementGroupOperationLock.Lock()
 	defer placementGroupOperationLock.Unlock()
 
-	key := fmt.Sprintf("%s:creation", groupName)
+	key := fmt.Sprintf(placementGroupCreationKey, groupName)
 	if timestamp, ok := placementGroupOperationMap[key]; ok {
 		if time.Now().Before(timestamp.Add(placementGroupSilenceTime)) {
 			return false

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	creationTimeout           = time.Minute * 6
-	vmOperationRateLimit      = time.Second * 6
-	vmMigrationTimeout        = time.Minute * 20
-	placementGroupSilenceTime = time.Minute * 30
-	placementGroupCreationKey = "%s:creation"
+	creationTimeout               = time.Minute * 6
+	vmOperationRateLimit          = time.Second * 6
+	vmMigrationTimeout            = time.Minute * 20
+	placementGroupSilenceTime     = time.Minute * 30
+	placementGroupCreationLockKey = "%s:creation"
 )
 
 var vmStatusMap = make(map[string]time.Time)
@@ -145,7 +145,7 @@ func setPlacementGroupDuplicate(groupName string) {
 	placementGroupOperationLock.Lock()
 	defer placementGroupOperationLock.Unlock()
 
-	placementGroupOperationMap[fmt.Sprintf(placementGroupCreationKey, groupName)] = time.Now()
+	placementGroupOperationMap[fmt.Sprintf(placementGroupCreationLockKey, groupName)] = time.Now()
 }
 
 // canCreatePlacementGroup returns whether placement group creation can be performed.
@@ -153,7 +153,7 @@ func canCreatePlacementGroup(groupName string) bool {
 	placementGroupOperationLock.Lock()
 	defer placementGroupOperationLock.Unlock()
 
-	key := fmt.Sprintf(placementGroupCreationKey, groupName)
+	key := fmt.Sprintf(placementGroupCreationLockKey, groupName)
 	if timestamp, ok := placementGroupOperationMap[key]; ok {
 		if time.Now().Before(timestamp.Add(placementGroupSilenceTime)) {
 			return false

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -24,9 +25,10 @@ import (
 )
 
 const (
-	creationTimeout      = time.Minute * 6
-	vmOperationRateLimit = time.Second * 6
-	vmMigrationTimeout   = time.Minute * 20
+	creationTimeout           = time.Minute * 6
+	vmOperationRateLimit      = time.Second * 6
+	vmMigrationTimeout        = time.Minute * 20
+	placementGroupSilenceTime = time.Minute * 6
 )
 
 var vmStatusMap = make(map[string]time.Time)
@@ -135,4 +137,29 @@ func releaseTicketForPlacementGroupOperation(groupName string) {
 	defer placementGroupOperationLock.Unlock()
 
 	delete(placementGroupOperationMap, groupName)
+}
+
+// setPlacementGroupDuplicate sets whether placement group is duplicated.
+func setPlacementGroupDuplicate(groupName string) {
+	placementGroupOperationLock.Lock()
+	defer placementGroupOperationLock.Unlock()
+
+	placementGroupOperationMap[fmt.Sprintf("%s:creation", groupName)] = time.Now()
+}
+
+// canCreatePlacementGroup returns whether placement group creation can be performed.
+func canCreatePlacementGroup(groupName string) bool {
+	placementGroupOperationLock.Lock()
+	defer placementGroupOperationLock.Unlock()
+
+	key := fmt.Sprintf("%s:creation", groupName)
+	if timestamp, ok := placementGroupOperationMap[key]; ok {
+		if time.Now().Before(timestamp.Add(placementGroupSilenceTime)) {
+			return false
+		}
+
+		delete(placementGroupOperationMap, key)
+	}
+
+	return true
 }

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Placement Group Operation Limiter", func() {
 	})
 
 	It("canCreatePlacementGroup", func() {
-		key := fmt.Sprintf(placementGroupCreationKey, groupName)
+		key := fmt.Sprintf(placementGroupCreationLockKey, groupName)
 
 		Expect(placementGroupOperationMap).NotTo(HaveKey(key))
 		Expect(canCreatePlacementGroup(groupName)).To(BeTrue())

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Placement Group Operation Limiter", func() {
 	})
 
 	It("canCreatePlacementGroup", func() {
-		key := fmt.Sprintf("%s:creation", groupName)
+		key := fmt.Sprintf(placementGroupCreationKey, groupName)
 
 		Expect(placementGroupOperationMap).NotTo(HaveKey(key))
 		Expect(canCreatePlacementGroup(groupName)).To(BeTrue())

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -23,18 +23,19 @@ import (
 
 // error codes.
 const (
-	ClusterNotFound          = "CLUSTER_NOT_FOUND"
-	HostNotFound             = "HOST_NOT_FOUND"
-	VMTemplateNotFound       = "VM_TEMPLATE_NOT_FOUND"
-	VMNotFound               = "VM_NOT_FOUND"
-	VMDuplicate              = "VM_DUPLICATE"
-	TaskNotFound             = "TASK_NOT_FOUND"
-	VlanNotFound             = "VLAN_NOT_FOUND"
-	VMPlacementGroupNotFound = "VM_PLACEMENT_GROUP_NOT_FOUND"
-	LabelCreateFailed        = "LABEL_CREATE_FAILED"
-	LabelAddFailed           = "LABEL_ADD_FAILED"
-	CloudInitError           = "VM_CLOUD_INIT_CONFIG_ERROR"
-	MemoryInsufficientError  = "HostAvailableMemoryFilter"
+	ClusterNotFound           = "CLUSTER_NOT_FOUND"
+	HostNotFound              = "HOST_NOT_FOUND"
+	VMTemplateNotFound        = "VM_TEMPLATE_NOT_FOUND"
+	VMNotFound                = "VM_NOT_FOUND"
+	VMDuplicate               = "VM_DUPLICATE"
+	TaskNotFound              = "TASK_NOT_FOUND"
+	VlanNotFound              = "VLAN_NOT_FOUND"
+	VMPlacementGroupNotFound  = "VM_PLACEMENT_GROUP_NOT_FOUND"
+	VMPlacementGroupDuplicate = "PLACEMENT_GROUP_DUPLICATE_NAME"
+	LabelCreateFailed         = "LABEL_CREATE_FAILED"
+	LabelAddFailed            = "LABEL_ADD_FAILED"
+	CloudInitError            = "VM_CLOUD_INIT_CONFIG_ERROR"
+	MemoryInsufficientError   = "HostAvailableMemoryFilter"
 )
 
 func IsVMNotFound(err error) bool {
@@ -55,6 +56,10 @@ func IsTaskNotFound(err error) bool {
 
 func IsVMPlacementGroupNotFound(err error) bool {
 	return strings.Contains(err.Error(), VMPlacementGroupNotFound)
+}
+
+func IsVMPlacementGroupDuplicate(message string) bool {
+	return strings.Contains(message, VMPlacementGroupDuplicate)
 }
 
 func IsCloudInitConfigError(message string) bool {


### PR DESCRIPTION
### TOWER-8664 同名放置组

创建放置组的时候偶尔会遇到同名放置组错误，原因是 ELF 中成功创建了该放置组，但是 Tower 却把自己 DB 中的放置组删除了，CAPE 重试创建，Tower 会认为 ELF 已经存在同名放置组而任务失败。Tower 目前大约一个小时定时同步。

![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/f6939df9-363b-4ce3-a13b-8bb9874ef70b)

Tower 预计在 Q4 修复该问题，CAPE 遇到该问题先增加重试的间隔时间，避免重复的失败任务。

### 其他改动
 修复单测偶现的一个问题，异步删除资源，需要轮询确认。

### 测试
1.在没有出现同名放置组的情况，放置组可以正常创建，且手动删除放置组后，Reconcile 的时候会马上重新创建。

2.制造同名放置组错误，观察到创建放置组的逻辑在 30m 内不被允许，过了 30m 后，放置组被正常创建出来。
