### PR TITLE
SKS-1691: Increase the wait timeout for creating placement group to 10s

### DIFF
--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -101,7 +101,7 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 		// For simplicity, both cases are treated as duplicate placement groups.
 		setPlacementGroupDuplicate(placementGroupName)
 
-		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.PlacementGroupCreationWaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)
+		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done: placementName %s, taskID %s", placementGroupName, *withTaskVMPlacementGroup.TaskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -66,7 +66,7 @@ func (r *ElfMachineReconciler) reconcilePlacementGroup(ctx *context.MachineConte
 		if placementGroup, err := r.createPlacementGroup(ctx, placementGroupName); err != nil {
 			return reconcile.Result{}, err
 		} else if placementGroup == nil {
-			return reconcile.Result{RequeueAfter: config.VMPlacementGroupDuplicateTimeout}, err
+			return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, err
 		}
 	} else if placementGroup == nil {
 		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -2618,7 +2618,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
-			Expect(result.RequeueAfter).To(Equal(config.VMPlacementGroupDuplicateTimeout))
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeueTimeout))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Tower has duplicate placement group, skip creating placement group %s", placementGroupName)))
 		})

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -2593,7 +2593,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done timed out in %s: placementName %s, taskID %s", config.PlacementGroupCreationWaitTaskTimeout, placementGroupName, *withTaskVMPlacementGroup.TaskID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done: placementName %s, taskID %s", placementGroupName, *withTaskVMPlacementGroup.TaskID)))
 			Expect(canCreatePlacementGroup(placementGroupName)).To(BeFalse())
 
 			logBuffer = new(bytes.Buffer)

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -148,3 +148,7 @@ func resetVMStatusMap() {
 func resetVMOperationMap() {
 	vmOperationMap = make(map[string]time.Time)
 }
+
+func resetPlacementGroupOperationMap() {
+	placementGroupOperationMap = make(map[string]time.Time)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,10 +25,6 @@ var (
 	// requeueing a CAPE operation.
 	DefaultRequeueTimeout = 10 * time.Second
 
-	// VMPlacementGroupDuplicateTimeout is the time for how long to wait when
-	// requeueing a CAPE operation after encountering VMPlacementGroupDuplicate error.
-	VMPlacementGroupDuplicateTimeout = 10 * time.Minute
-
 	// WaitTaskInterval is the default interval time polling task.
 	WaitTaskInterval = 1 * time.Second
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,4 +34,7 @@ var (
 
 	// WaitTaskTimeout is the default timeout for waiting for task to complete.
 	WaitTaskTimeout = 3 * time.Second
+
+	// PlacementGroupCreationWaitTaskTimeout is the timeout for waiting for placement group creation task to complete.
+	PlacementGroupCreationWaitTaskTimeout = 10 * time.Second
 )


### PR DESCRIPTION
### 问题
当前创建放置组使用了3秒超时时间，而Tower创建放置组的任务超过3秒还没有结束时，会导致 CAPE 没有捕获到 “同名放置组”的错误，从而在requeue时继续创建放置组。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/4ce00ad1-f8e0-4f68-82b9-c1d58b2fb5e7)

### 方案
把等待创建放置组的Task的超时时间设置为10秒(因为大多数创建放置组的请求都是只耗时0秒，还有一些是1到9秒不等)。如果等待超时，就认定创建放置组失败，进入5分钟的创建放置组静默期。如果Tower确实遇到创建放置组任务超时，则Tower会主动从ELF同步此放置组，如果Tower在10秒后创建放置组任务成功，则CAPE也会在随后每10秒的requeue中查找到此放置组。

### 测试
通过给ELF主机CPU加压，能让Tower创建放置组的任务需要10秒以上才能完成，甚至1分钟后超时失败。从而验证此PR的有效性。
`[smartx@node20-216 20:14:13 ~]$ stress-ng -c 4 -l 60`