### PR TITLE
SKS-1691: Increase placement group updating timeout to 10s

### DIFF
--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -94,14 +94,14 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 		return nil, err
 	}
 
-	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval)
+	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval)
 	if err != nil {
 		// The default timeout for Tower to create a placement group is one minute.
 		// When current task times out, duplicate placement groups may or may not appear.
 		// For simplicity, both cases are treated as duplicate placement groups.
 		setPlacementGroupDuplicate(placementGroupName)
 
-		return nil, errors.Wrapf(err, "failed to wait for placement group creation task done: placementName %s, taskID %s", placementGroupName, *withTaskVMPlacementGroup.TaskID)
+		return nil, errors.Wrapf(err, "failed to wait for placement group creation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {
@@ -564,9 +564,9 @@ func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContex
 	}
 
 	taskID := *task.ID
-	task, err = ctx.VMService.WaitTask(taskID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval)
+	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group updation task done: placementName %s, taskID %s", *placementGroup.Name, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group updation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, taskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -94,7 +94,7 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 		return nil, err
 	}
 
-	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.PlacementGroupCreationWaitTaskTimeout, config.WaitTaskInterval)
+	task, err := ctx.VMService.WaitTask(*withTaskVMPlacementGroup.TaskID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
 		// The default timeout for Tower to create a placement group is one minute.
 		// When current task times out, duplicate placement groups may or may not appear.
@@ -564,9 +564,9 @@ func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContex
 	}
 
 	taskID := *task.ID
-	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
+	task, err = ctx.VMService.WaitTask(taskID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group updation task done: placementName %s, taskID %s", *placementGroup.Name, taskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {

--- a/controllers/elfmachine_controller_placement_group.go
+++ b/controllers/elfmachine_controller_placement_group.go
@@ -101,7 +101,7 @@ func (r *ElfMachineReconciler) createPlacementGroup(ctx *context.MachineContext,
 		// For simplicity, both cases are treated as duplicate placement groups.
 		setPlacementGroupDuplicate(placementGroupName)
 
-		return nil, errors.Wrapf(err, "failed to wait for placement group creation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)
+		return nil, errors.Wrapf(err, "failed to wait for placement group creating task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {
@@ -566,7 +566,7 @@ func (r *ElfMachineReconciler) addVMsToPlacementGroup(ctx *context.MachineContex
 	taskID := *task.ID
 	task, err = ctx.VMService.WaitTask(taskID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group updation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group updating task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, taskID)
 	}
 
 	if *task.Status == models.TaskStatusFAILED {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -874,7 +874,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -898,7 +898,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err := reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
@@ -910,7 +910,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			taskStatus = models.TaskStatusFAILED
 			task.Status = &taskStatus
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
@@ -919,12 +919,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task done: placementName %s, taskID %s", *placementGroup.Name, *task.ID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, *task.ID)))
 		})
 
 		It("should wait for placement group task done", func() {
@@ -1002,7 +1002,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs([]string{}).Return([]*models.VM{}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-				mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -1110,7 +1110,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, gomock.Any()).Return(task, nil)
-				mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -2560,7 +2560,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
@@ -2575,7 +2575,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
@@ -2588,12 +2588,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task done: placementName %s, taskID %s", placementGroupName, *withTaskVMPlacementGroup.TaskID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)))
 			Expect(canCreatePlacementGroup(placementGroupName)).To(BeFalse())
 
 			logBuffer = new(bytes.Buffer)
@@ -2604,7 +2604,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
 			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
 			task.ErrorMessage = pointer.String(service.VMPlacementGroupDuplicate)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeoutForPlacementGroupOperation, config.WaitTaskInterval).Return(task, nil)
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -924,7 +924,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, *task.ID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updating task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, *placementGroup.Name, *task.ID)))
 		})
 
 		It("should wait for placement group task done", func() {
@@ -2593,7 +2593,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creation task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group creating task to complete in %s: pgName %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, *withTaskVMPlacementGroup.TaskID)))
 			Expect(canCreatePlacementGroup(placementGroupName)).To(BeFalse())
 
 			logBuffer = new(bytes.Buffer)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -874,7 +874,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -898,7 +898,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err := reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
