### PR TITLE
SKS-1717: Stop rolling out more CP VM when the placement group is full and KCP replicas is greater than host count

### DIFF
--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -220,7 +220,7 @@ func (r *ElfMachineReconciler) preCheckPlacementGroup(ctx *context.MachineContex
 	// If KCP.Spec.Replicas is greater than the host count,
 	// do not allow creating more KCP VM because there is no more host to place the new VM.
 	if int(*kcp.Spec.Replicas) > usedHostsByPG.Len() {
-		ctx.Logger.V(1).Info("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts", "placementGroup", *placementGroup.Name, "usedHostsByPG", usedHostsByPG.String(), "usedHostsCount", usedHostsByPG.Len(), "kcpReplicas", *kcp.Spec.Replicas)
+		ctx.Logger.V(1).Info("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts", "placementGroup", *placementGroup.Name, "usedHostsByPG", usedHostsByPG.String(), "usedHostsCount", usedHostsByPG.Len(), "kcpReplicas", *kcp.Spec.Replicas)
 
 		return nil, nil
 	}
@@ -433,7 +433,7 @@ func (r *ElfMachineReconciler) joinPlacementGroup(ctx *context.MachineContext, v
 				// If KCP.Spec.Replicas is greater than the host count,
 				// do not allow creating more KCP VM because there is no more host to place the new VM.
 				if int(*kcp.Spec.Replicas) > usedHostsByPG.Len() {
-					ctx.Logger.V(1).Info("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts", "placementGroup", *placementGroup.Name, "usedHostsByPG", usedHostsByPG.String(), "usedHostsCount", usedHostsByPG.Len(), "kcpReplicas", *kcp.Spec.Replicas)
+					ctx.Logger.V(1).Info("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts", "placementGroup", *placementGroup.Name, "usedHostsByPG", usedHostsByPG.String(), "usedHostsCount", usedHostsByPG.Len(), "kcpReplicas", *kcp.Spec.Replicas)
 
 					return false, nil
 				}

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -425,8 +425,7 @@ func (r *ElfMachineReconciler) joinPlacementGroup(ctx *context.MachineContext, v
 				return false, err
 			}
 
-			// Only when the KCP is in rolling update, the VM is stopped, and all the hosts used by the placement group are available,
-			// will the upgrade be allowed.
+			// Proceed only when the KCP is in rolling update, the VM is stopped, and all the hosts used by the placement group are available.
 			// In this case the machine created by KCP rolling update can be powered on without being added to the placement group,
 			// so return true and nil to let reconcileVMStatus() power it on.
 			if kcputil.IsKCPInRollingUpdate(kcp) && *vm.Status == models.VMStatusSTOPPED {

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -430,14 +430,6 @@ func (r *ElfMachineReconciler) joinPlacementGroup(ctx *context.MachineContext, v
 			// In this case the machine created by KCP rolling update can be powered on without being added to the placement group,
 			// so return true and nil to let reconcileVMStatus() power it on.
 			if kcputil.IsKCPInRollingUpdate(kcp) && *vm.Status == models.VMStatusSTOPPED {
-				// If KCP.Spec.Replicas is greater than the host count,
-				// do not allow creating more KCP VM because there is no more host to place the new VM.
-				if int(*kcp.Spec.Replicas) > usedHostsByPG.Len() {
-					ctx.Logger.V(1).Info("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts", "placementGroup", *placementGroup.Name, "usedHostsByPG", usedHostsByPG.String(), "usedHostsCount", usedHostsByPG.Len(), "kcpReplicas", *kcp.Spec.Replicas)
-
-					return false, nil
-				}
-
 				unusablehosts := usedHostsByPG.FilterUnavailableHostsOrWithoutEnoughMemory(*service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
 				if unusablehosts.IsEmpty() {
 					ctx.Logger.Info("KCP is in rolling update, the placement group is full and has no unusable hosts, so skip adding VM to the placement group and power it on", "placementGroup", *placementGroup.Name, "availableHosts", availableHosts.String(), "usedHostsByPG", usedHostsByPG.String(), "vmRef", ctx.ElfMachine.Status.VMRef, "vmId", *vm.ID)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1056,7 +1056,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				ok, err = reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
-				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and capacity is less than replicas of kcp, so wait for enough available hosts"))
+				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts"))
 			})
 
 			It("should add VM to placement group when VM is not in placement group and the host where VM in is not in placement group", func() {
@@ -1418,7 +1418,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				host, err = reconciler.preCheckPlacementGroup(machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
-				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and capacity is less than replicas of kcp, so wait for enough available hosts"))
+				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts"))
 
 				logBuffer = new(bytes.Buffer)
 				klog.SetOutput(logBuffer)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1056,7 +1056,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				ok, err = reconciler.joinPlacementGroup(machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
-				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts"))
+				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts"))
 			})
 
 			It("should add VM to placement group when VM is not in placement group and the host where VM in is not in placement group", func() {
@@ -1418,7 +1418,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				host, err = reconciler.preCheckPlacementGroup(machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
-				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no available host for placing more KCP VM, so wait for enough available hosts"))
+				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts"))
 
 				logBuffer = new(bytes.Buffer)
 				klog.SetOutput(logBuffer)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1040,23 +1040,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
 				Expect(logBuffer.String()).To(ContainSubstring("KCP is in scaling up or being created, the placement group is full, so wait for enough available hosts"))
-
-				logBuffer = new(bytes.Buffer)
-				klog.SetOutput(logBuffer)
-				kcp.Spec.Replicas = pointer.Int32(2)
-				kcp.Status.Replicas = 2
-				kcp.Status.UpdatedReplicas = 1
-				ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md, kcp)
-				machineContext = newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-				mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
-				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
-				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{vm2}, nil)
-				reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
-				ok, err = reconciler.joinPlacementGroup(machineContext, vm)
-				Expect(ok).To(BeFalse())
-				Expect(err).To(BeZero())
-				Expect(logBuffer.String()).To(ContainSubstring("KCP is in rolling update, the placement group is full and no more host for placing more KCP VM, so wait for enough available hosts"))
 			})
 
 			It("should add VM to placement group when VM is not in placement group and the host where VM in is not in placement group", func() {


### PR DESCRIPTION
### 问题
[[SKS-1717] 放置组 - 1.0版本的5cp工作负载集群升级后缩容为3cp，放置组中之有一个cp节点 - Jira](http://jira.smartx.com/browse/SKS-1717)
 CP 数量大于放置组容量的集群可以进行升级。例如 3可用主机环境，可以升级 5 CP 的集群。预期只能升级前 3个 CP，阻塞在第四个新 CP。

### 方案
恢复之前删除的代码 `int(*kcp.Spec.Replicas) > usedHostsByPG.Len()`。当放置组已经满了，且 kcp.Spec.Replicas 大于当前放置组已使用的容量的时候，后续的 CP 节点不允许进行滚动更新。

### 测试
3 主机环境。

1. 5CP 没有使用放置组的集群升级（模拟 1.0 升级到 1.1），前三个新 CP 正常升级，且进入了放置组。第四个新 CP 因可用主机不够阻塞。这个时候手动缩容为 3CP，第四个新 CP 被自动删除。集群完成升级。

2. 3 CP 集群可以正常升级。

3. 3CP 集群扩容到 3CP，第四个 CP 因可用主机不够阻塞。手动缩容到 3CP，第四个 CP 被自动删除，恢复正常。

