### PR TITLE
SKS-1465: Add DeleteMachineAnnotation to the failed CP Machine when scaling down KCP after a failed scaling up

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,6 +53,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - controlplane.cluster.x-k8s.io

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -64,7 +64,7 @@ import (
 //+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments;machinedeployments/status,verbs=get;list;watch
-//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 // ElfMachineReconciler reconciles an ElfMachine object.
@@ -174,7 +174,7 @@ func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_
 	}
 
 	logger := r.Logger.WithValues("namespace", elfMachine.Namespace,
-		"elfCluster", elfCluster.Name, "elfMachine", elfMachine.Name)
+		"elfCluster", elfCluster.Name, "elfMachine", elfMachine.Name, "machine", machine.Name)
 
 	// Create the machine context for this request.
 	machineContext := &context.MachineContext{

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -27,8 +27,10 @@ import (
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
@@ -36,6 +38,7 @@ import (
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
+	annotationsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/annotations"
 	kcputil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/kcp"
 	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
 )
@@ -159,29 +162,61 @@ func (r *ElfMachineReconciler) preCheckPlacementGroup(ctx *context.MachineContex
 
 	availableHostSet := service.HostsToSet(availableHosts)
 	unusedHostSet := availableHostSet.Difference(usedHostSet)
+	if unusedHostSet.Len() != 0 {
+		ctx.Logger.V(2).Info("The placement group still has capacity", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "unusedHosts", unusedHostSet.UnsortedList())
+
+		return pointer.String(""), nil
+	}
 
 	kcp, err := machineutil.GetKCPByMachine(ctx, ctx.Client, ctx.Machine)
 	if err != nil {
 		return nil, err
 	}
 
-	if !kcputil.IsKCPInRollingUpdate(kcp) {
-		if unusedHostSet.Len() != 0 {
-			return pointer.String(""), nil
-		}
-
+	// KCP is not in scaling down/rolling update.
+	if !(kcputil.IsKCPInRollingUpdate(kcp) || kcputil.IsKCPInScalingDown(kcp)) {
 		ctx.Logger.V(2).Info("The placement group is full, wait for enough available hosts", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "usedHosts", usedHostSet.UnsortedList())
 
 		return nil, nil
 	}
 
-	// KCP is in rolling update.
+	// KCP is in scaling down.
+	//
+	// If the placement group is full during KCP scaling up, and then scale down,
+	// the Machine being created cannot pass the Preflight checks(https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#preflight-checks),
+	// so the Machine will not be deleted.
+	// We can set delete annotation on the Machine and KCP will delete it.
+	if kcputil.IsKCPInScalingDown(kcp) {
+		if annotationsutil.HasAnnotation(ctx.Machine, clusterv1.DeleteMachineAnnotation) {
+			return nil, nil
+		}
 
-	if unusedHostSet.Len() != 0 {
-		ctx.Logger.V(2).Info("The placement group still has capacity, skip selecting host for rolling update", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList(), "unusedHosts", unusedHostSet.UnsortedList(), "vmRef", ctx.ElfMachine.Status.VMRef)
+		newMachine := ctx.Machine.DeepCopy()
+		patchHelper, err := patch.NewHelper(ctx.Machine, r.Client)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to init patch helper for %s %s/%s", ctx.Machine.GroupVersionKind(), ctx.Machine.Namespace, ctx.Machine.Name)
+		}
 
-		return pointer.String(""), nil
+		// Allow scaling down of KCP with the possibility of marking specific control plane machine(s) to be deleted with delete annotation key.
+		// The presence of the annotation will affect the rollout strategy in a way that, it implements the following prioritization logic in descending order,
+		// while selecting machines for scale down:
+		//   1.outdatedMachines with the delete annotation
+		//   2.machines with the delete annotation
+		//   3.outdated machines
+		//   4.all machines
+		//
+		// Refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#scale-down
+		annotations.AddAnnotations(newMachine, map[string]string{clusterv1.DeleteMachineAnnotation: ""})
+		if err := patchHelper.Patch(r, newMachine); err != nil {
+			return nil, errors.Wrapf(err, "failed to patch Machine %s to set delete annotation key %s.", newMachine.Name, clusterv1.DeleteMachineAnnotation)
+		}
+
+		ctx.Logger.Info("Setted the delete annotation key on Machine for KCP delete it, because the placement group is full and KCP scale up first then scale down", "placementGroup", *placementGroup.Name, "availableHosts", availableHostSet.UnsortedList())
+
+		return nil, nil
 	}
+
+	// KCP is in rolling update.
 
 	if !service.ContainsUnavailableHost(hosts, usedHostSet.UnsortedList(), *service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB)) &&
 		int(*kcp.Spec.Replicas) == usedHostSet.Len() {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -915,7 +915,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				vm2.Host = &models.NestedHost{ID: host.ID, Name: host.Name}
 				placementGroup := fake.NewVMPlacementGroup([]string{*vm2.ID})
 				kcp.Spec.Replicas = pointer.Int32(1)
-				kcp.Status.Replicas = 1
+				kcp.Status.Replicas = 2
 				kcp.Status.UpdatedReplicas = 1
 				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md, kcp)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -1161,7 +1161,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 					{ID: vm3.ID, Name: vm3.Name},
 				}
 				kcp.Spec.Replicas = pointer.Int32(3)
-				kcp.Status.Replicas = 3
+				kcp.Status.Replicas = 4
 				kcp.Status.UpdatedReplicas = 1
 				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp, elfMachine1, machine1, elfMachine2, machine2, elfMachine3, machine3)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -1375,7 +1375,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				hostID, err := reconciler.preCheckPlacementGroup(machineContext)
 				Expect(err).To(BeZero())
 				Expect(hostID).To(BeNil())
-				Expect(logBuffer.String()).To(ContainSubstring("Setted the delete annotation key on Machine for KCP delete it"))
+				Expect(logBuffer.String()).To(ContainSubstring("Add the delete machine annotation on KCP Machine in order to delete it"))
 				Expect(reconciler.Client.Get(reconciler, capiutil.ObjectKey(machine), machine)).To(Succeed())
 				Expect(machine.Annotations).Should(HaveKey(clusterv1.DeleteMachineAnnotation))
 			})

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -916,6 +916,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				placementGroup := fake.NewVMPlacementGroup([]string{*vm2.ID})
 				kcp.Spec.Replicas = pointer.Int32(1)
 				kcp.Status.Replicas = 1