@@ -910,7 +910,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			taskStatus = models.TaskStatusFAILED
 			task.Status = &taskStatus
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
@@ -919,12 +919,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
 			mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			err = reconciler.addVMsToPlacementGroup(machineContext, placementGroup, []string{*vm.ID})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task done timed out in %s: placementName %s, taskID %s", config.WaitTaskTimeout, *placementGroup.Name, *task.ID)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("failed to wait for placement group updation task done: placementName %s, taskID %s", *placementGroup.Name, *task.ID)))
 		})
 
 		It("should wait for placement group task done", func() {
@@ -1002,7 +1002,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs([]string{}).Return([]*models.VM{}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, []string{*vm.ID}).Return(task, nil)
-				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+				mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -1110,7 +1110,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs([]string{*vm2.ID}).Return([]*models.VM{vm2}, nil)
 				mockVMService.EXPECT().AddVMsToPlacementGroup(placementGroup, gomock.Any()).Return(task, nil)
-				mockVMService.EXPECT().WaitTask(*task.ID, config.WaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+				mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				ok, err := reconciler.joinPlacementGroup(machineContext, vm)
@@ -2560,7 +2560,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupCreationWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
@@ -2575,7 +2575,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupCreationWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
@@ -2588,7 +2588,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupCreationWaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(nil, errors.New("xxx"))
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())
@@ -2604,7 +2604,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
 			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
 			task.ErrorMessage = pointer.String(service.VMPlacementGroupDuplicate)
-			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupCreationWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
+			mockVMService.EXPECT().WaitTask(*task.ID, config.PlacementGroupWaitTaskTimeout, config.WaitTaskInterval).Return(task, nil)
 
 			result, err = reconciler.reconcilePlacementGroup(machineContext)
 			Expect(result).To(BeZero())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,6 @@ var (
 	// WaitTaskTimeout is the default timeout for waiting for task to complete.
 	WaitTaskTimeout = 3 * time.Second
 
-	// WaitTaskTimeoutForPlacementGroupOperation is the timeout for waiting for placement group creation/updating/deletion task to complete.
+	// WaitTaskTimeoutForPlacementGroupOperation is the timeout for waiting for placement group creating/updating/deleting task to complete.
 	WaitTaskTimeoutForPlacementGroupOperation = 10 * time.Second
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,6 @@ var (
 	// WaitTaskTimeout is the default timeout for waiting for task to complete.
 	WaitTaskTimeout = 3 * time.Second
 
-	// PlacementGroupWaitTaskTimeout is the timeout for waiting for placement group creation/updation task to complete.
-	PlacementGroupWaitTaskTimeout = 10 * time.Second
+	// WaitTaskTimeoutForPlacementGroupOperation is the timeout for waiting for placement group creation/updating/deletion task to complete.
+	WaitTaskTimeoutForPlacementGroupOperation = 10 * time.Second
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,6 @@ var (
 	// WaitTaskTimeout is the default timeout for waiting for task to complete.
 	WaitTaskTimeout = 3 * time.Second
 
-	// PlacementGroupCreationWaitTaskTimeout is the timeout for waiting for placement group creation task to complete.
-	PlacementGroupCreationWaitTaskTimeout = 10 * time.Second
+	// PlacementGroupWaitTaskTimeout is the timeout for waiting for placement group creation/updation task to complete.
+	PlacementGroupWaitTaskTimeout = 10 * time.Second
 )

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -812,7 +812,7 @@ func (svr *TowerVMService) DeleteVMPlacementGroupsByName(placementGroupName stri
 	taskID := *deleteVMPlacementGroupResp.Payload[0].TaskID
 	withLatestStatusTask, err := svr.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group deletion task to complete in %s: namePrefix %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group deletion task to complete in %s: pgNamePrefix %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, taskID)
 	}
 
 	if *withLatestStatusTask.Status == models.TaskStatusFAILED {

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -812,7 +812,7 @@ func (svr *TowerVMService) DeleteVMPlacementGroupsByName(placementGroupName stri
 	taskID := *deleteVMPlacementGroupResp.Payload[0].TaskID
 	withLatestStatusTask, err := svr.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group deletion task done in %s: namePrefix %s, taskID %s", config.WaitTaskTimeout, placementGroupName, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group deletion task to complete in %s: namePrefix %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, taskID)
 	}
 
 	if *withLatestStatusTask.Status == models.TaskStatusFAILED {

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -812,7 +812,7 @@ func (svr *TowerVMService) DeleteVMPlacementGroupsByName(placementGroupName stri
 	taskID := *deleteVMPlacementGroupResp.Payload[0].TaskID
 	withLatestStatusTask, err := svr.WaitTask(taskID, config.WaitTaskTimeout, config.WaitTaskInterval)
 	if err != nil {
-		return errors.Wrapf(err, "failed to wait for placement group deletion task to complete in %s: pgNamePrefix %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, taskID)
+		return errors.Wrapf(err, "failed to wait for placement group deleting task to complete in %s: pgNamePrefix %s, taskID %s", config.WaitTaskTimeoutForPlacementGroupOperation, placementGroupName, taskID)
 	}
 
 	if *withLatestStatusTask.Status == models.TaskStatusFAILED {


### PR DESCRIPTION
### 问题
更新VM放置组这里的超时当前是 3s。观察 CI 能发现这个时间大多数是 0-3s，也有少数 6-10s。

### 解决
更新放置组和创建放置组一样，超时时间设置为 10s。

### 测试
创建和删除放置组正常。