### PR TITLE
SKS-1707: Optimize the creation/power on of virtual machines when PlacementGroupFilter detected for placement group

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -490,7 +490,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 				return nil, false, nil
 			}
 
-			ctx.Logger.V(1).Info(fmt.Sprintf("%s was detected previously, try to create VM", message))
+			ctx.Logger.V(1).Info(fmt.Sprintf("%s and the retry silence period passes, will try to create the VM again", message))
 		}
 
 		// Only limit the virtual machines of the worker nodes
@@ -752,7 +752,7 @@ func (r *ElfMachineReconciler) powerOnVM(ctx *context.MachineContext) error {
 			return nil
 		}
 
-		ctx.Logger.V(1).Info(fmt.Sprintf("%s was detected previously, try to power on VM %s to check if the ELF cluster has sufficient memory or satisfy policy for the placement group now", message, ctx.ElfMachine.Status.VMRef))
+		ctx.Logger.V(1).Info(fmt.Sprintf("%s and the retry silence period passes, will try to power on the VM again", message))
 	}
 
 	if ok := acquireTicketForUpdatingVM(ctx.ElfMachine.Name); !ok {
@@ -860,7 +860,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 			if err := recordPlacementGroupPolicyNotSatisfied(ctx, true); err != nil {
 				return true, err
 			}
-			message := "Not satisfy policy for the placement group"
+			message := "The placement group policy can not be satisfied"
 			ctx.Logger.Info(message)
 
 			return true, errors.New(message)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -298,7 +298,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
 			Expect(result.RequeueAfter).NotTo(BeZero())
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(logBuffer.String()).To(ContainSubstring("was detected previously, try to create VM"))
+			Expect(logBuffer.String()).To(ContainSubstring("and the retry silence period passes, will try to create the VM again"))
 			Expect(logBuffer.String()).To(ContainSubstring("Waiting for VM task done"))
 			elfMachine = &infrav1.ElfMachine{}
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
@@ -828,7 +828,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				expireELFScheduleVMError(machineContext, clusterKey)
 				err = reconciler.powerOnVM(machineContext)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(logBuffer.String()).To(ContainSubstring("was detected previously, try to power on VM"))
+				Expect(logBuffer.String()).To(ContainSubstring("and the retry silence period passes, will try to power on the VM again"))
 				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.PoweringOnReason}})
 				resetClusterResourceMap()
 			})
@@ -2699,7 +2699,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			elfMachine.Status.TaskRef = *task.ID
 			ok, err = reconciler.reconcileVMTask(machineContext, nil)
 			Expect(ok).Should(BeTrue())
-			Expect(err.Error()).To(ContainSubstring("Not satisfy policy for the placement group"))
+			Expect(err.Error()).To(ContainSubstring("The placement group policy can not be satisfied"))
 			Expect(logBuffer.String()).To(ContainSubstring("VM task failed"))
 
 			ok, msg, err := isELFScheduleVMErrorRecorded(machineContext)

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -25,31 +26,34 @@ const (
 	silenceTime = time.Minute * 5
 )
 
-var clusterStatusMap = make(map[string]*clusterStatus)
+var clusterResourceMap = make(map[string]*clusterResource)
 var lock sync.RWMutex
 