+				kcp.Status.UpdatedReplicas = 1
 				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md, kcp)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
@@ -1161,6 +1162,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				}
 				kcp.Spec.Replicas = pointer.Int32(3)
 				kcp.Status.Replicas = 3
+				kcp.Status.UpdatedReplicas = 1
 				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp, elfMachine1, machine1, elfMachine2, machine2, elfMachine3, machine3)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
@@ -1343,6 +1345,39 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(err).To(BeZero())
 				Expect(*hostID).To(Equal(""))
 				expectConditions(elfMachine, []conditionAssertion{})
+			})
+
+			It("kcp scale down", func() {
+				kcp.Spec.Replicas = pointer.Int32(1)
+				kcp.Status.Replicas = 2
+				kcp.Status.UpdatedReplicas = kcp.Status.Replicas
+				host := fake.NewTowerHost()
+				elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
+				fake.ToControlPlaneMachine(machine1, kcp)
+				fake.ToControlPlaneMachine(elfMachine1, kcp)
+				vm1 := fake.NewTowerVMFromElfMachine(elfMachine1)
+				vm1.Host = &models.NestedHost{ID: service.TowerString(*host.ID)}
+				elfMachine.Status.VMRef = *vm1.LocalID
+				placementGroup := fake.NewVMPlacementGroup([]string{})
+				placementGroup.Vms = []*models.NestedVM{
+					{ID: vm1.ID, Name: vm1.Name},
+				}
+				ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, kcp)
+				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+				placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctrlContext.Client, machine, cluster)
+				Expect(err).NotTo(HaveOccurred())
+				mockVMService.EXPECT().GetVMPlacementGroup(placementGroupName).Return(placementGroup, nil)
+				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return([]*models.Host{host}, nil)
+				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID})).Return([]*models.VM{vm1}, nil)
+
+				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+				hostID, err := reconciler.preCheckPlacementGroup(machineContext)
+				Expect(err).To(BeZero())
+				Expect(hostID).To(BeNil())
+				Expect(logBuffer.String()).To(ContainSubstring("Setted the delete annotation key on Machine for KCP delete it"))
+				Expect(reconciler.Client.Get(reconciler, capiutil.ObjectKey(machine), machine)).To(Succeed())
+				Expect(machine.Annotations).Should(HaveKey(clusterv1.DeleteMachineAnnotation))
 			})
 		})
 	})

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -22,6 +22,17 @@ import (
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 )
 
