### PR TITLE
SKS-1914: Add WaitingForPlacementGroupPolicySatisfied and WaitingForELFClusterWithSufficientMemory reasons

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -102,6 +102,14 @@ const (
 	// are automatically re-tried by the controller.
 	JoiningPlacementGroupFailedReason = "JoiningPlacementGroupFailed"
 
+	// WaitingForPlacementGroupPolicySatisfiedReason (Severity=Warning) documents an ElfMachine
+	// waiting for placement group policy be satisfied for VM to joining placement group.
+	WaitingForPlacementGroupPolicySatisfiedReason = "WaitingForPlacementGroupPolicySatisfied"
+
+	// WaitingForELFClusterWithSufficientMemoryReason (Severity=Info) documents an ElfMachine
+	// waiting for ELF cluster with sufficient memory to create or power on VM.
+	WaitingForELFClusterWithSufficientMemoryReason = "WaitingForELFClusterWithSufficientMemory"
+
 	// WaitingForAvailableHostRequiredByPlacementGroupReason (Severity=Info) documents an ElfMachine
 	// waiting for an available host required by placement group to create VM.
 	WaitingForAvailableHostRequiredByPlacementGroupReason = "WaitingForAvailableHostRequiredByPlacementGroup"

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -21,6 +21,10 @@ import (
 	"sync"
 	"time"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 )
@@ -50,6 +54,8 @@ func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, er
 	defer lock.Unlock()
 
 	if resource := getClusterResource(getKeyForInsufficientMemoryError(ctx.ElfCluster.Spec.Cluster)); resource != nil {
+		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForELFClusterWithSufficientMemoryReason, clusterv1.ConditionSeverityInfo, "")
+
 		return true, fmt.Sprintf("Insufficient memory detected for the ELF cluster %s", ctx.ElfCluster.Spec.Cluster), nil
 	}
 
@@ -59,6 +65,8 @@ func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, er
 	}
 
 	if resource := getClusterResource(getKeyForDuplicatePlacementGroupError(placementGroupName)); resource != nil {
+		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForPlacementGroupPolicySatisfiedReason, clusterv1.ConditionSeverityInfo, "")
+
 		return true, fmt.Sprintf("Not satisfy policy detected for the placement group %s", placementGroupName), nil
 	}
 

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -21,7 +21,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	towerresources "github.com/smartxworks/cluster-api-provider-elf/pkg/resources"
 	"github.com/smartxworks/cluster-api-provider-elf/test/fake"
@@ -146,12 +149,14 @@ var _ = Describe("TowerCache", func() {
 		Expect(ok).To(BeFalse())
 		Expect(msg).To(Equal(""))
 		Expect(err).ShouldNot(HaveOccurred())
+		expectConditions(elfMachine, []conditionAssertion{})
 
 		recordIsUnmet(machineContext, clusterKey, true)
 		ok, msg, err = isELFScheduleVMErrorRecorded(machineContext)
 		Expect(ok).To(BeTrue())
 		Expect(msg).To(ContainSubstring("Insufficient memory detected for the ELF cluster"))
 		Expect(err).ShouldNot(HaveOccurred())
+		expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForELFClusterWithSufficientMemoryReason}})
 
 		resetVMTaskErrorCache()
 		recordIsUnmet(machineContext, placementGroupKey, true)
@@ -159,6 +164,7 @@ var _ = Describe("TowerCache", func() {
 		Expect(ok).To(BeTrue())
 		Expect(msg).To(ContainSubstring("Not satisfy policy detected for the placement group"))
 		Expect(err).ShouldNot(HaveOccurred())
+		expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForPlacementGroupPolicySatisfiedReason}})
 	})
 })
 


### PR DESCRIPTION
### 增加 reasons 方便通过 ElfMachine 了解更多VM无法Ready的错误信息。
新增以下两个 reasons 用于反馈 ELF 集群内存不足和放置组策略不能满足。
- WaitingForELFClusterWithSufficientMemory
- WaitingForPlacementGroupPolicySatisfied

其他需要反馈但已有的 reasons ：
- ShuttingDownFailedReason
- PoweringOffFailedReason
- PoweringOnFailedReason
- WaitingForAvailableHostRequiredByPlacementGroupReason
- JoiningPlacementGroupFailedReason
- WaitingForAvailableHostWithEnoughGPUsReason
- AttachingGPUFailedReason
- DetachingGPUFailedReason