### PR TITLE
SKS-1632: Optimize the return value of reconcileVM

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -459,7 +459,7 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 //  4. Returning the real-time state of the VM to the caller
 //
 // The return bool value:
-// 1. true means that the VM is running and is joined to a placement group (if needed).
+// 1. true means that the VM is running and joined a placement group (if needed).
 // 2. false and error is nil means the VM is not running or wait to join the placement group.
 func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models.VM, bool, error) {
 	// If there is no vmRef then no VM exists, create one


### PR DESCRIPTION
### 问题
原有的 reconcileVM 只关注虚拟机是否处于 Running 状态，没有考虑放置组的情况。
日志 "VM state is not reconciled" 日志并不能准确的知道是不满足什么条件导致不能后续的 reconcile。
此外，"VM state is not reconciled" 会重复打印一些没有价值的日志，reconcileVM 本身已经打印了具体的日志。

### 方案
reconcileVM 增加返回一个 bool，如果为 true 表示 reconcileVM 已经达到了预期。这样就可以由 reconcileVM 自身决定是否达到了预期，而不需要在调用 reconcileVM 之外再做一次判断。同时也减少了日志 "VM state is not reconciled"。

### 测试
3 主机环境，1 CP + 1 Worker 集群

以下操作均成功：
1. 创建集群
2. 1 CP 扩容到 3 CP，1 Worker 扩容到 3 Worker
3. 删除集群
