### PR TITLE
SKS-1642: Delay creation of vm when duplicate vm is encountered

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -502,7 +502,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 		}
 
 		if ok, msg := acquireTicketForCreateVM(ctx.ElfMachine.Name, machineutil.IsControlPlaneMachine(ctx.ElfMachine)); !ok {
-			ctx.Logger.V(1).Info(fmt.Sprintf("%s, skip creating VM %s", msg, ctx.ElfMachine.Name))
+			ctx.Logger.V(1).Info(fmt.Sprintf("%s, skip creating VM", msg))
 			return nil, false, nil
 		}
 
@@ -701,7 +701,7 @@ func (r *ElfMachineReconciler) reconcileVMStatus(ctx *context.MachineContext, vm
 
 func (r *ElfMachineReconciler) shutDownVM(ctx *context.MachineContext) error {
 	if ok := acquireTicketForUpdatingVM(ctx.ElfMachine.Name); !ok {
-		ctx.Logger.V(1).Info(fmt.Sprintf("The VM operation reaches rate limit, skip shut down VM %s", ctx.ElfMachine.Status.VMRef))
+		ctx.Logger.V(1).Info("The VM operation reaches rate limit, skip shut down VM")
 
 		return nil
 	}

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -501,12 +501,9 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 			ctx.Logger.V(1).Info(fmt.Sprintf("%s and the retry silence period passes, will try to create the VM again", message))
 		}
 
-		// Only limit the virtual machines of the worker nodes
-		if !machineutil.IsControlPlaneMachine(ctx.ElfMachine) {
-			if ok := acquireTicketForCreateVM(ctx.ElfMachine.Name); !ok {
-				ctx.Logger.V(1).Info(fmt.Sprintf("The number of concurrently created VMs has reached the limit, skip creating VM %s", ctx.ElfMachine.Name))
-				return nil, false, nil
-			}
+		if ok, msg := acquireTicketForCreateVM(ctx.ElfMachine.Name, machineutil.IsControlPlaneMachine(ctx.ElfMachine)); !ok {
+			ctx.Logger.V(1).Info(fmt.Sprintf("%s, skip creating VM %s", msg, ctx.ElfMachine.Name))
+			return nil, false, nil
 		}
 
 		hostID, err := r.preCheckPlacementGroup(ctx)
@@ -858,6 +855,10 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		switch {
 		case service.IsCloneVMTask(task):
 			releaseTicketForCreateVM(ctx.ElfMachine.Name)
+
+			if service.IsVMDuplicateError(errorMessage) {
+				setVMDuplicate(ctx.ElfMachine.Name)
+			}
 		case service.IsMemoryInsufficientError(errorMessage):
 			recordElfClusterMemoryInsufficient(ctx, true)
 			message := fmt.Sprintf("Insufficient memory detected for the ELF cluster %s", ctx.ElfCluster.Spec.Cluster)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -2712,6 +2712,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should handle failed/succeeded task", func() {
 			resetClusterResourceMap()
+			resetVMOperationMap()
 			task := fake.NewTowerTask()
 			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
 			task.ErrorMessage = service.TowerString(service.MemoryInsufficientError)
@@ -2755,6 +2756,17 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(ok).To(BeFalse())
 			Expect(msg).To(Equal(""))
 			Expect(err).ShouldNot(HaveOccurred())
+
+			// Duplicate VM
+			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
+			task.Description = service.TowerString("Create a VM")
+			task.ErrorMessage = service.TowerString(service.VMDuplicateError)
+			elfMachine.Status.TaskRef = *task.ID
+			ok, err = reconciler.reconcileVMTask(machineContext, nil)
+			Expect(ok).Should(BeTrue())
+			Expect(err).ShouldNot(HaveOccurred())
+			ok, _ = acquireTicketForCreateVM(elfMachine.Name, true)
+			Expect(ok).To(BeFalse())
 		})
 	})
 

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -39,6 +39,7 @@ const (
 	PlacementGroupError       = "PlacementGroupFilter" // SMTX OS <= 5.0.4
 	PlacementGroupMustError   = "PlacementGroupMustFilter"
 	PlacementGroupPriorError  = "PlacementGroupPriorFilter"
+	VMDuplicateError          = "VM_DUPLICATED_NAME"
 )
 
 func IsVMNotFound(err error) bool {
@@ -47,6 +48,10 @@ func IsVMNotFound(err error) bool {
 
 func IsVMDuplicate(err error) bool {
 	return strings.Contains(err.Error(), VMDuplicate)
+}
+
+func IsVMDuplicateError(message string) bool {
+	return strings.Contains(message, VMDuplicateError)
 }
 
 func IsShutDownTimeout(message string) bool {

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -438,7 +438,7 @@ func (svr *TowerVMService) FindVMsByName(name string) ([]*models.VM, error) {
 	getVmsParams := clientvm.NewGetVmsParams()
 	getVmsParams.RequestBody = &models.GetVmsRequestBody{
 		Where: &models.VMWhereInput{
-			NameStartsWith: TowerString(name),
+			Name: TowerString(name),
 		},
 	}
 


### PR DESCRIPTION
### 问题
同名虚拟机创建任务过于频繁

### 解决
遇到同名虚拟机，延迟五分钟创建虚拟机。

TODO：vmConcurrentMap、vmOperationMap、placementGroupOperationMap 的数据存在内存泄露，需要 GC。

### 测试
每五分钟重试一次，符合预期
<img width="1312" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/0c82efc7-50f8-42b2-9dda-591611d96cfb">