-type clusterStatus struct {
-	Resources resources
-}
-
-type resources struct {
-	IsMemoryInsufficient bool
-	// LastDetected records the last memory detection time
+type clusterResource struct {
+	// IsUnmet indicates whether the resource does not meet the requirement.
+	// For example, true can indicate insufficient memory and not match placement group policy.
+	IsUnmet bool
+	// LastDetected records the last resource detection time
 	LastDetected time.Time
-	// LastRetried records the time of the last attempt to detect memory
+	// LastRetried records the time of the last attempt to detect resource
 	LastRetried time.Time
 }
 
-// isElfClusterMemoryInsufficient returns whether the ELF cluster has insufficient memory.
-func isElfClusterMemoryInsufficient(clusterID string) bool {
+// isElfClusterMemoryInsufficientOrPlacementGroupNotMatchPolicy returns whether the ELF cluster has insufficient memory
+// or the placement group not match policy.
+func isElfClusterMemoryInsufficientOrPlacementGroupNotMatchPolicy(clusterID string, placementGroupName string) (bool, string) {
 	lock.RLock()
 	defer lock.RUnlock()
 
-	if status, ok := clusterStatusMap[clusterID]; ok {
-		return status.Resources.IsMemoryInsufficient
+	if resource, ok := clusterResourceMap[getMemoryKey(clusterID)]; ok && resource.IsUnmet {
+		return true, fmt.Sprintf("Insufficient memory for the ELF cluster %s", clusterID)
 	}
 
-	return false
+	if resource, ok := clusterResourceMap[getPlacementGroupKey(placementGroupName)]; ok && resource.IsUnmet {
+		return true, fmt.Sprintf("Not match policy for the placement group %s", placementGroupName)
+	}
+
+	return false, ""
 }
 
 // setElfClusterMemoryInsufficient sets whether the memory is insufficient.
@@ -57,42 +61,60 @@ func setElfClusterMemoryInsufficient(clusterID string, isInsufficient bool) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	now := time.Now()
-	resources := resources{
-		IsMemoryInsufficient: isInsufficient,
-		LastDetected:         now,
-		LastRetried:          now,
-	}
+	clusterResourceMap[getMemoryKey(clusterID)] = newClusterResource(isInsufficient)
+}
 
-	if status, ok := clusterStatusMap[clusterID]; ok {
-		status.Resources = resources
-	} else {
-		clusterStatusMap[clusterID] = &clusterStatus{Resources: resources}
+// setPlacementGroupNotMatchPolicy sets whether the placement group not match policy.
+func setPlacementGroupNotMatchPolicy(placementGroupName string, notMatchPolicy bool) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	clusterResourceMap[getPlacementGroupKey(placementGroupName)] = newClusterResource(notMatchPolicy)
+}
+
+func newClusterResource(isUnmet bool) *clusterResource {
+	now := time.Now()
+	return &clusterResource{
+		IsUnmet:      isUnmet,
+		LastDetected: now,
+		LastRetried:  now,
 	}
 }
 
 // canRetryVMOperation returns whether virtual machine operations(Create/PowerOn)
 // can be performed.
-func canRetryVMOperation(clusterID string) bool {
+func canRetryVMOperation(clusterID string, placementGroupName string) bool {
 	lock.Lock()
 	defer lock.Unlock()
 
-	if status, ok := clusterStatusMap[clusterID]; ok {
-		if !status.Resources.IsMemoryInsufficient {
+	return canRetry(getMemoryKey(clusterID)) || canRetry(getPlacementGroupKey(placementGroupName))
+}
+
+func canRetry(key string) bool {
+	if resource, ok := clusterResourceMap[key]; ok {
+		if !resource.IsUnmet {
 			return false
 		}
 
-		if time.Now().Before(status.Resources.LastDetected.Add(silenceTime)) {
+		if time.Now().Before(resource.LastDetected.Add(silenceTime)) {
 			return false
 		} else {
-			if time.Now().Before(status.Resources.LastRetried.Add(silenceTime)) {
+			if time.Now().Before(resource.LastRetried.Add(silenceTime)) {
 				return false
 			} else {
-				status.Resources.LastRetried = time.Now()
+				resource.LastRetried = time.Now()
 				return true
 			}
 		}
 	}
 
 	return false
+}
+
+func getMemoryKey(clusterID string) string {
+	return fmt.Sprintf("%s-memory", clusterID)
+}
+
+func getPlacementGroupKey(placementGroup string) string {
+	return fmt.Sprintf("%s-placement-group", placementGroup)
 }

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -28,75 +28,62 @@ var _ = Describe("TowerCache", func() {
 
 	BeforeEach(func() {
 		clusterID = fake.UUID()
-		resetClusterStatusMap()
+		resetClusterResourceMap()
 	})
 
 	It("should set memoryInsufficient", func() {
-		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
-		Expect(clusterStatusMap[clusterID]).To(BeNil())
+		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
 
-		resetClusterStatusMap()
-		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
-		Expect(clusterStatusMap[clusterID]).To(BeNil())
-
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
+		resetClusterResourceMap()
+		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
 
 		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeFalse())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+
+		setElfClusterMemoryInsufficient(clusterID, false)
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterStatusMap[clusterID].Resources.IsMemoryInsufficient).To(BeTrue())
-		Expect(clusterStatusMap[clusterID].Resources.LastDetected).To(Equal(clusterStatusMap[clusterID].Resources.LastRetried))
-	})
-
-	It("should return whether memory is insufficient", func() {
-		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
-		Expect(clusterStatusMap[clusterID]).To(BeNil())
-
-		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
-
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeFalse())
-
-		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(isElfClusterMemoryInsufficient(clusterID)).To(BeTrue())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
+		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
 	})
 
 	It("should return whether need to detect", func() {
-		Expect(clusterStatusMap).NotTo(HaveKey(clusterID))
-		Expect(clusterStatusMap[clusterID]).To(BeNil())
+		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
+		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
 
-		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
 
 		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
 
-		clusterStatusMap[clusterID].Resources.LastDetected = clusterStatusMap[clusterID].Resources.LastDetected.Add(-silenceTime)
-		clusterStatusMap[clusterID].Resources.LastRetried = clusterStatusMap[clusterID].Resources.LastRetried.Add(-silenceTime)
-		Expect(canRetryVMOperation(clusterID)).To(BeTrue())
+		clusterResourceMap[getMemoryKey(clusterID)].LastDetected = clusterResourceMap[getMemoryKey(clusterID)].LastDetected.Add(-silenceTime)
+		clusterResourceMap[getMemoryKey(clusterID)].LastRetried = clusterResourceMap[getMemoryKey(clusterID)].LastRetried.Add(-silenceTime)
+		Expect(canRetryVMOperation(clusterID, "")).To(BeTrue())
 
-		Expect(canRetryVMOperation(clusterID)).To(BeFalse())
+		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
 	})
 })
 
-func resetClusterStatusMap() {
-	clusterStatusMap = make(map[string]*clusterStatus)
+func resetClusterResourceMap() {
+	clusterResourceMap = make(map[string]*clusterResource)
 }

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -17,72 +17,168 @@ limitations under the License.
 package controllers
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
 )
 
-var _ = Describe("TowerCache", func() {
-	var clusterID string
+const (
+	clusterKey        = "clusterID"
+	placementGroupKey = "getPlacementGroupName"
+)
 
+var _ = Describe("TowerCache", func() {
 	BeforeEach(func() {
-		clusterID = fake.UUID()
 		resetClusterResourceMap()
 	})
 
-	It("should set memoryInsufficient", func() {
-		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
-		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
+	It("should set memoryInsufficient/policyNotSatisfied", func() {
+		for _, name := range []string{clusterKey, placementGroupKey} {
+			resetClusterResourceMap()
+			elfCluster, cluster, elfMachine, machine, secret := fake.NewClusterAndMachineObjects()
+			elfCluster.Spec.Cluster = name
+			md := fake.NewMD()
+			md.Name = name
+			fake.ToWorkerMachine(machine, md)
+			fake.ToWorkerMachine(elfMachine, md)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, nil)
+			key := getKey(machineContext, name)
 
-		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			Expect(clusterResourceMap).NotTo(HaveKey(key))
+			Expect(clusterResourceMap[key]).To(BeNil())
 
-		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			recordIsUnmet(machineContext, name, true)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeTrue())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
 
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			recordIsUnmet(machineContext, name, true)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeTrue())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
 
-		resetClusterResourceMap()
-		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
-		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
+			recordIsUnmet(machineContext, name, false)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeFalse())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
 
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			resetClusterResourceMap()
+			Expect(clusterResourceMap).NotTo(HaveKey(name))
+			Expect(clusterResourceMap[key]).To(BeNil())
 
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeFalse())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			recordIsUnmet(machineContext, name, false)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeFalse())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
 
-		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].IsUnmet).To(BeTrue())
-		Expect(clusterResourceMap[getMemoryKey(clusterID)].LastDetected).To(Equal(clusterResourceMap[getMemoryKey(clusterID)].LastRetried))
+			recordIsUnmet(machineContext, name, false)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeFalse())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
+
+			recordIsUnmet(machineContext, name, true)
+			Expect(clusterResourceMap[key].IsUnmet).To(BeTrue())
+			Expect(clusterResourceMap[key].LastDetected).To(Equal(clusterResourceMap[key].LastRetried))
+		}
 	})
 
 	It("should return whether need to detect", func() {
-		Expect(clusterResourceMap).NotTo(HaveKey(clusterID))
-		Expect(clusterResourceMap[getMemoryKey(clusterID)]).To(BeNil())
+		for _, name := range []string{clusterKey, placementGroupKey} {
+			resetClusterResourceMap()
+			elfCluster, cluster, elfMachine, machine, secret := fake.NewClusterAndMachineObjects()
+			elfCluster.Spec.Cluster = name
+			md := fake.NewMD()
+			md.Name = name
+			fake.ToWorkerMachine(machine, md)
+			fake.ToWorkerMachine(elfMachine, md)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, nil)
+			key := getKey(machineContext, name)
 
-		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
+			Expect(clusterResourceMap).NotTo(HaveKey(key))
+			Expect(clusterResourceMap[key]).To(BeNil())
+			ok, err := canRetryVMOperation(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		setElfClusterMemoryInsufficient(clusterID, false)
-		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
+			recordIsUnmet(machineContext, name, false)
+			ok, err = canRetryVMOperation(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		setElfClusterMemoryInsufficient(clusterID, true)
-		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
+			recordIsUnmet(machineContext, name, true)
+			ok, err = canRetryVMOperation(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		clusterResourceMap[getMemoryKey(clusterID)].LastDetected = clusterResourceMap[getMemoryKey(clusterID)].LastDetected.Add(-silenceTime)
-		clusterResourceMap[getMemoryKey(clusterID)].LastRetried = clusterResourceMap[getMemoryKey(clusterID)].LastRetried.Add(-silenceTime)
-		Expect(canRetryVMOperation(clusterID, "")).To(BeTrue())
+			expireELFScheduleVMError(machineContext, name)
+			ok, err = canRetryVMOperation(machineContext)
+			Expect(ok).To(BeTrue())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		Expect(canRetryVMOperation(clusterID, "")).To(BeFalse())
+			ok, err = canRetryVMOperation(machineContext)
+			Expect(ok).To(BeFalse())
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+	})
+
+	It("isELFScheduleVMErrorRecorded", func() {
+		resetClusterResourceMap()
+		elfCluster, cluster, elfMachine, machine, secret := fake.NewClusterAndMachineObjects()
+		elfCluster.Spec.Cluster = clusterKey
+		md := fake.NewMD()
+		md.Name = placementGroupKey
+		fake.ToWorkerMachine(machine, md)
+		fake.ToWorkerMachine(elfMachine, md)
+		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+		machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, nil)
+
+		ok, msg, err := isELFScheduleVMErrorRecorded(machineContext)
+		Expect(ok).To(BeFalse())
+		Expect(msg).To(Equal(""))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		recordIsUnmet(machineContext, clusterKey, true)
+		ok, msg, err = isELFScheduleVMErrorRecorded(machineContext)
+		Expect(ok).To(BeTrue())
+		Expect(msg).To(ContainSubstring("Insufficient memory detected for the ELF cluster"))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		resetClusterResourceMap()
+		recordIsUnmet(machineContext, placementGroupKey, true)
+		ok, msg, err = isELFScheduleVMErrorRecorded(machineContext)
+		Expect(ok).To(BeTrue())
+		Expect(msg).To(ContainSubstring("Not satisfy policy detected for the placement group"))
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 })
+
+func getKey(ctx *context.MachineContext, name string) string {
+	if name == clusterKey {
+		return getMemoryKey(name)
+	}
+
+	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return getPlacementGroupKey(placementGroupName)
+}
+
+func recordIsUnmet(ctx *context.MachineContext, key string, isUnmet bool) {
+	if strings.Contains(key, clusterKey) {
+		recordElfClusterMemoryInsufficient(ctx, isUnmet)
+		return
+	}
+
+	Expect(recordPlacementGroupPolicyNotSatisfied(ctx, isUnmet)).ShouldNot(HaveOccurred())
+}
+
+func expireELFScheduleVMError(ctx *context.MachineContext, name string) {
+	key := getKey(ctx, name)
+	clusterResourceMap[key].LastDetected = clusterResourceMap[key].LastDetected.Add(-silenceTime)
+	clusterResourceMap[key].LastRetried = clusterResourceMap[key].LastRetried.Add(-silenceTime)
+}
 
 func resetClusterResourceMap() {
 	clusterResourceMap = make(map[string]*clusterResource)

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -36,6 +36,9 @@ const (
 	LabelAddFailed            = "LABEL_ADD_FAILED"
 	CloudInitError            = "VM_CLOUD_INIT_CONFIG_ERROR"
 	MemoryInsufficientError   = "HostAvailableMemoryFilter"
+	PlacementGroupError       = "PlacementGroupFilter" // SMTX OS <= 5.0.4
+	PlacementGroupMustError   = "PlacementGroupMustFilter"
+	PlacementGroupPriorError  = "PlacementGroupPriorFilter"
 )
 
 func IsVMNotFound(err error) bool {
@@ -85,4 +88,18 @@ func FormatCloudInitError(message string) string {
 
 func IsMemoryInsufficientError(message string) bool {
 	return strings.Contains(message, MemoryInsufficientError)
+}
+
+func IsPlacementGroupError(message string) bool {
+	return strings.Contains(message, PlacementGroupError) ||
+		IsPlacementGroupMustError(message) ||
+		IsPlacementGroupPriorError(message)
+}
+
+func IsPlacementGroupMustError(message string) bool {
+	return strings.Contains(message, PlacementGroupMustError)
+}
+
+func IsPlacementGroupPriorError(message string) bool {
+	return strings.Contains(message, PlacementGroupPriorError)
 }


### PR DESCRIPTION
### 问题 SKS-1707
在 3 主机环境创建 3CP 集群后，其中一个主机故障后，主机所在的 CP 虚拟机关机，CAPE 会尝试启动该虚拟机。因为 CP 使用了必须在不同主机的放置组，所以 ELF 尝试启动该虚拟机失败。

### 解决
跟之前内存不足一样，通过检测 ELF 返回的错误信息，如果发现是不满足放置组规则，每隔五分钟再运行创建或关机逻辑。

### 测试
在 3 主机环境创建 3CP 集群，然后使其中一个主机不可用，之后该主机所在的 CP 被关机，CAPE 会使用上述的策略进行尝试开机。

<img width="1302" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/224d4a0c-9806-4542-82b0-06541f402b06">

因改动了原来内存不足重试的逻辑，也测试了这部分，这次改动没有影响：
<img width="1282" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/5078c884-e671-4ade-ab98-4bb336f6dea0">

