### PR TITLE
Follow template's firmware settings when cloning vm from template

### DIFF
--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -233,7 +233,6 @@ func (svr *TowerVMService) Clone(
 		CPUCores:    cpuCores,
 		CPUSockets:  cpuSockets,
 		Memory:      TowerMemory(elfMachine.Spec.MemoryMiB),
-		Firmware:    models.NewVMFirmware(models.VMFirmwareBIOS),
 		Status:      models.NewVMStatus(models.VMStatusSTOPPED),
 		Ha:          TowerBool(elfMachine.Spec.HA),
 		IsFullCopy:  TowerBool(isFullCopy),


### PR DESCRIPTION
## Issue
在aarch64集群无法正常执行克隆操作

![Snipaste_2023-08-16_13-36-23](https://github.com/smartxworks/cluster-api-provider-elf/assets/3226923/1e7c8987-8d45-4612-bb2d-f101eecf591c)

## Cause
克隆vm的firmware设置不正确，它应该跟随template设置

## Changes
- 移除Firmware hardcode设置，使用为空自动跟随template的设置

## Test

arm64和amd64，uefi，bios均正常工作

<img width="1339" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/3226923/f721b66f-348c-4614-b434-77eec817fde3">

<img width="608" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/3226923/4b39b7b1-d043-42a3-a566-1f1b67b58d22">


<img width="599" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/3226923/196f8c9f-8674-4a0e-b4f8-054d0036a493">

