### PR TITLE
SKS-1474: Get VM NIC IP from K8s node to speed up VM reconcile

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -228,7 +228,8 @@ func (m *ElfMachine) SetVMDisconnectionTimestamp(timestamp *metav1.Time) {
 	}
 }
 
-func (m *ElfMachine) GetNetworkDevicesNeededIPAllocation() []NetworkDeviceSpec {
+// GetNetworkDevicesRequiringIP returns a slice of NetworkDeviceSpec which requires DHCP IP or static IP.
+func (m *ElfMachine) GetNetworkDevicesRequiringIP() []NetworkDeviceSpec {
 	networkDevices := []NetworkDeviceSpec{}
 
 	for index := range m.Spec.Network.Devices {

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -228,6 +228,20 @@ func (m *ElfMachine) SetVMDisconnectionTimestamp(timestamp *metav1.Time) {
 	}
 }
 
+func (m *ElfMachine) GetNetworkDevicesNeededIPAllocation() []NetworkDeviceSpec {
+	networkDevices := []NetworkDeviceSpec{}
+
+	for index := range m.Spec.Network.Devices {
+		if m.Spec.Network.Devices[index].NetworkType == NetworkTypeNone {
+			continue
+		}
+
+		networkDevices = append(networkDevices, m.Spec.Network.Devices[index])
+	}
+
+	return networkDevices
+}
+
 func (m *ElfMachine) GetVMDisconnectionTimestamp() *metav1.Time {
 	if m.Annotations == nil {
 		return nil

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -2063,7 +2063,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err := reconciler.reconcileDelete(machineContext)
-			fmt.Println(logBuffer.String())
 			Expect(result.RequeueAfter).NotTo(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2113,7 +2112,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err := reconciler.reconcileDelete(machineContext)
-			fmt.Println(logBuffer.String())
 			Expect(result.RequeueAfter).NotTo(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2160,7 +2158,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err := reconciler.reconcileDelete(machineContext)
-			fmt.Println(logBuffer.String())
 			Expect(result.RequeueAfter).NotTo(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2200,7 +2197,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			_, err := reconciler.reconcileDelete(machineContext)
-			fmt.Println(logBuffer.String())
 			Expect(err).NotTo(BeZero())
 
 			Expect(err.Error()).To(ContainSubstring("failed to get client"))


### PR DESCRIPTION
## 问题

[SKS-1474] CAPE同步VM网络信息慢 - Jira http://jira.smartx.com/browse/SKS-1474。 导致CAPE创建VM时有些时候需要等待3分钟才能从Tower处获取到IP，明显降低了VM创建速度。


## 根因

ELF同步已安装vmtools的VM的IP数据时，同步时延不固定，快的话1分钟内。慢的话也有2-3分钟的。
ELF同步慢的原因为每次要同步状态的虚拟机太多了，所以导致执行一轮耗费的时间太长。

## 修复

当Tower API没有返回网卡IP时，从k8s node获取VM第一块网卡IP。VM单网卡场景中可以加快CAPE同步VM IP的速度，加速VM创建过程。

## 测试

### 创建单网卡VM KSC集群

KSC集群创建成功

```
NAME                     K8SVERSION   SKSVERSION   STATUS   READY   CONTROLPLANES   WORKERS   AGE   CNI      CSI            CONTROLPLANEVIP
hw-sks-test-1.24.13-03   v1.24.13     v1.1.0       Ready    true    3/3             3/3       27m   calico   smtx-elf-csi   10.255.26.33:6443

kc get ksc -n default hw-sks-test-1.24.13-03 -ojson | jq .spec.topology
{
  "controlPlane": {
    "name": "controlplane",
    "nodeConfig": {
      "cloneMode": "FastClone",
      "cpuCores": 4,
      "memoryMB": 8192,
      "network": {
        "devices": [
          {
            "networkType": "IPV4_DHCP",
            "tag": "default",
            "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
          }
        ]
      }
    },
    "nodeDrainTimeout": "5m0s",
    "nodeVolumeDetachTimeout": "5m0s",
    "replicas": 3,
    "rolloutBefore": {
      "certificatesExpiryDays": 30
    }
  },
  "workers": [
    {
      "name": "workergroup",
      "nodeConfig": {
        "cloneMode": "FastClone",
        "cpuCores": 4,
        "memoryMB": 8192,
        "network": {
          "devices": [
            {
              "networkType": "IPV4_DHCP",
              "tag": "default",
              "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
            }
          ]
        }
      },
      "nodeDrainTimeout": "5m0s",
      "nodeVolumeDetachTimeout": "5m0s",
      "replicas": 3
    }
  ]
}
```

CAPE日志显示 worker node `hw-sks-test-1.24.13-03-workergroup-b2ct7` 19:50:35 同步VM网络信息成功
```
I0628 11:50:31.023470       1 elfmachine_controller.go:970] cape-controller-manager/elfmachine-controller "msg"="VM network is not ready yet" "elfCluster"="hw-sks-test-1.24.13-03" "elfMachine"="hw-sks-test-1.24.13-03-workergroup-8d2rg" "namespace"="default" "nicStatus"=null
I0628 11:50:31.310108       1 elfmachine_controller.go:970] cape-controller-manager/elfmachine-controller "msg"="VM network is not ready yet" "elfCluster"="hw-sks-test-1.24.13-03" "elfMachine"="hw-sks-test-1.24.13-03-controlplane-sdjtl" "namespace"="default" "nicStatus"=null
I0628 11:50:35.546377       1 elfmachine_controller.go:954] cape-controller-manager/elfmachine-controller "msg"="Setting node providerID and labels succeeded" "cluster"="hw-sks-test-1.24.13-03" "elfCluster"="hw-sks-test-1.24.13-03" "elfMachine"="hw-sks-test-1.24.13-03-workergroup-b2ct7" "hostID"="clfkutysd00ci09586lpcj3fb" "hostName"="node20-216" "namespace"="default" "node"="hw-sks-test-1.24.13-03-workergroup-b2ct7" "providerID"="elf://2a90383a-d09f-44cd-8328-312b9ccf61a7
```

vmtools同步信息时间为 19:51:05
<img width="1034" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/1aacdda7-8d2c-4a8a-81d5-47ac081c93fd">


### 创建双网卡VM KSC集群

```
 kc get ksc -n default hw-sks-test-1.24.13-04
NAME                     K8SVERSION   SKSVERSION   STATUS   READY   CONTROLPLANES   WORKERS   AGE   CNI      CSI            CONTROLPLANEVIP
hw-sks-test-1.24.13-04   v1.24.13     v1.1.0       Ready    true    3/3             3/3       17m   calico   smtx-elf-csi   10.255.26.34:6443

{
  "controlPlane": {
    "name": "controlplane",
    "nodeConfig": {
      "cloneMode": "FastClone",
      "cpuCores": 4,
      "memoryMB": 8192,
      "network": {
        "devices": [
          {
            "networkType": "IPV4_DHCP",
            "tag": "default",
            "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
          },
          {
            "networkType": "IPV4_DHCP",
            "tag": "default",
            "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_a0e64b64-355a-489f-8abb-ff8c22e1bc8f"
          }
        ]
      }
    },
    "nodeDrainTimeout": "5m0s",
    "nodeVolumeDetachTimeout": "5m0s",
    "replicas": 3,
    "rolloutBefore": {
      "certificatesExpiryDays": 30
    }
  },
  "workers": [
    {
      "name": "workergroup",
      "nodeConfig": {
        "cloneMode": "FastClone",
        "cpuCores": 4,
        "memoryMB": 8192,
        "network": {
          "devices": [
            {
              "networkType": "IPV4_DHCP",
              "tag": "default",
              "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
            },
            {
              "networkType": "IPV4_DHCP",
              "tag": "default",
              "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_a0e64b64-355a-489f-8abb-ff8c22e1bc8f"
            }
          ]
        }
      },
      "nodeDrainTimeout": "5m0s",
      "nodeVolumeDetachTimeout": "5m0s",
      "replicas": 3
    }
  ]
}

```