### PR TITLE
SKS-1804: Improve reconcileNetwork() to speed up fetching VM IP

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -250,6 +250,36 @@ func (m *ElfMachine) GetNetworkDevicesRequiringIP() []NetworkDeviceSpec {
 	return networkDevices
 }
 
+// GetNetworkDevicesRequiringDHCP returns a slice of NetworkDeviceSpec which requires DHCP IP.
+func (m *ElfMachine) GetNetworkDevicesRequiringDHCP() []NetworkDeviceSpec {
+	networkDevices := []NetworkDeviceSpec{}
+
+	for index := range m.Spec.Network.Devices {
+		if m.Spec.Network.Devices[index].NetworkType == NetworkTypeIPV4DHCP {
+			networkDevices = append(networkDevices, m.Spec.Network.Devices[index])
+		}
+	}
+
+	return networkDevices
+}
+
+// IsMachineStaticIP returns true if the IP is the static IP for the Machine.
+func (m *ElfMachine) IsMachineStaticIP(ip string) bool {
+	for index := range m.Spec.Network.Devices {
+		if m.Spec.Network.Devices[index].NetworkType != NetworkTypeIPV4 {
+			continue
+		}
+
+		for _, staticIP := range m.Spec.Network.Devices[index].IPAddrs {
+			if ip == staticIP {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (m *ElfMachine) GetVMDisconnectionTimestamp() *metav1.Time {
 	if m.Annotations == nil {
 		return nil

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1026,10 +1026,10 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm 
 		}
 	}
 
-	networkDevicesRequiringIP := ctx.ElfMachine.GetNetworkDevicesRequiringIP()
-	networkDevicesRequiringDHCP := ctx.ElfMachine.GetNetworkDevicesRequiringDHCP()
+	networkDevicesWithIP := ctx.ElfMachine.GetNetworkDevicesRequiringIP()
+	networkDevicesWithDHCP := ctx.ElfMachine.GetNetworkDevicesRequiringDHCP()
 
-	if len(ipToMachineAddressMap) < len(networkDevicesRequiringIP) {
+	if len(ipToMachineAddressMap) < len(networkDevicesWithIP) {
 		// Try to get VM NIC IP address from the K8s Node.
 		nodeIP, err := r.getK8sNodeIP(ctx, ctx.ElfMachine.Name)
 		if err == nil && nodeIP != "" {
@@ -1038,11 +1038,11 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm 
 				Type:    clusterv1.MachineInternalIP,
 			}
 		} else if err != nil {
-			ctx.Logger.Error(err, "failed to get VM NIC IP address from the K8s Node", "Node", ctx.ElfMachine.Name)
+			ctx.Logger.Error(err, "failed to get VM NIC IP address from the K8s node", "Node", ctx.ElfMachine.Name)
 		}
 	}
 
-	if len(networkDevicesRequiringDHCP) > 0 {
+	if len(networkDevicesWithDHCP) > 0 {
 		dhcpIPNum := 0
 		for _, ip := range ipToMachineAddressMap {
 			if !ctx.ElfMachine.IsMachineStaticIP(ip.Address) {
@@ -1050,7 +1050,7 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm 
 			}
 		}
 		// If not all DHCP NICs get IP, return false and wait for next requeue.
-		if dhcpIPNum < len(networkDevicesRequiringDHCP) {
+		if dhcpIPNum < len(networkDevicesWithDHCP) {
 			return false, nil
 		}
 	} else if len(ipToMachineAddressMap) < 1 {

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -980,10 +980,12 @@ func (r *ElfMachineReconciler) reconcileNode(ctx *context.MachineContext, vm *mo
 	return true, nil
 }
 
-// Ensure all the VM's NICs get IP addresses, otherwise requeue.
+// Ensure all the VM's NICs that need IP have obtained IP addresses and VM network ready, otherwise requeue.
+// 1. If there are DHCP VM NICs, it will ensure that all DHCP VM NICs obtain IP.
+// 2. If none of the VM NICs is the DHCP type, at least one IP must be obtained from Tower API or k8s node to ensure that the network is ready.
 //
 // In the scenario with many virtual machines, it could be slow for SMTX OS to synchronize VM information via vmtools.
-// So if Tower API returns empty IP address for the VM's 1st NIC, try to get its IP address from the corresponding K8s Node.
+// So if not enough IPs can be obtained from Tower API, try to get its IP address from the corresponding K8s Node.
 func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm *models.VM) (ret bool, reterr error) {
 	defer func() {
 		if reterr != nil {
@@ -1025,6 +1027,7 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm 
 	}
 
 	networkDevicesRequiringIP := ctx.ElfMachine.GetNetworkDevicesRequiringIP()
+	networkDevicesRequiringDHCP := ctx.ElfMachine.GetNetworkDevicesRequiringDHCP()
 
 	if len(ipToMachineAddressMap) < len(networkDevicesRequiringIP) {
 		// Try to get VM NIC IP address from the K8s Node.
@@ -1034,17 +1037,26 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx *context.MachineContext, vm 
 				Address: nodeIP,
 				Type:    clusterv1.MachineInternalIP,
 			}
+		} else if err != nil {
+			ctx.Logger.Error(err, "failed to get VM NIC IP address from the K8s Node", "Node", ctx.ElfMachine.Name)
+		}
+	}
 
-			// If not all NICs get IP, return false and wait for next requeue.
-			if len(ipToMachineAddressMap) < len(networkDevicesRequiringIP) {
-				return false, nil
+	if len(networkDevicesRequiringDHCP) > 0 {
+		dhcpIPNum := 0
+		for _, ip := range ipToMachineAddressMap {
+			if !ctx.ElfMachine.IsMachineStaticIP(ip.Address) {
+				dhcpIPNum++
 			}
-		} else {
-			if err != nil {
-				ctx.Logger.Error(err, "failed to get VM NIC IP address from the K8s Node", "Node", ctx.ElfMachine.Name)
-			}
+		}
+		// If not all DHCP NICs get IP, return false and wait for next requeue.
+		if dhcpIPNum < len(networkDevicesRequiringDHCP) {
 			return false, nil
 		}
+	} else if len(ipToMachineAddressMap) < 1 {
+		// If none of the VM NICs is the DHCP type,
+		// at least one IP must be obtained from Tower API or k8s node to ensure that the network is ready, otherwise requeue.
+		return false, nil
 	}
 
 	for _, machineAddress := range ipToMachineAddressMap {
@@ -1157,11 +1169,6 @@ func (r *ElfMachineReconciler) deleteNode(ctx *context.MachineContext, nodeName 
 
 // getK8sNodeIP get the default network IP of K8s Node.
 func (r *ElfMachineReconciler) getK8sNodeIP(ctx *context.MachineContext, nodeName string) (string, error) {
-	// Return early if control plane is not initialized.
-	if !conditions.IsTrue(ctx.Cluster, clusterv1.ControlPlaneInitializedCondition) {
-		return "", nil
-	}
-
 	kubeClient, err := util.NewKubeClient(ctx, ctx.Client, ctx.Cluster)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get client for Cluster %s/%s", ctx.Cluster.Namespace, ctx.Cluster.Name)

--- a/test/fake/types.go
+++ b/test/fake/types.go
@@ -117,7 +117,9 @@ func NewElfMachine(elfCluster *infrav1.ElfCluster) *infrav1.ElfMachine {
 			MemoryMiB:         1,
 			Network: infrav1.NetworkSpec{
 				Devices: []infrav1.NetworkDeviceSpec{
-					{},
+					{
+						NetworkType: infrav1.NetworkTypeIPV4DHCP,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## 问题

[SKS-1804] 优化ECP CNI场景下，ELFMachine Network Ready的等待时间 - Jira http://jira.smartx.com/browse/SKS-1804

ECP CNI场景下，VM携带有双网卡，一张网卡为静态IP，一张网卡需要DHCP，当前已有的处理无法覆盖该场景。

## 修复

1. 删除`getK8sNodeIP`方法里面，判断ControlPlaneInitializedCondition的逻辑。当第一个KCP VM获取IP慢时，ControlPlaneInitialized也会在较长时间后才会变成true(经过调查很可能是CAPI的bug)
2. 优化reconcileNetwork方法处理逻辑变更:
- 存在DHCP网卡时，需要所有的DHCP网卡都获取到IP则认为network ready。
- 不存在DHCP网卡时，则至少保证从Tower API/k8s node获取到一个IP，才认为network ready

## 测试

### ECP CNI KSC集群
```
kc get ksc -n default  hw-sks-test-1.24.17-04 -ojson | jq .spec.network.cni
{
  "ecpConfig": {
    "fakeIP": "100.64.254.254/32",
    "ippools": [
      {
        "cidr": "10.255.67.0/25",
        "gateway": "10.255.0.1",
        "name": "test",
        "subnet": "10.255.0.0/16"
      }
    ],
    "uplinkIP": "240.255.0.1/32"
  },
  "name": "ecp"
}

kc get ksc -n default  hw-sks-test-1.24.17-04 -ojson | jq .spec.topology.controlPlane.nodeConfig.network
{
  "devices": [
    {
      "networkType": "IPV4_DHCP",
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    },
    {
      "ipAddrs": [
        "240.255.0.1"
      ],
      "netmask": "255.255.255.255",
      "networkType": "IPV4",
      "tag": "ecp",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    }
  ]
}
```

k8s node创建时间
```
kc get nodes  hw-sks-test-1.24.17-04-controlplane-6wtfn  -ojson | jq .metadata.creationTimestamp
"2023-08-31T05:31:33Z"
```

ELFMachine VMProvisioned时间为`2023-08-31T05:31:42Z`
```
[
  {
    "lastTransitionTime": "2023-08-31T05:31:42Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2023-08-31T05:30:15Z",
    "status": "True",
    "type": "TowerAvailable"
  },
  {
    "lastTransitionTime": "2023-08-31T05:31:42Z",
    "status": "True",
    "type": "VMProvisioned"
  }
]
```
vmtools采集上报时间为 13:32:22
<img width="1036" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/7ec42ffa-2dbf-45ae-9000-d926d39bc44e">

ELFMachine VMProvisioned时间 先于vmtools数据上报时间，符合预期

### 单DHCP网卡集群

```
 kc get ksc -n default  hw-sks-test-1.24.17-04-single -ojson | jq .spec.topology.controlPlane.nodeConfig.network
{
  "devices": [
    {
      "networkType": "IPV4_DHCP",
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    }
  ]
}
```

k8s node创建时间
```
kc get node hw-sks-test-1.24.17-04-single-controlplane-pkppw  -ojson | jq .metadata.creationTimestamp
"2023-08-31T05:47:54Z"
```

ELFMachine VMProvisioned时间为`2023-08-31T05:47:55Z`
```
 kc get elfmachine -n default hw-sks-test-1.24.17-04-single-controlplane-pkppw -ojson | jq .status.conditions
[
  {
    "lastTransitionTime": "2023-08-31T05:47:55Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2023-08-31T05:46:40Z",
    "status": "True",
    "type": "TowerAvailable"
  },
  {
    "lastTransitionTime": "2023-08-31T05:47:55Z",
    "status": "True",
    "type": "VMProvisioned"
  }
]
```

vmtools采集上报时间为 13:48:59
<img width="1078" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/a3f159c1-96c6-47ea-aa94-cc8f24e1a803">

ELFMachine VMProvisioned时间 先于vmtools数据上报时间，符合预期

### 双DHCP网卡集群

```
  kc get ksc -n default  hw-sks-test-1.24.17-04-double -ojson | jq .spec.topology.controlPlane.nodeConfig.network
{
  "devices": [
    {
      "networkType": "IPV4_DHCP",
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    },
    {
      "networkType": "IPV4_DHCP",
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    }
  ]
}
```

k8s node创建时间
```
kc get node hw-sks-test-1.24.17-04-double-controlplane-4bgsg -ojson | jq .metadata.creationTimestamp
"2023-08-31T05:49:19Z"
```
ELFMachine VMProvisioned时间为2023-08-31T05:50:35Z

```
kc get elfmachine -n default hw-sks-test-1.24.17-04-double-controlplane-4bgsg -ojson | jq .status.conditions
[
  {
    "lastTransitionTime": "2023-08-31T05:50:35Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2023-08-31T05:47:56Z",
    "status": "True",
    "type": "TowerAvailable"
  },
  {
    "lastTransitionTime": "2023-08-31T05:50:35Z",
    "status": "True",
    "type": "VMProvisioned"
  }
]
```

vmtools采集数据上报时间
<img width="1112" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/4cddb602-64a2-4128-9db0-0fa09f135d61">

ELFMachine VMProvisioned时间 晚于vmtools数据上报时间，符合预期

### 单静态IP网卡集群
```
kc get ksc -n default  hw-sks-test-1.24.17-04-single-static -ojson | jq .spec.topology.controlPlane.nodeConfig.network
{
  "devices": [
    {
      "ipAddrs": [
        "10.255.233.186"
      ],
      "netmask": "255.255.0.0",
      "networkType": "IPV4",
      "routes": [
        {
          "gateway": "10.255.0.1"
        }
      ],
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    }
  ],
  "nameservers": [
    "10.255.0.2"
  ]
}
```

k8s node创建时间
```
kc get nodes hw-sks-test-1.24.17-04-single-static-controlplane-679vf -ojson | jq .metadata.creationTimestamp
"2023-08-31T06:33:11Z"
```

ELF Machine VMProvisioned 时间为 2023-08-31T06:33:19Z
```
[
  {
    "lastTransitionTime": "2023-08-31T06:33:19Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2023-08-31T06:31:19Z",
    "status": "True",
    "type": "TowerAvailable"
  },
  {
    "lastTransitionTime": "2023-08-31T06:33:19Z",
    "status": "True",
    "type": "VMProvisioned"
  }
]

```

vmtools采集数据时间

<img width="1101" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/6f724bec-c9e7-4340-ae25-15e095c92040">

ELF Machine VMProvisioned 在k8s node创建之后，符合预期

### 双静态IP网卡集群

```
 kc get ksc hw-sks-test-1.24.17-04-two-static -n default -ojson | jq .spec.topology.controlPlane.nodeConfig.network
{
  "devices": [
    {
      "ipAddrs": [
        "10.255.233.186"
      ],
      "netmask": "255.255.0.0",
      "networkType": "IPV4",
      "routes": [
        {
          "gateway": "10.255.0.1"
        }
      ],
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    },
    {
      "ipAddrs": [
        "10.255.233.187"
      ],
      "netmask": "255.255.0.0",
      "networkType": "IPV4",
      "routes": [
        {
          "gateway": "10.255.0.1"
        }
      ],
      "tag": "default",
      "vlan": "dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08"
    }
  ],
  "nameservers": [
    "10.255.0.2"
  ]
}
```

k8s node创建时间
```
kc get node hw-sks-test-1.24.17-04-two-static-controlplane-qht7s -ojson | jq .metadata.creationTimestamp
"2023-08-31T06:54:51Z"
```

ELFMachine VMProvisioned时间为2023-08-31T06:54:52Z
```
[
  {
    "lastTransitionTime": "2023-08-31T06:54:52Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2023-08-31T06:53:30Z",
    "status": "True",
    "type": "TowerAvailable"
  },
  {
    "lastTransitionTime": "2023-08-31T06:54:52Z",
    "status": "True",
    "type": "VMProvisioned"
  }
]
```

vmtools采集数据上报时间
<img width="1006" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/114376205/60767ead-5702-4e51-837c-e764981cd1b1">

ELF Machine VMProvisioned 在k8s node创建之后，符合预期
