### PR TITLE
SKS-1642: Delete duplicate orphan virtual machines

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -427,10 +427,6 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 		}
 	}
 
-	if result, err := r.deleteDuplicateVMs(ctx); err != nil || !result.IsZero() {
-		return result, err
-	}
-
 	// Reconcile the ElfMachine's providerID using the VM's UUID.
 	if err := r.reconcileProviderID(ctx, vm); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "unexpected error while reconciling providerID for %s", ctx)
@@ -455,6 +451,10 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 			"namespace", ctx.ElfMachine.Namespace, "elfMachine", ctx.ElfMachine.Name)
 
 		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
+	}
+
+	if result, err := r.deleteDuplicateVMs(ctx); err != nil || !result.IsZero() {
+		return result, err
 	}
 
 	return reconcile.Result{}, nil
@@ -1174,20 +1174,21 @@ func (r *ElfMachineReconciler) getK8sNodeIP(ctx *context.MachineContext, nodeNam
 // NOTE: These will be removed when Tower fixes issue with duplicate virtual machines.
 
 const (
-	// duplicateVMDefaultRequeueTimeout is the default time for how long to wait when
-	// requeueing a duplicate VM operation.
-	duplicateVMDefaultRequeueTimeout = 1 * time.Minute
-
-	// waitDuplicateVMTaskInterval is the default interval time polling task.
-	waitDuplicateVMTaskInterval = 10 * time.Second
-
-	// waitDuplicateVMTaskTimeout is the default timeout for waiting for task to complete.
-	waitDuplicateVMTaskTimeout = 1 * time.Minute
+	// The time duration for check duplicate VM,
+	// starting from when the virtual machine was created.
+	checkDuplicateVMDuration = 30 * time.Minute
 )
 
 // deleteDuplicateVMs deletes the duplicate virtual machines.
 // Only be used to delete duplicate VMs before the ElfCluster is deleted.
 func (r *ElfMachineReconciler) deleteDuplicateVMs(ctx *context.MachineContext) (reconcile.Result, error) {
+	// Duplicate virtual machines appear in the process of creating virtual machines,
+	// only need to check within half an hour after creating virtual machines.
+	if ctx.ElfMachine.DeletionTimestamp.IsZero() &&
+		time.Now().After(ctx.ElfMachine.CreationTimestamp.Add(checkDuplicateVMDuration)) {
+		return reconcile.Result{}, nil
+	}
+
 	vms, err := ctx.VMService.FindVMsByName(ctx.ElfMachine.Name)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -1198,23 +1199,27 @@ func (r *ElfMachineReconciler) deleteDuplicateVMs(ctx *context.MachineContext) (
 	}
 
 	if ctx.ElfMachine.Status.VMRef == "" {
-		ctx.Logger.Info("Waiting for ElfMachine to select one of the duplicate VMs before deleting the other", "vms", vms)
+		vmIDs := make([]string, 0, len(vms))
+		for i := 0; i < len(vms); i++ {
+			vmIDs = append(vmIDs, *vms[i].ID)
+		}
+		ctx.Logger.Info("Waiting for ElfMachine to select one of the duplicate VMs before deleting the other", "vms", vmIDs)
 		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
 	}
 
 	for i := 0; i < len(vms); i++ {
-		if *vms[i].ID == ctx.ElfMachine.Status.VMRef || *vms[i].LocalID == ctx.ElfMachine.Status.VMRef {
+		if *vms[i].ID == ctx.ElfMachine.Status.VMRef ||
+			*vms[i].LocalID == ctx.ElfMachine.Status.VMRef ||
+			*vms[i].Status != models.VMStatusSTOPPED {
 			continue
 		}
 
-		ctx.Logger.Info("Destroying duplicate VM", "vmID", *vms[i].ID)
-
 		// When there are duplicate virtual machines, the service of Tower is unstable.
 		// If there is a deletion operation error, just return and try again.
-		if ok, err := r.deleteVM(ctx, vms[i]); err != nil {
+		if err := r.deleteVM(ctx, vms[i]); err != nil {
 			return reconcile.Result{}, err
-		} else if !ok {
-			return reconcile.Result{RequeueAfter: duplicateVMDefaultRequeueTimeout}, nil
+		} else {
+			return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
 		}
 	}
 
@@ -1222,50 +1227,20 @@ func (r *ElfMachineReconciler) deleteDuplicateVMs(ctx *context.MachineContext) (
 }
 
 // deleteVM deletes the specified virtual machine.
-//
-// The return value:
-// 1. true means that the VM is deleted.
-// 2. false and error is nil means the VM is not deleted.
-func (r *ElfMachineReconciler) deleteVM(ctx *context.MachineContext, vm *models.VM) (bool, error) {
+func (r *ElfMachineReconciler) deleteVM(ctx *context.MachineContext, vm *models.VM) error {
 	// VM is performing an operation
 	if vm.EntityAsyncStatus != nil {
-		ctx.Logger.V(1).Info("Waiting for VM task done before deleting", "vmID", *vm.ID, "name", *vm.Name)
-		return false, nil
-	}
-
-	// Power off the VM
-	if *vm.Status != models.VMStatusSTOPPED {
-		task, err := ctx.VMService.PowerOff(*vm.ID)
-		if err != nil {
-			return false, err
-		}
-
-		withLatestStatusTask, err := ctx.VMService.WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval)
-		if err != nil {
-			return false, errors.Wrapf(err, "failed to wait for VM power off task done in %s: key %s/%s, taskID %s", waitDuplicateVMTaskTimeout, *vm.Name, *vm.ID, *task.ID)
-		}
-
-		if *withLatestStatusTask.Status == models.TaskStatusFAILED {
-			return false, errors.Errorf("failed to power off VM %s/%s in task %s", *vm.Name, *vm.ID, *withLatestStatusTask.ID)
-		}
+		ctx.Logger.V(1).Info("Waiting for VM task done before deleting the duplicate VM", "vmID", *vm.ID, "name", *vm.Name)
+		return nil
 	}
 
 	// Delete the VM
 	task, err := ctx.VMService.Delete(*vm.ID)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	withLatestStatusTask, err := ctx.VMService.WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to wait for VM deletion task done in %s: key %s/%s, taskID %s", waitDuplicateVMTaskTimeout, *vm.Name, *vm.ID, *task.ID)
-	}
+	ctx.Logger.Info(fmt.Sprintf("Destroying duplicate VM %s in task %s", *vm.ID, *task.ID))
 
-	if *withLatestStatusTask.Status == models.TaskStatusFAILED {
-		return false, errors.Errorf("failed to delete VM %s/%s in task %s", *vm.Name, *vm.ID, *withLatestStatusTask.ID)
-	}
-
-	ctx.Logger.V(1).Info("Duplicate VM already deleted", "vmID", *vm.ID, "name", *vm.Name)
-
-	return true, nil
+	return nil
 }

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -350,6 +350,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1630,6 +1631,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return(nil, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(2).Return(placementGroup, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1660,6 +1662,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(22).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(33).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(11)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Times(11).Return(nil, nil)
 
 			// k8s node IP is null, VM has no nic info
 			k8sNode.Status.Addresses = nil
@@ -1828,6 +1831,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(2).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1912,6 +1916,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.ID).Return(vm, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1937,6 +1942,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(vm, nil)
 			mockVMService.EXPECT().Get(*vm.LocalID).Return(vm, nil)
 			mockVMService.EXPECT().ShutDown(*vm.LocalID).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1961,6 +1967,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			vmNotFoundError := errors.New(service.VMNotFound)
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(nil, vmNotFoundError)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -1986,6 +1993,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2013,6 +2021,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(task, errors.New("some error"))
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 
@@ -2042,6 +2051,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().PowerOff(elfMachine.Status.VMRef).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2071,6 +2081,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetTask(elfMachine.Status.TaskRef).Return(task, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(nil, errors.New("some error"))
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2093,6 +2104,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().ShutDown(elfMachine.Status.VMRef).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2119,6 +2131,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(nil, errors.New("some error"))
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2144,6 +2157,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2171,6 +2185,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().PowerOff(elfMachine.Status.VMRef).Return(task, nil)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
@@ -2276,6 +2291,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlContext.Client = testEnv.Client
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			machineContext.VMService = mockVMService
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			// before reconcile, create k8s node for VM.
 			node := &corev1.Node{
@@ -2320,6 +2336,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			elfMachine.Status.VMRef = *vm.LocalID
 			cluster.Status.ControlPlaneReady = true
 			cluster.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			ctrlContext.Client = testEnv.Client
@@ -2371,6 +2388,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlContext.Client = testEnv.Client
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			machineContext.VMService = mockVMService
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			// before reconcile, create k8s node for VM.
 			node := &corev1.Node{
@@ -2416,6 +2434,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlContext.Client = testEnv.Client
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			machineContext.VMService = mockVMService
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 
 			// before reconcile, create k8s node for VM.
 			node := &corev1.Node{
@@ -2743,6 +2762,150 @@ var _ = Describe("ElfMachineReconciler", func() {
 					node.Labels[infrav1.HostServerIDLabel] == elfMachine.Status.HostServerRef &&
 					node.Labels[infrav1.HostServerNameLabel] == elfMachine.Status.HostServerName
 			}, timeout).Should(BeTrue())
+		})
+	})
+
+	Context("deleteDuplicateVMs", func() {
+		It("should do nothing without duplicate virtual machines", func() {
+			vm := fake.NewTowerVMFromElfMachine(elfMachine)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			ctrlContext.Client = testEnv.Client
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			machineContext.VMService = mockVMService
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).ToNot(HaveOccurred())
+
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm}, nil)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not delete the VM that in operation", func() {
+			vm1 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm1.Status = models.NewVMStatus(models.VMStatusSTOPPED)
+			vm1.EntityAsyncStatus = nil
+			elfMachine.Status.VMRef = *vm1.LocalID
+			vm2 := fake.NewTowerVMFromElfMachine(elfMachine)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result.RequeueAfter).To(Equal(duplicateVMDefaultRequeueTimeout))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Waiting for VM task done before deleting"))
+		})
+
+		It("should wait ElfMachine to select one of the duplicate VMs ", func() {
+			vm1 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm1.Status = models.NewVMStatus(models.VMStatusSTOPPED)
+			vm1.EntityAsyncStatus = nil
+			vm2 := fake.NewTowerVMFromElfMachine(elfMachine)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeueTimeout))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Waiting for ElfMachine to select one of the duplicate VMs before deleting the other"))
+		})
+
+		It("should delete duplicate virtual machines", func() {
+			vm1 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm1.EntityAsyncStatus = nil
+			elfMachine.Status.VMRef = *vm1.LocalID
+			vm2 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm2.Status = models.NewVMStatus(models.VMStatusRUNNING)
+			vm2.EntityAsyncStatus = nil
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			task := fake.NewTowerTask()
+			task.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().PowerOff(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().Delete(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Times(2).Return(task, nil)
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Destroying duplicate VM"))
+			Expect(logBuffer.String()).To(ContainSubstring("Duplicate VM already deleted"))
+
+			logBuffer = new(bytes.Buffer)
+			klog.SetOutput(logBuffer)
+			vm2.Status = models.NewVMStatus(models.VMStatusSTOPPED)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().Delete(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Return(task, nil)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Destroying duplicate VM"))
+			Expect(logBuffer.String()).To(ContainSubstring("Duplicate VM already deleted"))
+		})
+
+		It("should return an error when the task fail or times out", func() {
+			vm1 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm1.EntityAsyncStatus = nil
+			elfMachine.Status.VMRef = *vm1.LocalID
+			vm2 := fake.NewTowerVMFromElfMachine(elfMachine)
+			vm2.Status = models.NewVMStatus(models.VMStatusSTOPPED)
+			vm2.EntityAsyncStatus = nil
+			task := fake.NewTowerTask()
+			task.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().Delete(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Return(nil, errors.New("some error"))
+
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err := reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for VM deletion task done in %s: key %s/%s, taskID %s", waitDuplicateVMTaskTimeout, *vm2.Name, *vm2.ID, *task.ID)))
+
+			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().Delete(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Return(task, nil)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to delete VM %s/%s in task %s", *vm2.Name, *vm2.ID, *task.ID)))
+
+			vm2.Status = models.NewVMStatus(models.VMStatusRUNNING)
+			task.Status = models.NewTaskStatus(models.TaskStatusSUCCESSED)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().PowerOff(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Return(nil, errors.New("some error"))
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for VM power off task done in %s: key %s/%s, taskID %s", waitDuplicateVMTaskTimeout, *vm2.Name, *vm2.ID, *task.ID)))
+
+			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
+			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return([]*models.VM{vm1, vm2}, nil)
+			mockVMService.EXPECT().PowerOff(*vm2.ID).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, waitDuplicateVMTaskTimeout, waitDuplicateVMTaskInterval).Return(task, nil)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.deleteDuplicateVMs(machineContext)
+			Expect(result).To(BeZero())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to power off VM %s/%s in task %s", *vm2.Name, *vm2.ID, *task.ID)))
 		})
 	})
 })

--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -31,4 +31,4 @@ const (
 )
 
 // MaxConcurrentVMCreations is the maximum number of concurrent virtual machine creations.
-var MaxConcurrentVMCreations = 20
+var MaxConcurrentVMCreations = 50

--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -31,4 +31,4 @@ const (
 )
 
 // MaxConcurrentVMCreations is the maximum number of concurrent virtual machine creations.
-var MaxConcurrentVMCreations = 50
+var MaxConcurrentVMCreations = 20

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -157,6 +157,21 @@ func (mr *MockVMServiceMockRecorder) FindByIDs(ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDs", reflect.TypeOf((*MockVMService)(nil).FindByIDs), ids)
 }
 
+// FindVMsByName mocks base method.
+func (m *MockVMService) FindVMsByName(name string) ([]*models.VM, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVMsByName", name)
+	ret0, _ := ret[0].([]*models.VM)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVMsByName indicates an expected call of FindVMsByName.
+func (mr *MockVMServiceMockRecorder) FindVMsByName(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVMsByName", reflect.TypeOf((*MockVMService)(nil).FindVMsByName), name)
+}
+
 // Get mocks base method.
 func (m *MockVMService) Get(id string) (*models.VM, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -54,6 +54,7 @@ type VMService interface {
 	Get(id string) (*models.VM, error)
 	GetByName(name string) (*models.VM, error)
 	FindByIDs(ids []string) ([]*models.VM, error)
+	FindVMsByName(name string) ([]*models.VM, error)
 	GetVMNics(vmID string) ([]*models.VMNic, error)
 	GetVMTemplate(template string) (*models.ContentLibraryVMTemplate, error)
 	GetTask(id string) (*models.Task, error)
@@ -417,6 +418,28 @@ func (svr *TowerVMService) FindByIDs(ids []string) ([]*models.VM, error) {
 	getVmsParams.RequestBody = &models.GetVmsRequestBody{
 		Where: &models.VMWhereInput{
 			OR: []*models.VMWhereInput{{LocalIDIn: ids}, {IDIn: ids}},
+		},
+	}
+
+	getVmsResp, err := svr.Session.VM.GetVms(getVmsParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return getVmsResp.Payload, nil
+}
+
+// FindVMsByName searches for virtual machines by name.
+func (svr *TowerVMService) FindVMsByName(name string) ([]*models.VM, error) {
+	if name == "" {
+		return nil, nil
+	}
+
+	getVmsParams := clientvm.NewGetVmsParams()
+	getVmsParams.RequestBody = &models.GetVmsRequestBody{
+		Where: &models.VMWhereInput{
+			NameStartsWith: TowerString(name),
+			Description:    TowerString(VMPlacementGroupDescription),
 		},
 	}
 

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -439,7 +439,6 @@ func (svr *TowerVMService) FindVMsByName(name string) ([]*models.VM, error) {
 	getVmsParams.RequestBody = &models.GetVmsRequestBody{
 		Where: &models.VMWhereInput{
 			NameStartsWith: TowerString(name),
-			Description:    TowerString(VMPlacementGroupDescription),
 		},
 	}
 


### PR DESCRIPTION
### 问题

当前 ELF 允许同名虚拟机存在，Tower 不允许通过 API 创建同名虚拟机。但 Tower 目前在同步 VM 到 ELF 超时失败后，会删除本地 DB 的虚拟机记录，但如果这个时候 ELF 成功创建了该虚拟机。如果再通过 Tower API 重试创建该虚拟机，就有可能出现两个同名的虚拟机。但目前 CAPE 只能使用其他一个虚拟机。

### 解决
Tower 预计未来会解决同名虚拟机的问题。在 Tower 解决该问题之前，CAPE 需要自动检测同名虚拟机，如果发现同名虚拟机，需要自动把不使用的虚拟机删除。

在当前的 ElfMachine reconcile 和删除 ElfMachine 的逻辑，在不影响现有逻辑和功能的前提下加入根据虚拟机名称找到同名虚拟机的代码。

如果考虑性能问题，可以考虑增加检测同名虚拟机的间隔时间（6m 等），例如在 ElfMachine 记录每次同名检测的时间。

可以考虑仅在创建 ElfMachine 一个时间段内（例如一个小时）做重名虚拟机检查，因为同名虚拟机仅发生在创建虚拟机的过程。

### 测试
同时创建 1CP + 30+ Worker 集群，尝试重现同名虚拟机环境。

暂复现一个同名虚拟机，观察到正常 reconcile 会删除重复的虚拟机。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/e710e661-c2b7-4cde-aab1-4488d005d55d)

![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/33534a2b-5b1b-452d-b5f8-84fd6b9d1217)

![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/e60fa89e-2fb1-40b2-ac13-a071c4ca5b27)


TODO：需要验证在删除集群的时候删除重复的虚拟机。
