### PR TITLE
Add CloudTower Server URL to VM description

### DIFF
--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -18,7 +18,7 @@ package config
 
 const (
 	// VMDescription is the default description in a VM.
-	VMDescription = "Automatically created kubernetes node by CloudTower %s."
+	VMDescription = "Automatically created Kubernetes node by CloudTower %s."
 
 	// VMNumCPUs is the default virtual processors in a VM.
 	VMNumCPUs = 2

--- a/pkg/config/vm.go
+++ b/pkg/config/vm.go
@@ -18,7 +18,7 @@ package config
 
 const (
 	// VMDescription is the default description in a VM.
-	VMDescription = "Automatically created kubernetes node."
+	VMDescription = "Automatically created kubernetes node by CloudTower %s."
 
 	// VMNumCPUs is the default virtual processors in a VM.
 	VMNumCPUs = 2

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	goctx "context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -243,7 +244,7 @@ func (svr *TowerVMService) Clone(
 		ClusterID:   cluster.ID,
 		HostID:      TowerString(hostID),
 		Name:        TowerString(elfMachine.Name),
-		Description: TowerString(config.VMDescription),
+		Description: TowerString(fmt.Sprintf(config.VMDescription, elfCluster.Spec.Tower.Server)),
 		Vcpu:        vCPU,
 		CPUCores:    cpuCores,
 		CPUSockets:  cpuSockets,


### PR DESCRIPTION
### 修改虚拟机描述
增加 Tower URL 到虚拟机描述，在多 Tower 场景下可以区分虚拟机是由哪个 Tower 创建的。

### 测试
<img width="481" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/bd27b7cd-be49-4da9-81f6-84d06383392c">
