### PR TITLE
SKS-1459: Check for available hosts before creating a virtual machine

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -91,6 +91,9 @@ const (
 	// an error while joining placement group; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	JoiningPlacementGroupFailedReason = "JoiningPlacementGroupFailed"
+
+	// WaitingForAvailableHostReason (Severity=Info) documents a ElfMachine waiting for a available host to create VM.
+	WaitingForAvailableHostReason = "WaitingForAvailableHost"
 )
 
 // Conditions and Reasons related to make connections to a Tower. Can currently be used by ElfCluster and ElfMachine

--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -24,15 +24,15 @@ const (
 	// VMProvisionedCondition documents the status of the provisioning of a VM.
 	VMProvisionedCondition clusterv1.ConditionType = "VMProvisioned"
 
-	// WaitingForClusterInfrastructureReason (Severity=Info) documents a ElfMachine waiting for the cluster
+	// WaitingForClusterInfrastructureReason (Severity=Info) documents an ElfMachine waiting for the cluster
 	// infrastructure to be ready before starting the provisioning process.
 	WaitingForClusterInfrastructureReason = "WaitingForClusterInfrastructure"
 
-	// WaitingForBootstrapDataReason (Severity=Info) documents a ElfMachine waiting for the bootstrap
+	// WaitingForBootstrapDataReason (Severity=Info) documents an ElfMachine waiting for the bootstrap
 	// script to be ready before starting the provisioning process.
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
 
-	// WaitingForStaticIPAllocationReason (Severity=Info) documents a ElfMachine waiting for the allocation of
+	// WaitingForStaticIPAllocationReason (Severity=Info) documents an ElfMachine waiting for the allocation of
 	// a static IP address.
 	WaitingForStaticIPAllocationReason = "WaitingForStaticIPAllocation"
 
@@ -42,58 +42,59 @@ const (
 	// UpdatingReason documents (Severity=Info) ElfMachine currently executing the update operation.
 	UpdatingReason = "Updating"
 
-	// PoweringOnReason documents (Severity=Info) a ElfMachine currently executing the power on sequence.
+	// PoweringOnReason documents (Severity=Info) an ElfMachine currently executing the power on sequence.
 	PoweringOnReason = "PoweringOn"
 
-	// PowerOffReason documents (Severity=Info) a ElfMachine currently executing the power off sequence.
+	// PowerOffReason documents (Severity=Info) an ElfMachine currently executing the power off sequence.
 	PowerOffReason = "PoweringOff"
 
-	// ShuttingDownReason documents (Severity=Info) a ElfMachine currently executing the shut down sequence.
+	// ShuttingDownReason documents (Severity=Info) an ElfMachine currently executing the shut down sequence.
 	ShuttingDownReason = "ShuttingDown"
 
-	// PoweringOnFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// PoweringOnFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while powering on; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	PoweringOnFailedReason = "PoweringOnFailed"
 
-	// PoweringOffFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// PoweringOffFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while powering off; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	PoweringOffFailedReason = "PoweringOffFailed"
 
-	// ShuttingDownFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// ShuttingDownFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while shutting down; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	ShuttingDownFailedReason = "ShuttingDownFailed"
 
-	// CloningFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// CloningFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while provisioning; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	CloningFailedReason = "CloningFailed"
 
-	// UpdatingFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// UpdatingFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while updating; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	UpdatingFailedReason = "UpdatingFailed"
 
-	// TaskFailureReason (Severity=Warning) documents a ElfMachine task failure; the reconcile look will automatically
+	// TaskFailureReason (Severity=Warning) documents an ElfMachine task failure; the reconcile look will automatically
 	// retry the operation, but a user intervention might be required to fix the problem.
 	TaskFailureReason = "TaskFailure"
 
-	// WaitingForNetworkAddressesReason (Severity=Info) documents a ElfMachine waiting for the machine network
+	// WaitingForNetworkAddressesReason (Severity=Info) documents an ElfMachine waiting for the machine network
 	// settings to be reported after machine being powered on.
 	WaitingForNetworkAddressesReason = "WaitingForNetworkAddresses"
 
-	// JoiningPlacementGroupReason documents (Severity=Info) a ElfMachine currently executing the join placement group operation.
+	// JoiningPlacementGroupReason documents (Severity=Info) an ElfMachine currently executing the join placement group operation.
 	JoiningPlacementGroupReason = "JoiningPlacementGroup"
 
-	// JoiningPlacementGroupFailedReason (Severity=Warning) documents a ElfMachine controller detecting
+	// JoiningPlacementGroupFailedReason (Severity=Warning) documents an ElfMachine controller detecting
 	// an error while joining placement group; those kind of errors are usually transient and failed provisioning
 	// are automatically re-tried by the controller.
 	JoiningPlacementGroupFailedReason = "JoiningPlacementGroupFailed"
 
-	// WaitingForAvailableHostReason (Severity=Info) documents a ElfMachine waiting for a available host to create VM.
-	WaitingForAvailableHostReason = "WaitingForAvailableHost"
+	// WaitingForAvailableHostRequiredByPlacementGroupReason (Severity=Info) documents an ElfMachine
+	// waiting for an available host required by placement group to create VM.
+	WaitingForAvailableHostRequiredByPlacementGroupReason = "WaitingForAvailableHostRequiredByPlacementGroup"
 )
 
 // Conditions and Reasons related to make connections to a Tower. Can currently be used by ElfCluster and ElfMachine

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -59,7 +59,7 @@ type Tower struct {
 	SkipTLSVerify bool `json:"skipTLSVerify,omitempty"`
 }
 
-// ElfMachineTemplateResource describes the data needed to create a ElfMachine from a template.
+// ElfMachineTemplateResource describes the data needed to create an ElfMachine from a template.
 type ElfMachineTemplateResource struct {
 	// Spec is the specification of the desired behavior of the machine.
 	Spec ElfMachineSpec `json:"spec"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
@@ -37,7 +37,7 @@ spec:
             properties:
               template:
                 description: ElfMachineTemplateResource describes the data needed
-                  to create a ElfMachine from a template.
+                  to create an ElfMachine from a template.
                 properties:
                   spec:
                     description: Spec is the specification of the desired behavior

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -31,13 +31,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
-	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,7 +54,6 @@ import (
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/util"
-	kcputil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/kcp"
 	labelsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/labels"
 	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
@@ -397,6 +394,10 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 		return reconcile.Result{}, nil
 	}
 
+	if result, err := r.reconcilePlacementGroup(ctx); err != nil || !result.IsZero() {
+		return result, err
+	}
+
 	if r.isWaitingForStaticIPAllocation(ctx) {
 		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForStaticIPAllocationReason, clusterv1.ConditionSeverityInfo, "")
 		ctx.Logger.Info("VM is waiting for static ip to be available")
@@ -499,14 +500,14 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			}
 		}
 
-		hostID, err := r.getVMHostForRollingUpdate(ctx)
-		if err != nil {
+		hostID, err := r.preCheckPlacementGroup(ctx)
+		if err != nil || hostID == nil {
 			return nil, err
 		}
 
 		ctx.Logger.Info("Create VM for ElfMachine")
 
-		withTaskVM, err := ctx.VMService.Clone(ctx.ElfCluster, ctx.Machine, ctx.ElfMachine, bootstrapData, hostID)
+		withTaskVM, err := ctx.VMService.Clone(ctx.ElfCluster, ctx.Machine, ctx.ElfMachine, bootstrapData, *hostID)
 		if err != nil {
 			releaseTicketForCreateVM(ctx.ElfMachine.Name)
 
@@ -582,7 +583,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 	}
 
 	// Before the virtual machine is powered on, put the virtual machine into the specified placement group.
-	if ok, err := r.reconcilePlacementGroup(ctx, vm); err != nil || !ok {
+	if ok, err := r.joinPlacementGroup(ctx, vm); err != nil || !ok {
 		return nil, err
 	}
 
@@ -870,432 +871,6 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 	}
 
 	return false, nil
-}
-
-// reconcilePlacementGroup puts the virtual machine into the placement group.
-func (r *ElfMachineReconciler) reconcilePlacementGroup(ctx *context.MachineContext, vm *models.VM) (ret bool, reterr error) {
-	defer func() {
-		if reterr != nil {
-			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.JoiningPlacementGroupFailedReason, clusterv1.ConditionSeverityWarning, reterr.Error())
-		} else if !ret {
-			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.JoiningPlacementGroupReason, clusterv1.ConditionSeverityInfo, "")
-		}
-	}()
-
-	towerCluster, err := ctx.VMService.GetCluster(ctx.ElfCluster.Spec.Cluster)
-	if err != nil {
-		return false, err
-	}
-
-	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
-	if err != nil {
-		return false, err
-	}
-
-	if ok := acquireTicketForPlacementGroupOperation(placementGroupName); ok {
-		defer releaseTicketForPlacementGroupOperation(placementGroupName)
-	} else {
-		return false, nil
-	}
-
-	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
-	if err != nil {
-		if !service.IsVMPlacementGroupNotFound(err) {
-			return false, err
-		}
-
-		placementGroup, err = r.createPlacementGroup(ctx, placementGroupName, *towerCluster.ID)
-		if err != nil || placementGroup == nil {
-			return false, err
-		}
-	}
-
-	// Placement group is performing an operation
-	if !machineutil.IsUUID(*placementGroup.LocalID) || placementGroup.EntityAsyncStatus != nil {
-		ctx.Logger.Info("Waiting for placement group task done", "placementGroup", *placementGroup.Name)
-
-		return false, nil
-	}
-
-	placementGroupVMSet := sets.NewString()
-	for i := 0; i < len(placementGroup.Vms); i++ {
-		placementGroupVMSet.Insert(*placementGroup.Vms[i].ID)
-	}
-
-	if placementGroupVMSet.Has(*vm.ID) {
-		return true, nil
-	}
-
-	if machineutil.IsControlPlaneMachine(ctx.Machine) {
-		usedHostSet, err := r.getHostsInPlacementGroup(ctx, placementGroup)
-		if err != nil {
-			return false, err
-		}
-
-		hosts, err := ctx.VMService.GetHostsByCluster(*towerCluster.ID)
-		if err != nil {
-			return false, err
-		}
-
-		availableHosts := r.getAvailableHosts(ctx, hosts, usedHostSet, vm)
-		if len(availableHosts) < len(hosts) {
-			unavailableHostInfo := service.GetUnavailableHostInfo(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-			ctx.Logger.Info("Unavailable hosts found", "unavailableHosts", unavailableHostInfo, "placementGroup", *placementGroup.Name, "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-		}
-
-		availableHostSet := service.HostsToSet(availableHosts)
-		unusedHostSet := availableHostSet.Difference(usedHostSet)
-		if unusedHostSet.Len() == 0 {
-			kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
-			if err != nil {
-				return false, err
-			}
-
-			// Only when the KCP is in rolling update, the VM is stopped, and all the hosts used by the placement group are available,
-			// will the upgrade be allowed with the same number of hosts and CP nodes.
-			// In this case first machine created by KCP rolling update can be powered on without being added to the placement group.
-			if kcputil.IsKCPInRollingUpdate(kcp) &&
-				*vm.Status == models.VMStatusSTOPPED &&
-				!service.ContainsUnavailableHost(hosts, usedHostSet.UnsortedList(), *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB)) {
-				ctx.Logger.Info("The placement group is full and KCP is in rolling update, skip adding VM to the placement group", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-
-				return true, nil
-			}
-
-			if *vm.Status == models.VMStatusRUNNING || *vm.Status == models.VMStatusSUSPENDED {
-				ctx.Logger.V(2).Info(fmt.Sprintf("The placement group is full and VM is in %s status, skip adding VM to the placement group", *vm.Status), "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-
-				return true, nil
-			}
-
-			// KCP is scaling out or being created.
-			ctx.Logger.V(2).Info("The placement group is full, wait for enough available hosts", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-
-			return false, nil
-		}
-
-		if !unusedHostSet.Has(*vm.Host.ID) && *vm.Status != models.VMStatusSTOPPED {
-			return r.migrateVMForPlacementGroup(ctx, vm, placementGroup, unusedHostSet.UnsortedList()[0])
-		}
-	}
-
-	if !placementGroupVMSet.Has(*vm.ID) {
-		placementGroupVMSet.Insert(*vm.ID)
-		if err := r.addVMsToPlacementGroup(ctx, placementGroup, placementGroupVMSet.List()); err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
-}
-
-// migrateVMForPlacementGroup migrates the virtual machine to the specified target host.
-func (r *ElfMachineReconciler) migrateVMForPlacementGroup(ctx *context.MachineContext, vm *models.VM, placementGroup *models.VMPlacementGroup, targetHost string) (bool, error) {
-	kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
-	if err != nil {
-		return false, err
-	}
-
-	if *kcp.Spec.Replicas != kcp.Status.UpdatedReplicas {
-		ctx.Logger.Info("KCP rolling update in progress, skip migrating VM", "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-
-		return true, nil
-	}
-
-	if ok := acquireTicketForPlacementGroupVMMigration(*placementGroup.Name); !ok {
-		ctx.Logger.V(1).Info("The placement group is performing another VM migration, skip migrating VM", "placementGroup", service.GetTowerString(placementGroup.Name), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
-
-		return false, nil
-	}
-
-	withTaskVM, err := ctx.VMService.Migrate(service.GetTowerString(vm.ID), targetHost)
-	if err != nil {
-		return false, err
-	}
-
-	ctx.ElfMachine.SetTask(*withTaskVM.TaskID)
-
-	ctx.Logger.Info(fmt.Sprintf("Waiting for the VM to be migrated from %s to %s", *vm.Host.ID, targetHost), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID, "taskRef", ctx.ElfMachine.Status.TaskRef)
-
-	return false, nil
-}
-
-func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext, placementGroupName, towerClusterID string) (*models.VMPlacementGroup, error) {
-	// TODO: This will be removed when Tower fixes issue with placement group data syncing.
-	if ok := canCreatePlacementGroup(placementGroupName); !ok {
-		ctx.Logger.V(2).Info(fmt.Sprintf("Tower has duplicate placement group, skip creating placement group %s", placementGroupName))
-
-		return nil, nil
-	}
-
-	placementGroupPolicy := towerresources.GetVMPlacementGroupPolicy(ctx.Machine)
-	withTaskVMPlacementGroup, err := ctx.VMService.CreateVMPlacementGroup(placementGroupName, towerClusterID, placementGroupPolicy)
-	if err != nil {
-		return nil, err
-	}
-
-	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout, config.WaitTaskInterval)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)
-	}
-
-	if *task.Status == models.TaskStatusFAILED {
-		if service.IsVMPlacementGroupDuplicate(service.GetTowerString(task.ErrorMessage)) {
-			setPlacementGroupDuplicate(placementGroupName)
-
-			ctx.Logger.Info(fmt.Sprintf("Duplicate placement group detected, will try again in %s", placementGroupSilenceTime), "placementGroup", placementGroupName)
-		}
-
-		return nil, errors.Errorf("failed to create placement group %s in task %s", placementGroupName, *task.ID)
-	}
-
-	ctx.Logger.Info("Creating placement group succeeded", "taskID", *task.ID, "placementGroup", placementGroupName)
-
-	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
-	if err != nil {
-		return nil, err
-	}
-
-	return placementGroup, nil
-}
-
-// deletePlacementGroup deletes the placement group when the MachineDeployment is deleted
-// and the cluster is not deleted.
-// If the cluster is deleted, all placement groups are deleted by the ElfCluster controller.
-func (r *ElfMachineReconciler) deletePlacementGroup(ctx *context.MachineContext) (bool, error) {
-	if !ctx.Cluster.DeletionTimestamp.IsZero() || machineutil.IsControlPlaneMachine(ctx.Machine) {
-		return true, nil
-	}
-
-	md, err := machineutil.GetMDByMachine(ctx, ctx.Client, ctx.Machine)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-
-		return false, err
-	}
-
-	// SKS will set replicas to 0 before deleting the MachineDeployment,
-	// and then delete it after all the machines are deleted.
-	// In this scenario, CAPE needs to delete the placement group first
-	// when md.Spec.Replicas is 0.
-	if md.DeletionTimestamp.IsZero() && *md.Spec.Replicas > 0 {
-		return true, nil
-	}
-
-	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
-	if err != nil {
-		return false, err
-	}
-
-	// Only delete the placement groups created by CAPE.
-	if !strings.HasPrefix(placementGroupName, towerresources.GetVMPlacementGroupNamePrefix(ctx.Cluster)) {
-		return true, nil
-	}
-
-	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
-	if err != nil {
-		if service.IsVMPlacementGroupNotFound(err) {
-			return true, nil
-		}
-
-		return false, err
-	}
-
-	if ok := acquireTicketForPlacementGroupOperation(*placementGroup.Name); ok {
-		defer releaseTicketForPlacementGroupOperation(*placementGroup.Name)
-	} else {
-		return false, nil
-	}
-
-	if err := ctx.VMService.DeleteVMPlacementGroupsByName(*placementGroup.Name); err != nil {
-		return false, err
-	} else {
-		ctx.Logger.Info(fmt.Sprintf("Placement group %s deleted", *placementGroup.Name))
-	}
-
-	return true, nil
-}
-
-func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup, vmIDs []string) error {
-	task, err := ctx.VMService.AddVMsToPlacementGroup(placementGroup, vmIDs)
-	if err != nil {
-		return err
-	}
-
-	taskID := *task.ID
-	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
-	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, taskID)
-	}
-
-	if *task.Status == models.TaskStatusFAILED {
-		return errors.Errorf("failed to update placement group %s in task %s", *placementGroup.Name, taskID)
-	}
-
-	ctx.Logger.Info("Updating placement group succeeded", "taskID", taskID, "placementGroup", *placementGroup.Name, "vmIDs", vmIDs)
-
-	return nil
-}
-
-// getVMHostForRollingUpdate returns the target host server id for a virtual machine during rolling update.
-// During KCP rolling update, machines will be deleted in the order of creation.
-// Find the latest created machine in the placement group,
-// and set the host where the machine is located to the first machine created by KCP rolling update.
-// This prevents migration of virtual machine during KCP rolling update when using a placement group.
-func (r *ElfMachineReconciler) getVMHostForRollingUpdate(ctx *context.MachineContext) (string, error) {
-	if !machineutil.IsControlPlaneMachine(ctx.Machine) {
-		return "", nil
-	}
-
-	kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
-	if err != nil {
-		return "", err
-	}
-
-	if !kcputil.IsKCPInRollingUpdate(kcp) {
-		// KCP is scaling out or being created. Then simply return.
-		return "", nil
-	}
-
-	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
-	if err != nil {
-		return "", err
-	}
-	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
-	if err != nil {
-		if service.IsVMPlacementGroupNotFound(err) {
-			return "", nil
-		}
-
-		return "", err
-	}
-
-	placementGroupVMSet := sets.NewString()
-	for i := 0; i < len(placementGroup.Vms); i++ {
-		placementGroupVMSet.Insert(*placementGroup.Vms[i].ID)
-	}
-
-	usedHostSet, err := r.getHostsInPlacementGroup(ctx, placementGroup)
-	if err != nil {
-		return "", err
-	}
-
-	towerCluster, err := ctx.VMService.GetCluster(ctx.ElfCluster.Spec.Cluster)
-	if err != nil {
-		return "", err
-	}
-
-	hosts, err := ctx.VMService.GetHostsByCluster(*towerCluster.ID)
-	if err != nil {
-		return "", err
-	}
-
-	availableHosts := service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-	if len(availableHosts) < len(hosts) {
-		unavailableHostInfo := service.GetUnavailableHostInfo(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-		ctx.Logger.Info("Unavailable hosts found", "unavailableHosts", unavailableHostInfo, "placementGroup", *placementGroup.Name, "vmRef", ctx.ElfMachine.Status.VMRef)
-	}
-
-	availableHostSet := service.HostsToSet(availableHosts)
-	unusedHostSet := availableHostSet.Difference(usedHostSet)
-	// Only when the placement group is full does it need to get the latest created machine.
-	if unusedHostSet.Len() != 0 {
-		ctx.Logger.V(2).Info("The placement group still has capacity, skip selecting host for rolling update", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "unusedHosts", unusedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef)
-
-		return "", nil
-	}
-
-	elfMachines, err := machineutil.GetControlPlaneElfMachinesInCluster(ctx, ctx.Client, ctx.Cluster.Namespace, ctx.Cluster.Name)
-	if err != nil {
-		return "", err
-	}
-
-	elfMachineMap := make(map[string]*infrav1.ElfMachine)
-	for i := 0; i < len(elfMachines); i++ {
-		if machineutil.IsUUID(elfMachines[i].Status.VMRef) {
-			elfMachineMap[elfMachines[i].Name] = elfMachines[i]
-		}
-	}
-
-	placementGroupMachines := make([]*clusterv1.Machine, 0, len(placementGroup.Vms))
-	vmMap := make(map[string]string)
-	for i := 0; i < len(placementGroup.Vms); i++ {
-		if elfMachine, ok := elfMachineMap[*placementGroup.Vms[i].Name]; ok {
-			machine, err := capiutil.GetOwnerMachine(r, r.Client, elfMachine.ObjectMeta)
-			if err != nil {
-				return "", err
-			}
-
-			placementGroupMachines = append(placementGroupMachines, machine)
-			vmMap[machine.Name] = *(placementGroup.Vms[i].ID)
-		}
-	}
-
-	machines := collections.FromMachines(placementGroupMachines...)
-	if machine := machines.Newest(); machine != nil {
-		if vm, err := ctx.VMService.Get(vmMap[machine.Name]); err != nil {
-			return "", err
-		} else {
-			host := service.GetHostFromList(*vm.Host.ID, hosts)
-			if host == nil {
-				ctx.Logger.Info("Host not found, skip selecting host for VM", "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
-			} else {
-				ok, message := service.IsAvailableHost(host, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-				if ok {
-					ctx.Logger.Info("Selected the host server for VM since the placement group is full", "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
-
-					return *vm.Host.ID, nil
-				}
-
-				ctx.Logger.Info(fmt.Sprintf("Host is unavailable: %s, skip selecting host for VM", message), "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
-			}
-		}
-	}
-
-	return "", nil
-}
-
-// getHostsInPlacementGroup returns the hosts where all virtual machines of placement group located.
-func (r *ElfMachineReconciler) getHostsInPlacementGroup(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup) (sets.Set[string], error) {
-	placementGroupVMSet := sets.Set[string]{}
-	for i := 0; i < len(placementGroup.Vms); i++ {
-		placementGroupVMSet.Insert(*placementGroup.Vms[i].ID)
-	}
-
-	vms, err := ctx.VMService.FindByIDs(placementGroupVMSet.UnsortedList())
-	if err != nil {
-		return nil, err
-	}
-
-	hostSet := sets.Set[string]{}
-	for i := 0; i < len(vms); i++ {
-		hostSet.Insert(*vms[i].Host.ID)
-	}
-
-	return hostSet, nil
-}
-
-// getAvailableHosts returns available hosts.
-func (r *ElfMachineReconciler) getAvailableHosts(ctx *context.MachineContext, hosts []*models.Host, usedHostSet sets.Set[string], vm *models.VM) []*models.Host {
-	var availableHosts []*models.Host
-	// If the VM is running, and the host where the VM is located
-	// is not used by the placement group, then it is not necessary to
-	// check the memory is sufficient to determine whether the host is available.
-	// Otherwise, the VM may need to be migrated to another host,
-	// and need to check whether the memory is sufficient.
-	if *vm.Status == models.VMStatusRUNNING {
-		availableHosts = service.GetAvailableHosts(hosts, 0)
-		unusedHostSet := service.HostsToSet(availableHosts).Difference(usedHostSet)
-		if !unusedHostSet.Has(*vm.Host.ID) {
-			availableHosts = service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-		}
-	} else {
-		availableHosts = service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
-	}
-
-	return availableHosts
 }
 
 func (r *ElfMachineReconciler) reconcileProviderID(ctx *context.MachineContext, vm *models.VM) error {

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -67,7 +67,7 @@ import (
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
-// ElfMachineReconciler reconciles a ElfMachine object.
+// ElfMachineReconciler reconciles an ElfMachine object.
 type ElfMachineReconciler struct {
 	*context.ControllerContext
 	NewVMService service.NewVMServiceFunc

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -116,14 +116,14 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 
 // preCheckPlacementGroup checks whether there are still available hosts before creating the virtual machine.
 //
-// rethost:
+// The return value:
 // 1. nil means there are not enough hosts.
 // 2. An empty string indicates that there is an available host.
 // 3. A non-empty string indicates that the specified host ID was returned.
 func (r *ElfMachineReconciler) preCheckPlacementGroup(ctx *context.MachineContext) (rethost *string, reterr error) {
 	defer func() {
 		if rethost == nil {
-			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForAvailableHostReason, clusterv1.ConditionSeverityInfo, "")
+			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForAvailableHostRequiredByPlacementGroupReason, clusterv1.ConditionSeverityInfo, "")
 		}
 	}()
 
@@ -258,7 +258,7 @@ func (r *ElfMachineReconciler) getVMHostForRollingUpdate(ctx *context.MachineCon
 
 // getHostsInPlacementGroup returns the hosts where all virtual machines of placement group located.
 func (r *ElfMachineReconciler) getHostsInPlacementGroup(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup) (sets.Set[string], error) {
-	placementGroupVMSet := service.GetPlacementGroupVMSet(placementGroup)
+	placementGroupVMSet := service.GetVMsInPlacementGroup(placementGroup)
 	vms, err := ctx.VMService.FindByIDs(placementGroupVMSet.UnsortedList())
 	if err != nil {
 		return nil, err
@@ -335,7 +335,7 @@ func (r *ElfMachineReconciler) joinPlacementGroup(ctx *context.MachineContext, v
 		return false, err
 	}
 
-	placementGroupVMSet := service.GetPlacementGroupVMSet(placementGroup)
+	placementGroupVMSet := service.GetVMsInPlacementGroup(placementGroup)
 	if placementGroupVMSet.Has(*vm.ID) {
 		return true, nil
 	}

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -1,0 +1,516 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
+	kcputil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/kcp"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
+)
+
+// reconcilePlacementGroup makes sure that the placement group exist.
+func (r *ElfMachineReconciler) reconcilePlacementGroup(ctx *context.MachineContext) (reconcile.Result, error) {
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if placementGroup, err := r.getPlacementGroup(ctx, placementGroupName); err != nil {
+		if !service.IsVMPlacementGroupNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		if ok := acquireTicketForPlacementGroupOperation(placementGroupName); ok {
+			defer releaseTicketForPlacementGroupOperation(placementGroupName)
+		} else {
+			return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
+		}
+
+		if placementGroup, err := r.createPlacementGroup(ctx, placementGroupName); err != nil {
+			return reconcile.Result{}, err
+		} else if placementGroup == nil {
+			return reconcile.Result{RequeueAfter: config.VMPlacementGroupDuplicateTimeout}, err
+		}
+	} else if placementGroup == nil {
+		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext, placementGroupName string) (*models.VMPlacementGroup, error) {
+	// TODO: This will be removed when Tower fixes issue with placement group data syncing.
+	if ok := canCreatePlacementGroup(placementGroupName); !ok {
+		ctx.Logger.V(2).Info(fmt.Sprintf("Tower has duplicate placement group, skip creating placement group %s", placementGroupName))
+
+		return nil, nil
+	}
+
+	towerCluster, err := ctx.VMService.GetCluster(ctx.ElfCluster.Spec.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	placementGroupPolicy := towerresources.GetVMPlacementGroupPolicy(ctx.Machine)
+	withTaskVMPlacementGroup, err := ctx.VMService.CreateVMPlacementGroup(placementGroupName, *towerCluster.ID, placementGroupPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeout, config.WaitTaskInterval)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)
+	}
+
+	if *task.Status == models.TaskStatusFAILED {
+		if service.IsVMPlacementGroupDuplicate(service.GetTowerString(task.ErrorMessage)) {
+			setPlacementGroupDuplicate(placementGroupName)
+
+			ctx.Logger.Info(fmt.Sprintf("Duplicate placement group detected, will try again in %s", placementGroupSilenceTime), "placementGroup", placementGroupName)
+		}
+
+		return nil, errors.Errorf("failed to create placement group %s in task %s", placementGroupName, *task.ID)
+	}
+
+	ctx.Logger.Info("Creating placement group succeeded", "taskID", *task.ID, "placementGroup", placementGroupName)
+
+	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	return placementGroup, nil
+}
+
+// preCheckPlacementGroup checks whether there are still available hosts before creating the virtual machine.
+//
+// rethost:
+// 1. nil means there are not enough hosts.
+// 2. An empty string indicates that there is an available host.
+// 3. A non-empty string indicates that the specified host ID was returned.
+func (r *ElfMachineReconciler) preCheckPlacementGroup(ctx *context.MachineContext) (rethost *string, reterr error) {
+	defer func() {
+		if rethost == nil {
+			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForAvailableHostReason, clusterv1.ConditionSeverityInfo, "")
+		}
+	}()
+
+	if !machineutil.IsControlPlaneMachine(ctx.Machine) {
+		return pointer.String(""), nil
+	}
+
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	placementGroup, err := r.getPlacementGroup(ctx, placementGroupName)
+	if err != nil || placementGroup == nil {
+		return nil, err
+	}
+
+	usedHostSet, err := r.getHostsInPlacementGroup(ctx, placementGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	hosts, err := ctx.VMService.GetHostsByCluster(ctx.ElfCluster.Spec.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	availableHosts := service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+	if len(availableHosts) < len(hosts) {
+		unavailableHostInfo := service.GetUnavailableHostInfo(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+		ctx.Logger.V(1).Info("Unavailable hosts found", "unavailableHosts", unavailableHostInfo, "placementGroup", *placementGroup.Name, "vmRef", ctx.ElfMachine.Status.VMRef)
+	}
+
+	availableHostSet := service.HostsToSet(availableHosts)
+	unusedHostSet := availableHostSet.Difference(usedHostSet)
+
+	kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
+	if err != nil {
+		return nil, err
+	}
+
+	if !kcputil.IsKCPInRollingUpdate(kcp) {
+		if unusedHostSet.Len() != 0 {
+			return pointer.String(""), nil
+		}
+
+		ctx.Logger.V(2).Info("The placement group is full, wait for enough available hosts", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList())
+
+		return nil, nil
+	}
+
+	// KCP is in rolling update.
+
+	if unusedHostSet.Len() != 0 {
+		ctx.Logger.V(2).Info("The placement group still has capacity, skip selecting host for rolling update", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "unusedHosts", unusedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef)
+
+		return pointer.String(""), nil
+	}
+
+	if !service.ContainsUnavailableHost(hosts, usedHostSet.UnsortedList(), *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB)) &&
+		int(*kcp.Spec.Replicas) == usedHostSet.Len() {
+		// Only when KCP is in rolling update and the placement group is full
+		// does it need to get the latest created machine.
+		hostID, err := r.getVMHostForRollingUpdate(ctx, placementGroup, hosts)
+		if err != nil || hostID == "" {
+			return nil, err
+		}
+
+		return pointer.String(hostID), err
+	}
+
+	ctx.Logger.V(2).Info("The placement group is full, wait for enough available hosts", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList())
+
+	return nil, nil
+}
+
+// getVMHostForRollingUpdate returns the target host server id for a virtual machine during rolling update.
+// During KCP rolling update, machines will be deleted in the order of creation.
+// Find the latest created machine in the placement group,
+// and set the host where the machine is located to the first machine created by KCP rolling update.
+// This prevents migration of virtual machine during KCP rolling update when using a placement group.
+func (r *ElfMachineReconciler) getVMHostForRollingUpdate(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup, hosts []*models.Host) (string, error) {
+	elfMachines, err := machineutil.GetControlPlaneElfMachinesInCluster(ctx, ctx.Client, ctx.Cluster.Namespace, ctx.Cluster.Name)
+	if err != nil {
+		return "", err
+	}
+
+	elfMachineMap := make(map[string]*infrav1.ElfMachine)
+	for i := 0; i < len(elfMachines); i++ {
+		if machineutil.IsUUID(elfMachines[i].Status.VMRef) {
+			elfMachineMap[elfMachines[i].Name] = elfMachines[i]
+		}
+	}
+
+	placementGroupMachines := make([]*clusterv1.Machine, 0, len(placementGroup.Vms))
+	vmMap := make(map[string]string)
+	for i := 0; i < len(placementGroup.Vms); i++ {
+		if elfMachine, ok := elfMachineMap[*placementGroup.Vms[i].Name]; ok {
+			machine, err := capiutil.GetOwnerMachine(r, r.Client, elfMachine.ObjectMeta)
+			if err != nil {
+				return "", err
+			}
+
+			placementGroupMachines = append(placementGroupMachines, machine)
+			vmMap[machine.Name] = *(placementGroup.Vms[i].ID)
+		}
+	}
+
+	machines := collections.FromMachines(placementGroupMachines...)
+	if machine := machines.Newest(); machine != nil {
+		if vm, err := ctx.VMService.Get(vmMap[machine.Name]); err != nil {
+			return "", err
+		} else {
+			host := service.GetHostFromList(*vm.Host.ID, hosts)
+			if host == nil {
+				ctx.Logger.Info("Host not found, skip selecting host for VM", "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
+			} else {
+				ok, message := service.IsAvailableHost(host, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+				if ok {
+					ctx.Logger.Info("Selected the host server for VM since the placement group is full", "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
+
+					return *vm.Host.ID, nil
+				}
+
+				ctx.Logger.Info(fmt.Sprintf("Host is unavailable: %s, skip selecting host for VM", message), "hostID", *vm.Host.ID, "vmRef", ctx.ElfMachine.Status.VMRef)
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// getHostsInPlacementGroup returns the hosts where all virtual machines of placement group located.
+func (r *ElfMachineReconciler) getHostsInPlacementGroup(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup) (sets.Set[string], error) {
+	placementGroupVMSet := service.GetPlacementGroupVMSet(placementGroup)
+	vms, err := ctx.VMService.FindByIDs(placementGroupVMSet.UnsortedList())
+	if err != nil {
+		return nil, err
+	}
+
+	hostSet := sets.Set[string]{}
+	for i := 0; i < len(vms); i++ {
+		hostSet.Insert(*vms[i].Host.ID)
+	}
+
+	return hostSet, nil
+}
+
+// getAvailableHosts returns available hosts.
+func (r *ElfMachineReconciler) getAvailableHosts(ctx *context.MachineContext, hosts []*models.Host, usedHostSet sets.Set[string], vm *models.VM) []*models.Host {
+	var availableHosts []*models.Host
+	// If the VM is running, and the host where the VM is located
+	// is not used by the placement group, then it is not necessary to
+	// check the memory is sufficient to determine whether the host is available.
+	// Otherwise, the VM may need to be migrated to another host,
+	// and need to check whether the memory is sufficient.
+	if *vm.Status == models.VMStatusRUNNING {
+		availableHosts = service.GetAvailableHosts(hosts, 0)
+		unusedHostSet := service.HostsToSet(availableHosts).Difference(usedHostSet)
+		if !unusedHostSet.Has(*vm.Host.ID) {
+			availableHosts = service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+		}
+	} else {
+		availableHosts = service.GetAvailableHosts(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+	}
+
+	return availableHosts
+}
+
+func (r *ElfMachineReconciler) getPlacementGroup(ctx *context.MachineContext, placementGroupName string) (*models.VMPlacementGroup, error) {
+	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Placement group is performing an operation
+	if !machineutil.IsUUID(*placementGroup.LocalID) || placementGroup.EntityAsyncStatus != nil {
+		ctx.Logger.Info("Waiting for placement group task done", "placementGroup", *placementGroup.Name)
+
+		return nil, nil
+	}
+
+	return placementGroup, nil
+}
+
+// joinPlacementGroup puts the virtual machine into the placement group.
+func (r *ElfMachineReconciler) joinPlacementGroup(ctx *context.MachineContext, vm *models.VM) (ret bool, reterr error) {
+	defer func() {
+		if reterr != nil {
+			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.JoiningPlacementGroupFailedReason, clusterv1.ConditionSeverityWarning, reterr.Error())
+		} else if !ret {
+			conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.JoiningPlacementGroupReason, clusterv1.ConditionSeverityInfo, "")
+		}
+	}()
+
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
+	if err != nil {
+		return false, err
+	}
+
+	if ok := acquireTicketForPlacementGroupOperation(placementGroupName); ok {
+		defer releaseTicketForPlacementGroupOperation(placementGroupName)
+	} else {
+		return false, nil
+	}
+
+	placementGroup, err := r.getPlacementGroup(ctx, placementGroupName)
+	if err != nil || placementGroup == nil {
+		return false, err
+	}
+
+	placementGroupVMSet := service.GetPlacementGroupVMSet(placementGroup)
+	if placementGroupVMSet.Has(*vm.ID) {
+		return true, nil
+	}
+
+	if machineutil.IsControlPlaneMachine(ctx.Machine) {
+		usedHostSet, err := r.getHostsInPlacementGroup(ctx, placementGroup)
+		if err != nil {
+			return false, err
+		}
+
+		hosts, err := ctx.VMService.GetHostsByCluster(ctx.ElfCluster.Spec.Cluster)
+		if err != nil {
+			return false, err
+		}
+
+		availableHosts := r.getAvailableHosts(ctx, hosts, usedHostSet, vm)
+		if len(availableHosts) < len(hosts) {
+			unavailableHostInfo := service.GetUnavailableHostInfo(hosts, *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
+			ctx.Logger.Info("Unavailable hosts found", "unavailableHosts", unavailableHostInfo, "placementGroup", *placementGroup.Name, "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+		}
+
+		availableHostSet := service.HostsToSet(availableHosts)
+		unusedHostSet := availableHostSet.Difference(usedHostSet)
+		if unusedHostSet.Len() == 0 {
+			kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
+			if err != nil {
+				return false, err
+			}
+
+			// Only when the KCP is in rolling update, the VM is stopped, and all the hosts used by the placement group are available,
+			// will the upgrade be allowed with the same number of hosts and CP nodes.
+			// In this case first machine created by KCP rolling update can be powered on without being added to the placement group.
+			if kcputil.IsKCPInRollingUpdate(kcp) &&
+				*vm.Status == models.VMStatusSTOPPED &&
+				!service.ContainsUnavailableHost(hosts, usedHostSet.UnsortedList(), *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB)) &&
+				int(*kcp.Spec.Replicas) == usedHostSet.Len() {
+				ctx.Logger.Info("The placement group is full and KCP is in rolling update, skip adding VM to the placement group", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+
+				return true, nil
+			}
+
+			if *vm.Status == models.VMStatusRUNNING || *vm.Status == models.VMStatusSUSPENDED {
+				ctx.Logger.V(2).Info(fmt.Sprintf("The placement group is full and VM is in %s status, skip adding VM to the placement group", *vm.Status), "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+
+				return true, nil
+			}
+
+			// KCP is scaling out or being created.
+			ctx.Logger.V(2).Info("The placement group is full, wait for enough available hosts", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+
+			return false, nil
+		}
+
+		if !unusedHostSet.Has(*vm.Host.ID) && *vm.Status != models.VMStatusSTOPPED {
+			return r.migrateVMForPlacementGroup(ctx, vm, placementGroup, unusedHostSet.UnsortedList()[0])
+		}
+	}
+
+	if !placementGroupVMSet.Has(*vm.ID) {
+		placementGroupVMSet.Insert(*vm.ID)
+		if err := r.addVMsToPlacementGroup(ctx, placementGroup, placementGroupVMSet.UnsortedList()); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// migrateVMForPlacementGroup migrates the virtual machine to the specified target host.
+func (r *ElfMachineReconciler) migrateVMForPlacementGroup(ctx *context.MachineContext, vm *models.VM, placementGroup *models.VMPlacementGroup, targetHost string) (bool, error) {
+	kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
+	if err != nil {
+		return false, err
+	}
+
+	if *kcp.Spec.Replicas != kcp.Status.UpdatedReplicas {
+		ctx.Logger.Info("KCP rolling update in progress, skip migrating VM", "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+
+		return true, nil
+	}
+
+	if ok := acquireTicketForPlacementGroupVMMigration(*placementGroup.Name); !ok {
+		ctx.Logger.V(1).Info("The placement group is performing another VM migration, skip migrating VM", "placementGroup", service.GetTowerString(placementGroup.Name), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)
+
+		return false, nil
+	}
+
+	withTaskVM, err := ctx.VMService.Migrate(service.GetTowerString(vm.ID), targetHost)
+	if err != nil {
+		return false, err
+	}
+
+	ctx.ElfMachine.SetTask(*withTaskVM.TaskID)
+
+	ctx.Logger.Info(fmt.Sprintf("Waiting for the VM to be migrated from %s to %s", *vm.Host.ID, targetHost), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID, "taskRef", ctx.ElfMachine.Status.TaskRef)
+
+	return false, nil
+}
+
+func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContext, placementGroup *models.VMPlacementGroup, vmIDs []string) error {
+	task, err := ctx.VMService.AddVMsToPlacementGroup(placementGroup, vmIDs)
+	if err != nil {
+		return err
+	}
+
+	taskID := *task.ID
+	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
+	if err != nil {
+		return errors.Wrapf(err, "failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, taskID)
+	}
+
+	if *task.Status == models.TaskStatusFAILED {
+		return errors.Errorf("failed to update placement group %s in task %s", *placementGroup.Name, taskID)
+	}
+
+	ctx.Logger.Info("Updating placement group succeeded", "taskID", taskID, "placementGroup", *placementGroup.Name, "vmIDs", vmIDs)
+
+	return nil
+}
+
+// deletePlacementGroup deletes the placement group when the MachineDeployment is deleted
+// and the cluster is not deleted.
+// If the cluster is deleted, all placement groups are deleted by the ElfCluster controller.
+func (r *ElfMachineReconciler) deletePlacementGroup(ctx *context.MachineContext) (bool, error) {
+	if !ctx.Cluster.DeletionTimestamp.IsZero() || machineutil.IsControlPlaneMachine(ctx.Machine) {
+		return true, nil
+	}
+
+	md, err := machineutil.GetMDByMachine(ctx, ctx.Client, ctx.Machine)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, err
+	}
+
+	// SKS will set replicas to 0 before deleting the MachineDeployment,
+	// and then delete it after all the machines are deleted.
+	// In this scenario, CAPE needs to delete the placement group first
+	// when md.Spec.Replicas is 0.
+	if md.DeletionTimestamp.IsZero() && *md.Spec.Replicas > 0 {
+		return true, nil
+	}
+
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
+	if err != nil {
+		return false, err
+	}
+
+	// Only delete the placement groups created by CAPE.
+	if !strings.HasPrefix(placementGroupName, towerresources.GetVMPlacementGroupNamePrefix(ctx.Cluster)) {
+		return true, nil
+	}
+
+	placementGroup, err := ctx.VMService.GetVMPlacementGroup(placementGroupName)
+	if err != nil {
+		if service.IsVMPlacementGroupNotFound(err) {
+			return true, nil
+		}
+
+		return false, err
+	}
+
+	if ok := acquireTicketForPlacementGroupOperation(*placementGroup.Name); ok {
+		defer releaseTicketForPlacementGroupOperation(*placementGroup.Name)
+	} else {
+		return false, nil
+	}
+
+	if err := ctx.VMService.DeleteVMPlacementGroupsByName(*placementGroup.Name); err != nil {
+		return false, err
+	} else {
+		ctx.Logger.Info(fmt.Sprintf("Placement group %s deleted", *placementGroup.Name))
+	}
+
+	return true, nil
+}

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1320,7 +1320,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(err).To(BeZero())
 				Expect(hostID).To(BeNil())
 				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
-				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForAvailableHostReason}})
+				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForAvailableHostRequiredByPlacementGroupReason}})
 
 				elfMachine.Status.Conditions = nil
 				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
@@ -1460,7 +1460,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 	})
 
-	Context("Delete a ElfMachine", func() {
+	Context("Delete an ElfMachine", func() {
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
 			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -219,10 +219,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 	})
 
 	Context("Reconcile ElfMachine VM", func() {
+		var placementGroup *models.VMPlacementGroup
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
 			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
 			machine.Spec.Bootstrap = clusterv1.Bootstrap{DataSecretName: &secret.Name}
+
+			placementGroup = fake.NewVMPlacementGroup([]string{fake.ID()})
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 		})
 
 		It("should set CloningFailedReason condition when failed to retrieve bootstrap data", func() {
@@ -304,7 +308,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should allow VM to be temporarily disconnected", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusRUNNING
@@ -319,7 +322,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return([]*models.VMNic{nic}, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
@@ -349,6 +351,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(elfMachine.GetVMDisconnectionTimestamp()).NotTo(BeNil())
 
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			patchHelper, err := patch.NewHelper(elfMachine, reconciler.Client)
 			Expect(err).ToNot(HaveOccurred())
 			now := metav1.NewTime(time.Now().Add(-infrav1.VMDisconnectionTimeout))
@@ -440,7 +443,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should power on the VM after it is created", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
@@ -456,7 +458,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOn(*vm.LocalID).Return(task2, nil)
@@ -504,7 +505,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should handle power on error", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
@@ -519,7 +519,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOn(*vm.LocalID).Return(nil, errors.New("some error"))
@@ -537,7 +536,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It(" handle power on task failure", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
@@ -553,7 +551,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOn(*vm.LocalID).Return(task2, nil)
@@ -573,7 +570,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should power off the VM when vm is in SUSPENDED status", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSUSPENDED
@@ -589,7 +585,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOff(*vm.LocalID).Return(task2, nil)
@@ -608,7 +603,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should handle power off error", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSUSPENDED
@@ -623,7 +617,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task1, nil)
 			mockVMService.EXPECT().PowerOff(*vm.LocalID).Return(nil, errors.New("some error"))
@@ -751,15 +744,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 	})
 
-	Context("Reconcile Placement Group", func() {
+	Context("Reconcile Join Placement Group", func() {
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
 			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
 			machine.Spec.Bootstrap = clusterv1.Bootstrap{DataSecretName: &secret.Name}
 		})
 
-		It("should create a new placement group and add vm to the placement group", func() {
-			towerCluster := fake.NewTowerCluster()
+		It("should add vm to the placement group", func() {
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
@@ -767,93 +759,21 @@ var _ = Describe("ElfMachineReconciler", func() {
 			task := fake.NewTowerTask()
 			taskStatus := models.TaskStatusSUCCESSED
 			task.Status = &taskStatus
-			withTaskVMPlacementGroup := fake.NewWithTaskVMPlacementGroup(nil, task)
 			elfMachine.Status.VMRef = *vm.LocalID
 			placementGroup := fake.NewVMPlacementGroup(nil)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Times(2).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+			ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 			Expect(ok).To(BeTrue())
 			Expect(err).To(BeZero())
-			Expect(logBuffer.String()).To(ContainSubstring("Creating placement group succeeded"))
 			Expect(logBuffer.String()).To(ContainSubstring("Updating placement group succeeded"))
-		})
-
-		It("createPlacementGroup", func() {
-			towerCluster := fake.NewTowerCluster()
-			vm := fake.NewTowerVM()
-			vm.EntityAsyncStatus = nil
-			status := models.VMStatusSTOPPED
-			vm.Status = &status
-			task := fake.NewTowerTask()
-			taskStatus := models.TaskStatusSUCCESSED
-			task.Status = &taskStatus
-			withTaskVMPlacementGroup := fake.NewWithTaskVMPlacementGroup(nil, task)
-			elfMachine.Status.VMRef = *vm.LocalID
-			placementGroup := fake.NewVMPlacementGroup(nil)
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
-			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-
-			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			pg, err := reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
-			Expect(err).To(BeZero())
-			Expect(*pg.Name).To(Equal(*placementGroup.Name))
-			Expect(logBuffer.String()).To(ContainSubstring("Creating placement group succeeded"))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			taskStatus = models.TaskStatusFAILED
-			task.Status = &taskStatus
-			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
-
-			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
-			Expect(pg).To(BeNil())
-			Expect(strings.Contains(err.Error(), "failed to create placement group")).To(BeTrue())
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
-
-			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
-			Expect(pg).To(BeNil())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, *withTaskVMPlacementGroup.TaskID)))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
-			task.ErrorMessage = pointer.String(service.VMPlacementGroupDuplicate)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
-			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
-			Expect(pg).To(BeNil())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to create placement group"))
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Duplicate placement group detected, will try again in %s", placementGroupSilenceTime)))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			pg, err = reconciler.createPlacementGroup(machineContext, *placementGroup.Name, *towerCluster.ID)
-			Expect(pg).To(BeNil())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Tower has duplicate placement group, skip creating placement group %s", *placementGroup.Name)))
 		})
 
 		It("addVMsToPlacementGroup", func() {
@@ -901,18 +821,18 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should wait for placement group task done", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
-			placementGroup := fake.NewVMPlacementGroup(nil)
-			placementGroup.EntityAsyncStatus = models.EntityAsyncStatusUPDATING.Pointer()
+			placementGroup1 := fake.NewVMPlacementGroup(nil)
+			placementGroup2 := fake.NewVMPlacementGroup(nil)
+			placementGroup2.EntityAsyncStatus = models.EntityAsyncStatusUPDATING.Pointer()
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup1, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup2, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -926,17 +846,17 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should handle placement group error", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVM()
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
 			vm.Status = &status
 			elfMachine.Status.VMRef = *vm.LocalID
+			placementGroup := fake.NewVMPlacementGroup(nil)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New("some error"))
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -960,7 +880,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			})
 
 			It("should not check whether the memory of host is sufficient when VM is running and the host where the VM is located is not used", func() {
-				towerCluster := fake.NewTowerCluster()
 				host := fake.NewTowerHost()
 				host.AllocatableMemoryBytes = service.TowerMemory(0)
 				vm := fake.NewTowerVMFromElfMachine(elfMachine)
@@ -972,22 +891,20 @@ var _ = Describe("ElfMachineReconciler", func() {
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{}).Return([]*models.VM{}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
 				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Updating placement group succeeded"))
 			})
 
 			It("should not be added when placement group is full", func() {
-				towerCluster := fake.NewTowerCluster()
 				host := fake.NewTowerHost()
 				vm := fake.NewTowerVM()
 				vm.Status = models.NewVMStatus(models.VMStatusSTOPPED)
@@ -1003,13 +920,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{vm2}, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full and KCP is in rolling update, skip adding VM to the placement group"))
@@ -1017,13 +933,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 				logBuffer = new(bytes.Buffer)
 				klog.SetOutput(logBuffer)
 				host.HostState = &models.NestedMaintenanceHostState{State: models.NewMaintenanceModeEnum(models.MaintenanceModeEnumMAINTENANCEMODE)}
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{}, nil)
 
 				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err = reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err = reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
@@ -1033,13 +948,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 				klog.SetOutput(logBuffer)
 				vm.Status = models.NewVMStatus(models.VMStatusRUNNING)
 				host.HostState = &models.NestedMaintenanceHostState{State: models.NewMaintenanceModeEnum(models.MaintenanceModeEnumMAINTENANCEMODE)}
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{}, nil)
 
 				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err = reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err = reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
@@ -1047,7 +961,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			})
 
 			It("should add VM to placement group when VM is not in placement group and the host where VM in is not in placement group", func() {
-				towerCluster := fake.NewTowerCluster()
 				host1 := fake.NewTowerHost()
 				host2 := fake.NewTowerHost()
 				host3 := fake.NewTowerHost()
@@ -1066,15 +979,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, gomock.Any()).Return(task, nil)
 				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
@@ -1082,7 +994,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			})
 
 			It("should not migrate VM when VM is running and kcp.Spec.Replicas != kcp.Status.UpdatedReplicas", func() {
-				towerCluster := fake.NewTowerCluster()
 				host1 := fake.NewTowerHost()
 				host2 := fake.NewTowerHost()
 				host3 := fake.NewTowerHost()
@@ -1103,13 +1014,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
@@ -1117,7 +1027,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			})
 
 			It("should migrate VM to another host when the VM is running and the host of VM is not in unused hosts", func() {
-				towerCluster := fake.NewTowerCluster()
 				host1 := fake.NewTowerHost()
 				host2 := fake.NewTowerHost()
 				vm := fake.NewTowerVM()
@@ -1137,14 +1046,13 @@ var _ = Describe("ElfMachineReconciler", func() {
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
-				mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
-				mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2}, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2}, nil)
 				mockVMService.EXPECT().Migrate(*vm.ID, *host1.ID).Return(withTaskVM, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err := reconciler.reconcilePlacementGroup(machineContext, vm)
+				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
 				Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
@@ -1154,7 +1062,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 	})
 
-	Context("Reconcile VM Host", func() {
+	Context("Pre Check Placement Group", func() {
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
 			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
@@ -1163,175 +1071,279 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.ToControlPlaneMachine(elfMachine, kcp)
 		})
 
-		It("should not set host when kcp.Spec.Replicas > kcp.Status.Replicas", func() {
-			kcp.Spec.Replicas = pointer.Int32(1)
-			kcp.Status.Replicas = 0
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp)
-			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		Context("Rolling Update", func() {
+			It("when placement group is full", func() {
+				host := fake.NewTowerHost()
+				elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
+				elfMachine2, machine2 := fake.NewMachineObjects(elfCluster, cluster)
+				elfMachine3, machine3 := fake.NewMachineObjects(elfCluster, cluster)
+				vm1 := fake.NewTowerVMFromElfMachine(elfMachine1)
+				vm1.Host = &models.NestedHost{ID: service.TowerString(*host.ID)}
+				vm2 := fake.NewTowerVMFromElfMachine(elfMachine2)
+				vm2.Host = &models.NestedHost{ID: service.TowerString(*host.ID)}
+				vm3 := fake.NewTowerVMFromElfMachine(elfMachine3)
+				vm3.Host = &models.NestedHost{ID: service.TowerString(*host.ID)}
+				elfMachine1.Status.VMRef = *vm1.LocalID
+				elfMachine2.Status.VMRef = *vm2.LocalID
+				elfMachine3.Status.VMRef = *vm3.LocalID
+				vm := fake.NewTowerVM()
+				elfMachine.Status.VMRef = *vm.LocalID
+				placementGroup := fake.NewVMPlacementGroup([]string{})
+				placementGroup.Vms = []*models.NestedVM{}
+				kcp.Spec.Replicas = pointer.Int32(3)
+				kcp.Status.Replicas = 3
+				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp, elfMachine1, machine1, elfMachine2, machine2, elfMachine3, machine3)
+				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine1, machine1)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine2, machine2)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine3, machine3)
+				placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+				Expect(err).NotTo(HaveOccurred())
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			host, err := reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(host).To(BeEmpty())
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{})).Return([]*models.VM{}, nil)
+
+				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err := reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(*hostID).To(Equal(""))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				placementGroup.Vms = []*models.NestedVM{{ID: vm1.ID, Name: vm1.Name}}
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID})).Return([]*models.VM{vm1}, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
+			})
+
+			It("when placement group is full", func() {
+				host1 := fake.NewTowerHost()
+				host2 := fake.NewTowerHost()
+				host3 := fake.NewTowerHost()
+				elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
+				elfMachine2, machine2 := fake.NewMachineObjects(elfCluster, cluster)
+				elfMachine3, machine3 := fake.NewMachineObjects(elfCluster, cluster)
+				machine1.CreationTimestamp = metav1.Now()
+				machine2.CreationTimestamp = metav1.NewTime(time.Now().Add(1 * time.Minute))
+				machine3.CreationTimestamp = metav1.NewTime(time.Now().Add(2 * time.Minute))
+				fake.ToControlPlaneMachine(machine1, kcp)
+				fake.ToControlPlaneMachine(elfMachine1, kcp)
+				fake.ToControlPlaneMachine(machine2, kcp)
+				fake.ToControlPlaneMachine(elfMachine2, kcp)
+				fake.ToControlPlaneMachine(machine3, kcp)
+				fake.ToControlPlaneMachine(elfMachine3, kcp)
+				vm1 := fake.NewTowerVMFromElfMachine(elfMachine1)
+				vm1.Host = &models.NestedHost{ID: service.TowerString(*host1.ID)}
+				vm2 := fake.NewTowerVMFromElfMachine(elfMachine2)
+				vm2.Host = &models.NestedHost{ID: service.TowerString(*host2.ID)}
+				vm3 := fake.NewTowerVMFromElfMachine(elfMachine3)
+				vm3.Host = &models.NestedHost{ID: service.TowerString(*host3.ID)}
+				elfMachine1.Status.VMRef = *vm1.LocalID
+				elfMachine2.Status.VMRef = *vm2.LocalID
+				elfMachine3.Status.VMRef = *vm3.LocalID
+				vm := fake.NewTowerVM()
+				elfMachine.Status.VMRef = *vm.LocalID
+				placementGroup := fake.NewVMPlacementGroup([]string{})
+				placementGroup.Vms = []*models.NestedVM{
+					{ID: vm1.ID, Name: vm1.Name},
+					{ID: vm2.ID, Name: vm2.Name},
+					{ID: vm3.ID, Name: vm3.Name},
+				}
+				kcp.Spec.Replicas = pointer.Int32(3)
+				kcp.Status.Replicas = 3
+				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp, elfMachine1, machine1, elfMachine2, machine2, elfMachine3, machine3)
+				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine1, machine1)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine2, machine2)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine3, machine3)
+				placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
+
+				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				host, err := reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(*host).To(Equal(*vm3.Host.ID))
+
+				// One of the hosts is unavailable.
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				host1.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				host, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(host).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				host1.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
+				host2.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				host, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(host).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				host2.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
+				host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2, host3}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				host, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(host).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
+				hosts := []*models.Host{host1, host2, host3}
+				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err := reconciler.getVMHostForRollingUpdate(machineContext, placementGroup, hosts)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(Equal(""))
+				Expect(logBuffer.String()).To(ContainSubstring("Host is unavailable: host is in CONNECTED_ERROR status, skip selecting host for VM"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				vm3.Host.ID = service.TowerString(fake.UUID())
+				hosts = []*models.Host{host1, host2, host3}
+				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.getVMHostForRollingUpdate(machineContext, placementGroup, hosts)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(Equal(""))
+				Expect(logBuffer.String()).To(ContainSubstring("Host not found, skip selecting host for VM"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				vm3.Host = &models.NestedHost{ID: service.TowerString(*host3.ID)}
+				host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
+				host4 := fake.NewTowerHost()
+				host4.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
+				vm4 := fake.NewTowerVMFromElfMachine(elfMachine1)
+				vm4.Host = &models.NestedHost{ID: service.TowerString(*host4.ID)}
+				hosts = []*models.Host{host1, host2, host3, host4}
+				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.getVMHostForRollingUpdate(machineContext, placementGroup, hosts)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(Equal(*vm3.Host.ID))
+				Expect(logBuffer.String()).To(ContainSubstring("Selected the host server for VM since the placement group is full"))
+
+				logBuffer = new(bytes.Buffer)
+				klog.SetOutput(logBuffer)
+				host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
+				hosts = []*models.Host{host1, host2, host3, host4}
+				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
+
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.getVMHostForRollingUpdate(machineContext, placementGroup, hosts)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(Equal(*vm3.Host.ID))
+				Expect(logBuffer.String()).To(ContainSubstring("Selected the host server for VM since the placement group is full"))
+			})
 		})
 
-		It("should not set host when placement group does not exist", func() {
-			kcp.Spec.Replicas = pointer.Int32(1)
-			kcp.Status.Replicas = 1
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp)
-			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		Context("Scale", func() {
+			It("kcp scale up", func() {
+				kcp.Spec.Replicas = pointer.Int32(2)
+				kcp.Status.Replicas = 1
+				host1 := fake.NewTowerHost()
+				host2 := fake.NewTowerHost()
+				elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
+				elfMachine2, machine2 := fake.NewMachineObjects(elfCluster, cluster)
+				machine1.CreationTimestamp = metav1.Now()
+				machine2.CreationTimestamp = metav1.NewTime(time.Now().Add(1 * time.Minute))
+				fake.ToControlPlaneMachine(machine1, kcp)
+				fake.ToControlPlaneMachine(elfMachine1, kcp)
+				fake.ToControlPlaneMachine(machine2, kcp)
+				fake.ToControlPlaneMachine(elfMachine2, kcp)
+				vm1 := fake.NewTowerVMFromElfMachine(elfMachine1)
+				vm1.Host = &models.NestedHost{ID: service.TowerString(*host1.ID)}
+				vm2 := fake.NewTowerVMFromElfMachine(elfMachine2)
+				vm2.Host = &models.NestedHost{ID: service.TowerString(*host2.ID)}
+				elfMachine1.Status.VMRef = *vm1.LocalID
+				elfMachine2.Status.VMRef = *vm2.LocalID
+				vm := fake.NewTowerVM()
+				elfMachine.Status.VMRef = *vm.LocalID
+				placementGroup := fake.NewVMPlacementGroup([]string{})
+				placementGroup.Vms = []*models.NestedVM{
+					{ID: vm1.ID, Name: vm1.Name},
+				}
+				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp)
+				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+				placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+				Expect(err).NotTo(HaveOccurred())
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID})).Return([]*models.VM{vm1}, nil)
 
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err := reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("The placement group is full, wait for enough available hosts"))
+				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForAvailableHostReason}})
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			host, err := reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(host).To(BeEmpty())
-		})
+				elfMachine.Status.Conditions = nil
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1, host2}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID})).Return([]*models.VM{vm1}, nil)
 
-		It("should not set host when placement group has capacity", func() {
-			towerCluster := fake.NewTowerCluster()
-			host1 := fake.NewTowerHost()
-			placementGroup := fake.NewVMPlacementGroup([]string{})
-			kcp.Spec.Replicas = pointer.Int32(1)
-			kcp.Status.Replicas = 1
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp)
-			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(*hostID).To(Equal(""))
+				expectConditions(elfMachine, []conditionAssertion{})
 
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().FindByIDs([]string{}).Return(nil, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1}, nil)
+				placementGroup.Vms = []*models.NestedVM{}
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host1}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{})).Return([]*models.VM{}, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			host, err := reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(host).To(BeEmpty())
-		})
-
-		It("should set host when placement group is full", func() {
-			towerCluster := fake.NewTowerCluster()
-			host1 := fake.NewTowerHost()
-			host2 := fake.NewTowerHost()
-			host3 := fake.NewTowerHost()
-			elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
-			elfMachine2, machine2 := fake.NewMachineObjects(elfCluster, cluster)
-			elfMachine3, machine3 := fake.NewMachineObjects(elfCluster, cluster)
-			machine1.CreationTimestamp = metav1.Now()
-			machine2.CreationTimestamp = metav1.NewTime(time.Now().Add(1 * time.Minute))
-			machine3.CreationTimestamp = metav1.NewTime(time.Now().Add(2 * time.Minute))
-			fake.ToControlPlaneMachine(machine1, kcp)
-			fake.ToControlPlaneMachine(elfMachine1, kcp)
-			fake.ToControlPlaneMachine(machine2, kcp)
-			fake.ToControlPlaneMachine(elfMachine2, kcp)
-			fake.ToControlPlaneMachine(machine3, kcp)
-			fake.ToControlPlaneMachine(elfMachine3, kcp)
-			vm1 := fake.NewTowerVMFromElfMachine(elfMachine1)
-			vm1.Host = &models.NestedHost{ID: service.TowerString(*host1.ID)}
-			vm2 := fake.NewTowerVMFromElfMachine(elfMachine2)
-			vm2.Host = &models.NestedHost{ID: service.TowerString(*host2.ID)}
-			vm3 := fake.NewTowerVMFromElfMachine(elfMachine3)
-			vm3.Host = &models.NestedHost{ID: service.TowerString(*host3.ID)}
-			elfMachine1.Status.VMRef = *vm1.LocalID
-			elfMachine2.Status.VMRef = *vm2.LocalID
-			elfMachine3.Status.VMRef = *vm3.LocalID
-			vm := fake.NewTowerVM()
-			elfMachine.Status.VMRef = *vm.LocalID
-			placementGroup := fake.NewVMPlacementGroup([]string{})
-			placementGroup.Vms = []*models.NestedVM{
-				{ID: vm1.ID, Name: vm1.Name},
-				{ID: vm2.ID, Name: vm2.Name},
-				{ID: vm3.ID, Name: vm3.Name},
-			}
-			kcp.Spec.Replicas = pointer.Int32(3)
-			kcp.Status.Replicas = 3
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp, elfMachine1, machine1, elfMachine2, machine2, elfMachine3, machine3)
-			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine1, machine1)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine2, machine2)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine3, machine3)
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3}, nil)
-			mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			hostID, err := reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(hostID).To(Equal(*vm3.Host.ID))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
-			mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3}, nil)
-			mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
-
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			hostID, err = reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(hostID).To(Equal(""))
-			Expect(logBuffer.String()).To(ContainSubstring("Host is unavailable: host is in CONNECTED_ERROR status, skip selecting host for VM"))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			vm3.Host.ID = service.TowerString(fake.UUID())
-			mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3}, nil)
-			mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
-
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			hostID, err = reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(hostID).To(Equal(""))
-			Expect(logBuffer.String()).To(ContainSubstring("Host not found, skip selecting host for VM"))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			vm3.Host = &models.NestedHost{ID: service.TowerString(*host3.ID)}
-			host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
-			host4 := fake.NewTowerHost()
-			host4.Status = models.NewHostStatus(models.HostStatusCONNECTEDERROR)
-			vm4 := fake.NewTowerVMFromElfMachine(elfMachine1)
-			vm4.Host = &models.NestedHost{ID: service.TowerString(*host4.ID)}
-			mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3, host4}, nil)
-			mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
-
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			hostID, err = reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(hostID).To(Equal(*vm3.Host.ID))
-			Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
-
-			logBuffer = new(bytes.Buffer)
-			klog.SetOutput(logBuffer)
-			host3.Status = models.NewHostStatus(models.HostStatusCONNECTEDHEALTHY)
-			mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-			mockVMService.EXPECT().GetHostsByCluster(*towerCluster.ID).Return([]*models.Host{host1, host2, host3, host4}, nil)
-			mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
-
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-			hostID, err = reconciler.getVMHostForRollingUpdate(machineContext)
-			Expect(err).To(BeZero())
-			Expect(hostID).To(Equal(*vm3.Host.ID))
-			Expect(logBuffer.String()).To(ContainSubstring("Unavailable hosts found"))
+				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err = reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(*hostID).To(Equal(""))
+				expectConditions(elfMachine, []conditionAssertion{})
+			})
 		})
 	})
 
@@ -1345,7 +1357,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 			cluster.Status.InfrastructureReady = true
 			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
 			machine.Spec.Bootstrap = clusterv1.Bootstrap{DataSecretName: &secret.Name}
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			elfMachine.Status.VMRef = *vm.LocalID
 			vm.EntityAsyncStatus = nil
@@ -1355,8 +1366,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return(nil, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(2).Return(placementGroup, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1376,7 +1386,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should wait VM network ready", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
@@ -1386,8 +1395,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Times(3).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return(nil, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Times(3).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(3).Return(placementGroup, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(6).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(9).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(3)
 
@@ -1425,7 +1433,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should set ElfMachine to ready when VM network is ready", func() {
-			towerCluster := fake.NewTowerCluster()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
@@ -1436,8 +1443,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return([]*models.VMNic{nic}, nil)
-			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
-			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(2).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
 
@@ -2056,6 +2062,106 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 	})
 
+	Context("Reconcile Placement Group", func() {
+		BeforeEach(func() {
+			cluster.Status.InfrastructureReady = true
+			conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
+			machine.Spec.Bootstrap = clusterv1.Bootstrap{DataSecretName: &secret.Name}
+		})
+
+		It("should makes sure that the placement group exist", func() {
+			towerCluster := fake.NewTowerCluster()
+			placementGroup := fake.NewVMPlacementGroup(nil)
+			placementGroup.EntityAsyncStatus = models.NewEntityAsyncStatus(models.EntityAsyncStatusUPDATING)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeueTimeout))
+			Expect(err).To(BeZero())
+
+			placementGroup.EntityAsyncStatus = nil
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(BeZero())
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			task := fake.NewTowerTask()
+			taskStatus := models.TaskStatusSUCCESSED
+			task.Status = &taskStatus
+			withTaskVMPlacementGroup := fake.NewWithTaskVMPlacementGroup(nil, task)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("Creating placement group succeeded"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			taskStatus = models.TaskStatusFAILED
+			task.Status = &taskStatus
+			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create placement group"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
+			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
+			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
+			task.ErrorMessage = pointer.String(service.VMPlacementGroupDuplicate)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create placement group"))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Duplicate placement group detected, will try again in %s", placementGroupSilenceTime)))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
+
+			result, err = reconciler.reconcilePlacementGroup(machineContext)
+			Expect(result.RequeueAfter).To(Equal(config.VMPlacementGroupDuplicateTimeout))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Tower has duplicate placement group, skip creating placement group %s", placementGroupName)))
+		})
+	})
+
 	Context("Reconcile static IP allocation", func() {
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
@@ -2064,6 +2170,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should wait for IP allocation", func() {
+			placementGroup := fake.NewVMPlacementGroup([]string{fake.ID()})
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(3).Return(placementGroup, nil)
+
 			// one IPV4 device without ipAddrs
 			elfMachine.Spec.Network.Devices = []infrav1.NetworkDeviceSpec{
 				{NetworkType: infrav1.NetworkTypeIPV4},
@@ -2086,6 +2195,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should not wait for IP allocation", func() {
+			placementGroup := fake.NewVMPlacementGroup([]string{fake.ID()})
+			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
+
 			// one IPV4 device with ipAddrs
 			elfMachine.Spec.Network.Devices = []infrav1.NetworkDeviceSpec{
 				{NetworkType: infrav1.NetworkTypeIPV4, IPAddrs: []string{"127.0.0.1"}},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,10 @@ var (
 	// requeueing a CAPE operation.
 	DefaultRequeueTimeout = 10 * time.Second
 
+	// VMPlacementGroupDuplicateTimeout is the time for how long to wait when
+	// requeueing a CAPE operation after encountering VMPlacementGroupDuplicate error.
+	VMPlacementGroupDuplicateTimeout = 10 * time.Minute
+
 	// WaitTaskInterval is the default interval time polling task.
 	WaitTaskInterval = 1 * time.Second
 

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -27,7 +27,7 @@ import (
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
 )
 
-// MachineContext is a Go context used with a ElfMachine.
+// MachineContext is a Go context used with an ElfMachine.
 type MachineContext struct {
 	*ControllerContext
 	Cluster     *clusterv1.Cluster

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -138,7 +138,7 @@ func HostsToSet(hosts []*models.Host) sets.Set[string] {
 	return hostSet
 }
 
-// GetVMsInPlacementGroup returns the virtual machine ID set in the placement group.
+// GetVMsInPlacementGroup returns a Set of IDs of the virtual machines in the placement group.
 func GetVMsInPlacementGroup(placementGroup *models.VMPlacementGroup) sets.Set[string] {
 	placementGroupVMSet := sets.Set[string]{}
 	for i := 0; i < len(placementGroup.Vms); i++ {

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -138,7 +138,8 @@ func HostsToSet(hosts []*models.Host) sets.Set[string] {
 	return hostSet
 }
 
-func GetPlacementGroupVMSet(placementGroup *models.VMPlacementGroup) sets.Set[string] {
+// GetVMsInPlacementGroup returns the virtual machine ID set in the placement group.
+func GetVMsInPlacementGroup(placementGroup *models.VMPlacementGroup) sets.Set[string] {
 	placementGroupVMSet := sets.Set[string]{}
 	for i := 0; i < len(placementGroup.Vms); i++ {
 		placementGroupVMSet.Insert(*placementGroup.Vms[i].ID)

--- a/pkg/service/util.go
+++ b/pkg/service/util.go
@@ -138,6 +138,15 @@ func HostsToSet(hosts []*models.Host) sets.Set[string] {
 	return hostSet
 }
 
+func GetPlacementGroupVMSet(placementGroup *models.VMPlacementGroup) sets.Set[string] {
+	placementGroupVMSet := sets.Set[string]{}
+	for i := 0; i < len(placementGroup.Vms); i++ {
+		placementGroupVMSet.Insert(*placementGroup.Vms[i].ID)
+	}
+
+	return placementGroupVMSet
+}
+
 func TowerMemory(memoryMiB int64) *int64 {
 	memory := memoryMiB
 	if memory <= 0 {


### PR DESCRIPTION
### 问题
SKS-1479、SKS-1465 需要更多的讨论，可以在下一个 PR 处理。

当前 PR 主要在 https://github.com/smartxworks/cluster-api-provider-elf/pull/119 的基础上，从“首先创建关机的虚拟机再检查是否有足够主机” 改成 “创建虚拟机前检查是否有足够主机将此虚拟机加入必须策略放置组”。

### 其他改动
放置组相关的代码独立到 elfmachine_controller_placement_group.go 方便管理，原有迁移过来的代码逻辑基本上没有调整，主要是针对在创建虚拟机前检查可用主机做了一些微调。

### 测试
测试环境为 3 可用主机 ELF 集群

1.创建 5 CP 集群，只有前 3 个 CP 正常创建，第四个虚拟机不能创建，需要等待足够主机
"The placement group is full, wait for enough available hosts"

2.创建 3 CP 集群，正常创建，扩容到 5 CP 失败，阻塞在等待可用主机（同上）。

3.升级 3 CP 集群，正常升级，没有发生虚拟机迁移