### PR TITLE
Fix using localID in non-UUID format as vmRef value

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -294,6 +294,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should recover from lost task", func() {
 			vm := fake.NewTowerVM()
 			vm.Name = &elfMachine.Name
+			vm.LocalID = pointer.String("placeholder-%s" + *vm.LocalID)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
@@ -1876,7 +1877,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should delete the VM that in creating status and have not been saved to ElfMachine", func() {
 			vm := fake.NewTowerVM()
-			vm.LocalID = nil
+			vm.LocalID = pointer.String("placeholder-%s" + *vm.LocalID)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)

--- a/pkg/util/tower.go
+++ b/pkg/util/tower.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
+	machineutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/machine"
+)
+
+// GetVMRef returns the ID or localID of the VM.
+// If the localID is in UUID format, return the localID, otherwise return the ID.
+//
+// Before the ELF VM is created, Tower sets a "placeholder-{UUID}" format string to localID, such as "placeholder-7d8b6df1-c623-4750-a771-3ba6b46995fa".
+// After the ELF VM is created, Tower sets the VM ID in UUID format to localID.
+func GetVMRef(vm *models.VM) string {
+	if vm == nil {
+		return ""
+	}
+
+	vmLocalID := service.GetTowerString(vm.LocalID)
+	if machineutil.IsUUID(vmLocalID) {
+		return vmLocalID
+	}
+
+	return *vm.ID
+}


### PR DESCRIPTION
## 问题 [SKS-1608](http://jira.smartx.com/browse/SKS-1608) 

在创建虚拟机的过程删除了相关的 ElfMachine，偶现虚拟机没有被删除。

原因是把 "placeholder-{UUID}" 格式的 UUID 设置给了 vmRef，但虚拟机创建好之后（同步到了 ELF），Tower 把 "placeholder-{UUID}" 改成了 "{UUID}"，但 vmRef 并没有被更新，导致使用 "placeholder-{UUID}" 格式的 vmRef 查不到虚拟机。

## 方案
不能使用 "placeholder-{UUID}" 格式的 localID 赋值给 vmRef，而是使用 ID 或者 UUID 格式的 localID。

## 测试
在 MHC E2E 中暂未发现未删除的虚拟机，需要继续再观察多次。
