### PR TITLE
Fix multi-architecture image build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	docker build --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(IMAGE_TAG)
+	docker build --platform linux/$(ARCH) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(IMAGE_TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
@@ -304,7 +304,6 @@ docker-push: ## Push the docker image
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:1.1-experimental
 	docker pull gcr.io/distroless/static:latest
 
 ## --------------------------------------


### PR DESCRIPTION
Fix build image platform error

```
> CONTROLLER_IMG=registry.smtx.io/demo/cape IMAGE_TAG=dev make release
rm -rf out
/Library/Developer/CommandLineTools/usr/bin/make docker-build-all
/Library/Developer/CommandLineTools/usr/bin/make ARCH=amd64 docker-build
docker pull gcr.io/distroless/static:latest
latest: Pulling from distroless/static
Digest: sha256:e7e79fb2947f38ce0fab6061733f7e1959c12b843079042fe13f56ca7b9d178c
Status: Image is up to date for gcr.io/distroless/static:latest
gcr.io/distroless/static:latest

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview gcr.io/distroless/static:latest
docker build --platform linux/amd64 --build-arg ARCH=amd64 --build-arg ldflags="-X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildVersion=dev' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildDate=2023-09-27T03:51:25Z' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitCommit=2a179dd30caa44fd0ca4972a7facc06663eab6b2' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitTreeState=dirty' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitMajor=1' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitMinor=2' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitVersion=v1.2.17-1-2a179dd30caa44-dirty' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitReleaseCommit=c4cc5fd0c35a30d0c3c1b991b9193291b3d1437d'" . -t registry.smtx.io/demo/cape-amd64:dev
[+] Building 138.4s (15/15) FINISHED                                                                                                                                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                               0.0s
 => => transferring dockerfile: 1.53kB                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 193B                                                                                                                                                                                                  0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                                                                                                                                  0.6s
 => [internal] load metadata for docker.io/library/golang:1.20.7                                                                                                                                                                   2.8s
 => [builder 1/7] FROM docker.io/library/golang:1.20.7@sha256:741d6f9bcab778441efe05c8e4369d4f8ff56c9a635a97d77f55d8b0ec62f907                                                                                                     0.0s
 => CACHED [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:92d40eea0b5307a94f2ebee3e94095e704015fb41e35fc1fcbd1d151cc282222                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                                  0.1s
 => => transferring context: 30.15kB                                                                                                                                                                                               0.0s
 => CACHED [builder 2/7] WORKDIR /workspace                                                                                                                                                                                        0.0s
 => CACHED [builder 3/7] COPY go.mod go.mod                                                                                                                                                                                        0.0s
 => CACHED [builder 4/7] COPY go.sum go.sum                                                                                                                                                                                        0.0s
 => CACHED [builder 5/7] RUN go mod download                                                                                                                                                                                       0.0s
 => CACHED [builder 6/7] COPY ./ ./                                                                                                                                                                                                0.0s
 => [builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -a -ldflags "-X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildVersion=dev' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg  134.8s
 => [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                                                                                                                         0.4s
 => exporting to image                                                                                                                                                                                                             0.2s
 => => exporting layers                                                                                                                                                                                                            0.1s
 => => writing image sha256:7c6a97ef45ec1cd40b4c39a65b1f3bc678d4efdb696ac1c2768b9435e461242a                                                                                                                                       0.0s
 => => naming to registry.smtx.io/demo/cape-amd64:dev                                                                                                                                                                              0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
/Library/Developer/CommandLineTools/usr/bin/make ARCH=arm64 docker-build
docker pull gcr.io/distroless/static:latest
latest: Pulling from distroless/static
Digest: sha256:e7e79fb2947f38ce0fab6061733f7e1959c12b843079042fe13f56ca7b9d178c
Status: Image is up to date for gcr.io/distroless/static:latest
gcr.io/distroless/static:latest

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview gcr.io/distroless/static:latest
docker build --platform linux/arm64 --build-arg ARCH=arm64 --build-arg ldflags="-X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildVersion=dev' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildDate=2023-09-27T03:53:45Z' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitCommit=2a179dd30caa44fd0ca4972a7facc06663eab6b2' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitTreeState=dirty' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitMajor=1' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitMinor=2' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitVersion=v1.2.17-1-2a179dd30caa44-dirty' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.gitReleaseCommit=c4cc5fd0c35a30d0c3c1b991b9193291b3d1437d'" . -t registry.smtx.io/demo/cape-arm64:dev
[+] Building 157.1s (15/15) FINISHED                                                                                                                                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                               0.0s
 => => transferring dockerfile: 1.53kB                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 193B                                                                                                                                                                                                  0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                                                                                                                                  1.9s
 => [internal] load metadata for docker.io/library/golang:1.20.7                                                                                                                                                                   2.2s
 => [internal] load build context                                                                                                                                                                                                  0.1s
 => => transferring context: 30.15kB                                                                                                                                                                                               0.0s
 => [builder 1/7] FROM docker.io/library/golang:1.20.7@sha256:741d6f9bcab778441efe05c8e4369d4f8ff56c9a635a97d77f55d8b0ec62f907                                                                                                    74.8s
 => => resolve docker.io/library/golang:1.20.7@sha256:741d6f9bcab778441efe05c8e4369d4f8ff56c9a635a97d77f55d8b0ec62f907                                                                                                             0.0s
 => => sha256:a014e5e7d08c37cf1703b97e701ccdc850e4a18d0ee679f03aa875dcd520aa85 49.59MB / 49.59MB                                                                                                                                   3.8s
 => => sha256:715cea74ecbb15cb82efef1e77dd60c31d90b01d1286d6f39b4562afaebe75f3 23.57MB / 23.57MB                                                                                                                                   6.8s
 => => sha256:003f1109a21287fa17dc866e87e8c6685113960cbb0379fee8f42b83de63c647 63.99MB / 63.99MB                                                                                                                                  33.0s
 => => sha256:741d6f9bcab778441efe05c8e4369d4f8ff56c9a635a97d77f55d8b0ec62f907 2.36kB / 2.36kB                                                                                                                                     0.0s
 => => sha256:53ef51ab1f2fba5c8973af9b0ca02e0795c8eec8aaddf9f6808e108e21e37d34 6.87kB / 6.87kB                                                                                                                                     0.0s
 => => sha256:7fcc2684ef0de5f7730be51a493d26289756356a3c385ce6374b86d31d0be446 1.58kB / 1.58kB                                                                                                                                     0.0s
 => => sha256:6529d3f2eda2bb51de0720b46e2e8359ed7a45efa1298a067b519e1cf2c094c0 86.30MB / 86.30MB                                                                                                                                  12.2s
 => => extracting sha256:a014e5e7d08c37cf1703b97e701ccdc850e4a18d0ee679f03aa875dcd520aa85                                                                                                                                          1.9s
 => => extracting sha256:715cea74ecbb15cb82efef1e77dd60c31d90b01d1286d6f39b4562afaebe75f3                                                                                                                                          0.5s
 => => sha256:c8819c2c34b5756ac0a4cddcd3b8f83ed84a6fc088e29be7d29f8749a01ae9be 95.56MB / 95.56MB                                                                                                                                  71.2s
 => => sha256:b27eb9816a97a8bf431a5ef39173a49a2b42aeba57f23e493024d43f0e33660c 155B / 155B                                                                                                                                        13.2s
 => => extracting sha256:003f1109a21287fa17dc866e87e8c6685113960cbb0379fee8f42b83de63c647                                                                                                                                          2.0s
 => => extracting sha256:6529d3f2eda2bb51de0720b46e2e8359ed7a45efa1298a067b519e1cf2c094c0                                                                                                                                          1.7s
 => => extracting sha256:c8819c2c34b5756ac0a4cddcd3b8f83ed84a6fc088e29be7d29f8749a01ae9be                                                                                                                                          3.3s
 => => extracting sha256:b27eb9816a97a8bf431a5ef39173a49a2b42aeba57f23e493024d43f0e33660c                                                                                                                                          0.0s
 => [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:92d40eea0b5307a94f2ebee3e94095e704015fb41e35fc1fcbd1d151cc282222                                                                                                    0.2s
 => => resolve gcr.io/distroless/static:nonroot@sha256:92d40eea0b5307a94f2ebee3e94095e704015fb41e35fc1fcbd1d151cc282222                                                                                                            0.0s
 => => sha256:92d40eea0b5307a94f2ebee3e94095e704015fb41e35fc1fcbd1d151cc282222 1.51kB / 1.51kB                                                                                                                                     0.0s
 => => sha256:dcf9c9cafaa9c328eff2ceff5f6057588336b48c9b91ddc0913102b33bbce723 1.65kB / 1.65kB                                                                                                                                     0.0s
 => => sha256:9430a8ab2d329267df1187feb73ae48f587349454cf5b3e6843eec50ece41eb1 1.30kB / 1.30kB                                                                                                                                     0.0s
 => [builder 2/7] WORKDIR /workspace                                                                                                                                                                                               0.8s
 => [builder 3/7] COPY go.mod go.mod                                                                                                                                                                                               0.0s
 => [builder 4/7] COPY go.sum go.sum                                                                                                                                                                                               0.0s
 => [builder 5/7] RUN go mod download                                                                                                                                                                                             41.4s
 => [builder 6/7] COPY ./ ./                                                                                                                                                                                                       0.1s
 => [builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64     go build -a -ldflags "-X 'github.com/smartxworks/cluster-api-provider-elf/pkg/version.buildVersion=dev' -X 'github.com/smartxworks/cluster-api-provider-elf/pkg/  37.2s
 => [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                                                                                                                         0.4s
 => exporting to image                                                                                                                                                                                                             0.2s
 => => exporting layers                                                                                                                                                                                                            0.2s
 => => writing image sha256:42c1ad375f4949b1f9de704830abf96bb4dee98f552b4ba117607919926831b3                                                                                                                                       0.0s
 => => naming to registry.smtx.io/demo/cape-arm64:dev                                                                                                                                                                              0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
/Library/Developer/CommandLineTools/usr/bin/make docker-push-all
/Library/Developer/CommandLineTools/usr/bin/make ARCH=amd64 docker-push
docker push registry.smtx.io/demo/cape-amd64:dev
The push refers to repository [registry.smtx.io/demo/cape-amd64]
eee250b9ccc6: Pushed 
4cb10dd2545b: Pushed 
d2d7ec0f6756: Pushed 
1a73b54f556b: Pushed 
e624a5370eca: Pushed 
d52f02c6501c: Pushed 
ff5700ec5418: Pushed 
7bea6b893187: Pushed 
6fbdf253bbc2: Pushed 
e023e0e48e6e: Pushed 
dev: digest: sha256:4ef9bd007643acc9684a8c638646511cd54ff1606e2432b5b817f8058dd4a89e size: 2402
/Library/Developer/CommandLineTools/usr/bin/make ARCH=arm64 docker-push
docker push registry.smtx.io/demo/cape-arm64:dev
The push refers to repository [registry.smtx.io/demo/cape-arm64]
530f9387bb03: Pushed 
4cb10dd2545b: Mounted from demo/cape-amd64 
d2d7ec0f6756: Mounted from demo/cape-amd64 
1a73b54f556b: Mounted from demo/cape-amd64 
e624a5370eca: Mounted from demo/cape-amd64 
d52f02c6501c: Mounted from demo/cape-amd64 
ff5700ec5418: Mounted from demo/cape-amd64 
7bea6b893187: Mounted from demo/cape-amd64 
6fbdf253bbc2: Mounted from demo/cape-amd64 
20655aa3102c: Pushed 
dev: digest: sha256:5faa5874cd0bd5589b33b99874da49fd411612b29f3cacda1fb8b48e2250bd0d size: 2402
/Library/Developer/CommandLineTools/usr/bin/make docker-push-manifest
## Minimum docker version 18.06.0 is required for creating and pushing manifest images.
docker manifest create --amend registry.smtx.io/demo/cape:dev registry.smtx.io/demo/cape-amd64:dev registry.smtx.io/demo/cape-arm64:dev
Created manifest list registry.smtx.io/demo/cape:dev
docker manifest push --purge registry.smtx.io/demo/cape:dev
Pushed ref registry.smtx.io/demo/cape@sha256:4ef9bd007643acc9684a8c638646511cd54ff1606e2432b5b817f8058dd4a89e with digest: sha256:4ef9bd007643acc9684a8c638646511cd54ff1606e2432b5b817f8058dd4a89e
Pushed ref registry.smtx.io/demo/cape@sha256:5faa5874cd0bd5589b33b99874da49fd411612b29f3cacda1fb8b48e2250bd0d with digest: sha256:5faa5874cd0bd5589b33b99874da49fd411612b29f3cacda1fb8b48e2250bd0d
sha256:0653221bf4051f4c58f4a23357079685dca3204320f8298a5ad07bcc2bb22995
/Library/Developer/CommandLineTools/usr/bin/make release-manifests
/Library/Developer/CommandLineTools/usr/bin/make manifests MANIFEST_DIR=out PULL_POLICY=IfNotPresent IMAGE=registry.smtx.io/demo/cape:dev
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
rm -rf .build/config
cp -R config .build
cp templates/cluster-template.yaml out/cluster-template.yaml
sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"IfNotPresent"'@' .build/config/default/manager_pull_policy.yaml
sed -i'' -e 's@image: .*@image: '"registry.smtx.io/demo/cape:dev"'@' .build/config/default/manager_image_patch.yaml
/Users/sonny/work/github/smartxworks/cluster-api-provider-elf/bin/kustomize build .build/config/default > out/infrastructure-components.yaml
cp metadata.yaml out/metadata.yaml
```

<img width="829" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/3226923/8c5ceb43-0c33-4d87-b8c0-c5acf4545821">