+// HasAnnotation returns true if the object has the specified annotation.
+func HasAnnotation(o metav1.Object, annotationKey string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, ok := annotations[annotationKey]
+	return ok
+}
+
 func GetPlacementGroupName(o metav1.Object) string {
 	annotations := o.GetAnnotations()
 	if annotations == nil {

--- a/pkg/util/kcp/kcp.go
+++ b/pkg/util/kcp/kcp.go
@@ -26,5 +26,10 @@ import (
 // If *kcp.Spec.Replicas > kcp.Status.Replicas, it means KCP is not in rolling update,
 // but scaling out or being created.
 func IsKCPInRollingUpdate(kcp *controlplanev1.KubeadmControlPlane) bool {
-	return *kcp.Spec.Replicas <= kcp.Status.Replicas
+	return *kcp.Spec.Replicas <= kcp.Status.Replicas && kcp.Status.UpdatedReplicas == 1
+}
+
+// IsKCPInRollingUpdate returns whether KCP is in scaling down.
+func IsKCPInScalingDown(kcp *controlplanev1.KubeadmControlPlane) bool {
+	return *kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.Replicas == kcp.Status.UpdatedReplicas
 }

--- a/pkg/util/kcp/kcp.go
+++ b/pkg/util/kcp/kcp.go
@@ -20,20 +20,29 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 )
 
-// IsKCPRollingUpdateFirstMachine returns whether KCP is creating the first rolling update CP machine.
+// IsKCPRollingUpdateFirstMachine returns true if KCP is in rolling update and creating the first CP Machine.
 //
-// If kcp.Status.Replicas > kcp.Spec.Replicas and kcp.Status.UpdatedReplicas == 1,
-// it means KCP is creating the first rolling update CP Machine.
+// KCP rollout algorithm is as follows:
+// Find Machines that have an outdated spec, If there is a machine requiring rollout
+// 1.Scale up control plane creating a machine with the new spec
+// 2.Scale down control plane by removing one of the machine that needs rollout (the oldest out-of date machine in the failure domain that has the most control-plane machines on it)
+//
+// kcp.Status.UpdatedReplicas is the total number of machines that are up to date with the control
+// plane's configuration and therefore do not require rollout.
+//
+// So when KCP is in rolling update and creating the first CP Machine,
+// kcp.Status.Replicas is greater than kcp.Spec.Replicas and kcp.Status.UpdatedReplicas equals 1.
 //
 // For more information about KCP replicas, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
+// For more information about KCP rollout, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#kubeadmcontrolplane-rollout
 func IsKCPRollingUpdateFirstMachine(kcp *controlplanev1.KubeadmControlPlane) bool {
 	return *kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.UpdatedReplicas == 1
 }
 
 // IsKCPInScalingDown returns whether KCP is in scaling down.
 //
-// If kcp.Spec.Replicas < kcp.Status.Replicas and kcp.Status.Replicas == kcp.Status.UpdatedReplicas,
-// it means KCP is in scaling down.
+// When KCP is in scaling down, machines managed by KCP is greater than kcp.Spec.Replicas,
+// and these machines are up to date with the control plane's configuration.
 //
 // For more information about KCP replicas, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
 func IsKCPInScalingDown(kcp *controlplanev1.KubeadmControlPlane) bool {

--- a/pkg/util/kcp/kcp.go
+++ b/pkg/util/kcp/kcp.go
@@ -20,16 +20,22 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 )
 
-// IsKCPInRollingUpdate returns whether KCP is in rolling update.
-// IMPORTANT: This function can only be used when creating a new Machine.
+// IsKCPRollingUpdateFirstMachine returns whether KCP is creating the first rolling update CP machine.
 //
-// If *kcp.Spec.Replicas > kcp.Status.Replicas, it means KCP is not in rolling update,
-// but scaling out or being created.
-func IsKCPInRollingUpdate(kcp *controlplanev1.KubeadmControlPlane) bool {
-	return *kcp.Spec.Replicas <= kcp.Status.Replicas && kcp.Status.UpdatedReplicas == 1
+// If kcp.Status.Replicas > kcp.Spec.Replicas and kcp.Status.UpdatedReplicas == 1,
+// it means KCP is creating the first rolling update CP Machine.
+//
+// For more information about KCP replicas, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
+func IsKCPRollingUpdateFirstMachine(kcp *controlplanev1.KubeadmControlPlane) bool {
+	return *kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.UpdatedReplicas == 1
 }
 
-// IsKCPInRollingUpdate returns whether KCP is in scaling down.
+// IsKCPInScalingDown returns whether KCP is in scaling down.
+//
+// If kcp.Spec.Replicas < kcp.Status.Replicas and kcp.Status.Replicas == kcp.Status.UpdatedReplicas,
+// it means KCP is in scaling down.
+//
+// For more information about KCP replicas, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
 func IsKCPInScalingDown(kcp *controlplanev1.KubeadmControlPlane) bool {
 	return *kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.Replicas == kcp.Status.UpdatedReplicas
 }


### PR DESCRIPTION
### 问题
扩容失败后再缩容会被判断为升级，因为根据 *kcp.Spec.Replicas <= kcp.Status.Replicas 判断 KCP 是否正在进行升级不准确。
可用主机不够的情况下，会和 KCP 先扩容再缩容冲突，判断为升级，而把该 CP 放在最新的 Machine 所属的主机上。
KCP 缩容默认会选择最老的 Machine 删除，导致触发一次虚拟机迁移。

### 解决

操作判断：https://docs.google.com/document/d/1kmq6C4lXcN8WaJ3qwIuRbdkTcyFUKc7F73cbAq3NZaA/edit#heading=h.o4v48qv6y0i

判断滚动第一个 CP 节点改成：*kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.UpdatedReplicas == 1
判断缩容改成：*kcp.Spec.Replicas < kcp.Status.Replicas && kcp.Status.Replicas == kcp.Status.UpdatedReplicas

参考文档：https://docs.google.com/document/d/1kmq6C4lXcN8WaJ3qwIuRbdkTcyFUKc7F73cbAq3NZaA/edit#heading=h.3fqxywg14v4w

### 测试
ELF 集群：3 主机

1.创建 3 CP 集群，可以正常进行升级，没有把升级判断为先扩容后缩容

2.创建 3 CP 集群，扩容为 5 CP，第四个 CP 因为主机不够，虚拟机没有创建出来。等扩容失败后，进行缩容为 3，观察到第四个 CP 的 Machine 被设置了 DeleteMachineAnnotation，然后 KCP 缩容的时候把该 Machine 删除了，KSC 变成  ready。