### PR TITLE
SKS-1573: Add DeleteMachineAnnotation to the failed CP Machine when scaling down KCP after a failed rolling update

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1464,6 +1464,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				kcp.Spec.Replicas = pointer.Int32(1)
 				kcp.Status.Replicas = 2
 				kcp.Status.UpdatedReplicas = kcp.Status.Replicas
+				conditions.MarkFalse(kcp, controlplanev1.ResizedCondition, controlplanev1.ScalingDownReason, clusterv1.ConditionSeverityWarning, "")
 				host := fake.NewTowerHost()
 				elfMachine1, machine1 := fake.NewMachineObjects(elfCluster, cluster)
 				fake.ToControlPlaneMachine(machine1, kcp)

--- a/pkg/util/kcp/kcp.go
+++ b/pkg/util/kcp/kcp.go
@@ -48,18 +48,7 @@ func IsKCPRollingUpdateFirstMachine(kcp *controlplanev1.KubeadmControlPlane) boo
 //
 // For more information about KCP ResizedCondition and ScalingDownReason, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/api/v1beta1/condition_consts.go
 func IsKCPInScalingDown(kcp *controlplanev1.KubeadmControlPlane) bool {
-	// When KCP is in rolling update, KCP controller marks
-	// MachinesSpecUpToDateCondition to false and RollingUpdateInProgressReason as Reason.
-	//
-	// When all machines are up to date, KCP controller marks MachinesSpecUpToDateCondition to true.
-	//
-	// For more information about KCP MachinesSpecUpToDateCondition and RollingUpdateInProgressReason, refer to https://github.com/kubernetes-sigs/cluster-api/blob/main/api/v1beta1/condition_consts.go
-	if conditions.IsFalse(kcp, controlplanev1.MachinesSpecUpToDateCondition) &&
-		conditions.GetReason(kcp, controlplanev1.MachinesSpecUpToDateCondition) == controlplanev1.RollingUpdateInProgressReason {
-		// If KCP rolling update and then scale down, then kcp.Spec.Replicas < kcp.Status.UpdatedReplicas.
-		return *kcp.Spec.Replicas < kcp.Status.UpdatedReplicas
-	}
-
 	return conditions.IsFalse(kcp, clusterv1.ResizedCondition) &&
-		conditions.GetReason(kcp, controlplanev1.ResizedCondition) == controlplanev1.ScalingDownReason
+		conditions.GetReason(kcp, controlplanev1.ResizedCondition) == controlplanev1.ScalingDownReason &&
+		*kcp.Spec.Replicas < kcp.Status.UpdatedReplicas
 }


### PR DESCRIPTION
## 问题
SKS 1.0 升级到 1.1，3主机环境，5 CP 集群升级到第四个新 CP，没有足够的可用主机，此时缩容为 3，第四个新 CP 没有被删除，导致缩容流程一直阻塞。

## 解决

可能遇到的几个场景分析：

### (1) 3 个可用主机环境
#### (1.1) 扩容 3 -> 5，可用主机不足后缩容
第四个 CP 需要等待可用主机，此时缩容为 3，kcp.Spec.Replicas 为 3，kcp.Status.UpdatedReplicas 为 4
MachinesSpecUpToDateCondition 为 false
ResizedCondition 为 false，ScalingDownReason

#### (1.2) SKS 升级 1.0 > 1.1, 滚动更新集群 5 -> 5 可用主机不足后缩容
第四个新 CP 需要等待可用主机，此时缩容为 3，kcp.Spec.Replicas 为 3，kcp.Status.UpdatedReplicas 为 4
MachinesSpecUpToDateCondition 为 false
ResizedCondition 为 false，ScalingDownReason

### (2) 4 个可用主机环境
#### (2.1) 扩容 3 -> 5，可用主机不足后缩容
第五个 CP 需要等待可用主机，此时缩容为 3，kcp.Spec.Replicas 为 3，kcp.Status.UpdatedReplicas 为 5
MachinesSpecUpToDateCondition 为 false
ResizedCondition 为 false，ScalingDownReason

#### (2.2) SKS 升级 1.0 > 1.1, 滚动更新集群 5 -> 5，可用主机不足后缩容
第五个新 CP 需要等待可用主机，此时缩容为 3，kcp.Spec.Replicas 为 3，kcp.Status.UpdatedReplicas 为 5
MachinesSpecUpToDateCondition 为 true
ResizedCondition 为 false，ScalingDownReason


### (3) 
正常滚动更新过程，会出现 ResizedCondition 为 false，ScalingDownReason。因为滚动更新的过程是通过先扩容再缩容，也就是创建一个新的节点再删除一个旧的节点。

### 总结

综上，通过 controlplanev1.ResizedCondition 为 false，并且 reason 为 controlplanev1.ScalingDownReason，并且 *kcp.Spec.Replicas < kcp.Status.UpdatedReplicas 判断是否在缩容。

## 测试
3 主机环境

 1 ) 扩容 3 CP -> 5 CP 后缩容 -> 3 CP，符合预期
 2 )  SKS 1.0 > 1.1，滚动更新集群 5 CP -> 5 CP 缩容 -> 3 CP，符合预期

4主机环境

 1 ) 扩容 3 CP -> 5 CP 后缩容 -> 3 CP，符合预期
 2 )  SKS 1.0 > 1.1，滚动更新集群 5 CP -> 5 CP 后缩容 -> 3 CP，符合预期