### PR TITLE
SKS-1701: Filter ECP IP when using `kubectl get elfmachine`

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -179,7 +179,7 @@ type ElfMachineStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElfMachine ready status"
 //+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="ElfMachine instance ID"
-//+kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.addresses[?(@.address!=\"240.255.0.1\")].address",description="IP address of one of the virtual machine's network devices"
+//+kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.addresses[?(@.address!=\"240.255.0.1\")].address",description="IP addresses of the virtual machine"
 //+kubebuilder:printcolumn:name="HOST",type="string",JSONPath=".status.hostServerName",description="Name of host server where the virtual machine runs on"
 //+kubebuilder:printcolumn:name="PLACEMENTGROUP",type="string",JSONPath=".status.placementGroupRef",description="ID of Tower placement group which this ElfMachine belongs to"
 //+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this ElfMachine"

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -179,7 +179,7 @@ type ElfMachineStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElfMachine ready status"
 //+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="ElfMachine instance ID"
-//+kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.addresses[0].address",description="IP address of the first network device of the virtual machine"
+//+kubebuilder:printcolumn:name="IP",type="string",JSONPath=".status.addresses[?(@.address!=\"240.255.0.1\")].address",description="IP address of one of the virtual machine's network devices"
 //+kubebuilder:printcolumn:name="HOST",type="string",JSONPath=".status.hostServerName",description="Name of host server where the virtual machine runs on"
 //+kubebuilder:printcolumn:name="PLACEMENTGROUP",type="string",JSONPath=".status.placementGroupRef",description="ID of Tower placement group which this ElfMachine belongs to"
 //+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this ElfMachine"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -23,7 +23,7 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
-    - description: IP address of one of the virtual machine's network devices
+    - description: IP addresses of the virtual machine
       jsonPath: .status.addresses[?(@.address!="240.255.0.1")].address
       name: IP
       type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -23,8 +23,8 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
-    - description: IP address of the first network device of the virtual machine
-      jsonPath: .status.addresses[0].address
+    - description: IP address of one of the virtual machine's network devices
+      jsonPath: .status.addresses[?(@.address!="240.255.0.1")].address
       name: IP
       type: string
     - description: Name of host server where the virtual machine runs on


### PR DESCRIPTION
### 问题
通过 kubectl get elfmachine 的时候，会显示 ECP 的 fake IP.

### 解决
通过 JSONPath=".status.addresses[?(@.address!=\"240.255.0.1\")].address 过滤 ECP IP，240.255.0.1 是 ECP 固定使用的 IP。

### 测试
1. addresses: [] 为空

kubectl get elfmachine  
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/04d40383-bdaf-47d3-91fe-dc5883a2ed96)

kubectl get elfmachine haijian-test3-controlplane-b7cwh -o=jsonpath="{.status.addresses[*].address}"
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/6bd65e8d-c491-4f4c-b81c-2946dbb79af4)

2. addresses: [{address: 240.255.0.1, type: InternalIP}]

kubectl get elfmachine (默认使用修改过的CRD column定义，会将ecp fake IP过滤掉)
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/8d6a9534-c6dc-4464-886f-c5a5c685ea0b)

kubectl get elfmachine haijian-test3-controlplane-b7cwh -o=jsonpath="{.status.addresses[*].address}"
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/f5a91aab-5a80-429e-b297-ea1ba6465bd3)

3. addresses: [{address: 240.255.0.1, type: InternalIP},{address: 10.255.3.60, type: InternalIP}]

kubectl get elfmachine
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/ca3d9dc5-276b-4035-9489-569b46d414dc)

kubectl get elfmachine haijian-test3-controlplane-b7cwh -o=jsonpath="{.status.addresses[*].address}"
![image (12)](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/d4629f90-ecfe-44d9-84c3-a6595d5d3853)


