### PR TITLE
SKS-1840: Make sure adding MachineFinalizer won't overwrite MachineStaticIPFinalizer

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -30,6 +30,11 @@ const (
 	// API Server.
 	MachineFinalizer = "elfmachine.infrastructure.cluster.x-k8s.io"
 
+	// MachineStaticIPFinalizer allows ReconcileElfMachine to clean up static ip
+	// resources associated with ElfMachine before removing it from the
+	// API Server.
+	MachineStaticIPFinalizer = "elfmachinestaticip.infrastructure.cluster.x-k8s.io"
+
 	// VMDisconnectionTimestampAnnotation is the annotation identifying the VM of ElfMachine disconnection time.
 	VMDisconnectionTimestampAnnotation = "cape.infrastructure.cluster.x-k8s.io/vm-disconnection-timestamp"
 )

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -99,6 +99,16 @@ type NetworkSpec struct {
 	PreferredAPIServerCIDR string `json:"preferredAPIServerCidr,omitempty"`
 }
 
+func (n *NetworkSpec) RequiresStaticIPs() bool {
+	for i := 0; i < len(n.Devices); i++ {
+		if n.Devices[i].NetworkType == NetworkTypeIPV4 && len(n.Devices[i].IPAddrs) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // NetworkDeviceSpec defines the network configuration for a virtual machine's
 // network device.
 type NetworkDeviceSpec struct {

--- a/pkg/util/patch/finalizer.go
+++ b/pkg/util/patch/finalizer.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	goctx "context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// AddFinalizerWithOptimisticLock adds a finalizer to the specified object
+// and saves it by using resourceVersion optimistic lock.
+func AddFinalizerWithOptimisticLock(ctx goctx.Context, c client.Client, obj client.Object, finalizer string) error {
+	modifiedObj := obj.DeepCopyObject().(client.Object)
+	ctrlutil.AddFinalizer(modifiedObj, finalizer)
+	return c.Patch(ctx, modifiedObj, client.MergeFromWithOptions(obj, client.MergeFromWithOptimisticLock{}))
+}


### PR DESCRIPTION
### [SKS-1840](http://jira.smartx.com/browse/SKS-1840)

#### 问题分析

1. CAPE-IP 等 CAPE 设置了 MachineFinalizer 之后，设置了 MachineStaticIPFinalizer，并开始分配 IP
2. CAPE reconcile 获取到的是设置 MachineStaticIPFinalizer 之前的数据，所以此时 reconcile，Finalizers 只有 MachineFinalizer，保存 ElfMachine 的时候 MachineStaticIPFinalizer 被覆盖了（已在本地复现）
3. 如果此时 ElfMachine 被删除，虚拟机还没有创建，所以 ElfMachine 的 MachineFinalizer 很快就被移除。因此 CAPE-IP 没有来得及释放 IP 资源。


#### 解决
CAPE 先检查 ElfMachine 如果需要静态 IP，并且没有设置 MachineStaticIPFinalizer，则等待 CAPE-IP 先把 MachineStaticIPFinalizer 设置好，再继续 reconcile。

而 CAPE-IP 会检查确保 MachineFinalizer 和 MachineStaticIPFinalizer 都存在的情况下，再分配 IP。这样就不会存在分配了 IP 但是没有设置 MachineStaticIPFinalizer 的情况。


### 测试

1. 创建使用静态 IP 的 1CP + 3Workers 集群正常，删除也正常。

2. 模拟脏数据没有复现静态 IP 没有被释放。
```go
// 1. 在代码中使用 elfMachine.Finalizers = nil，模拟使用脏数据
	ctx.ElfMachine.Finalizers = nil

	if !ctrlutil.ContainsFinalizer(ctx.ElfMachine, infrav1.MachineFinalizer) {
// 2. 保存 Finalizers 失败，MachineStaticIPFinalizer 没有被覆盖。
// 报错 "Operation cannot be fulfilled on elfmachines.infrastructure.cluster.x-k8s.io \"haijian-test2-controlplane-n4bjk\": the object has been modified; please apply your changes to the latest version and try again"
		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, patchutil.AddFinalizerWithOptimisticLock(ctx, r.Client, ctx.ElfMachine, infrav1.MachineFinalizer) 
	}

	if ctx.ElfMachine.Spec.Network.RequiresStaticIPs() && !ctrlutil.ContainsFinalizer(ctx.ElfMachine, infrav1.MachineStaticIPFinalizer) {
		return reconcile.Result{RequeueAfter: config.DefaultRequeueTimeout}, nil
	}
```