### PR TITLE
SKS-1691: Decrease the retry interval for creating placement groups to 5 minutes

### DIFF
--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -27,9 +27,9 @@ import (
 const (
 	creationTimeout      = time.Minute * 6
 	vmOperationRateLimit = time.Second * 6
-	// Normally, Tower syncs placement groups from the ELF cluster within a minute.
-	// When a placement group with the same name appears, the ELF service is unstable,
-	// so the retry time is set to 5 minutes.
+	// When Tower gets a placement group name duplicate error, it means the ELF API is responding slow.
+	// Tower will sync this placement group from ELF cluster immediately and the sync usually can complete within 1~2 minute.
+	// So set the placement group creation retry interval to 5 minutes.
 	placementGroupSilenceTime     = time.Minute * 5
 	placementGroupCreationLockKey = "%s:creation"
 )

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -25,9 +25,12 @@ import (
 )
 
 const (
-	creationTimeout               = time.Minute * 6
-	vmOperationRateLimit          = time.Second * 6
-	placementGroupSilenceTime     = time.Minute * 30
+	creationTimeout      = time.Minute * 6
+	vmOperationRateLimit = time.Second * 6
+	// Normally, Tower syncs placement groups from the ELF cluster within a minute.
+	// When a placement group with the same name appears, the ELF service is unstable,
+	// so the retry time is set to 5 minutes.
+	placementGroupSilenceTime     = time.Minute * 5
 	placementGroupCreationLockKey = "%s:creation"
 )
 


### PR DESCRIPTION
### 问题
Tower 在创建放置组的 task 中增加了检测到放置组已经存在会触发一次放置组数据同步。

### 方案

正常情况下放置组同步在一分钟内完成，考虑到出现同名放置组的时候 ELF 服务不稳定，暂把重试时间设置为 5m。

### 测试
需要等待 Tower 发版部署后，CAPE 发版后通过 E2E 验证。
