### PR TITLE
SKS-1978: Add 'cluster-api/accelerator' label to GPU node to support autoscaling

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -996,14 +996,21 @@ func (r *ElfMachineReconciler) reconcileNode(ctx *context.MachineContext, vm *mo
 	}
 
 	nodeGroupName := machineutil.GetNodeGroupName(ctx.Machine)
+	labels := map[string]string{
+		infrav1.HostServerIDLabel:   ctx.ElfMachine.Status.HostServerRef,
+		infrav1.HostServerNameLabel: ctx.ElfMachine.Status.HostServerName,
+		infrav1.TowerVMIDLabel:      *vm.ID,
+		infrav1.NodeGroupLabel:      nodeGroupName,
+	}
+	if len(ctx.ElfMachine.Spec.GPUDevices) > 0 {
+		labels[labelsutil.ClusterAutoscalerCAPIGPULabel] = labelsutil.ConvertToLabelValue(ctx.ElfMachine.Spec.GPUDevices[0].Model)
+	} else if len(ctx.ElfMachine.Spec.VGPUDevices) > 0 {
+		labels[labelsutil.ClusterAutoscalerCAPIGPULabel] = labelsutil.ConvertToLabelValue(ctx.ElfMachine.Spec.VGPUDevices[0].Type)
+	}
+
 	payloads := map[string]interface{}{
 		"metadata": map[string]interface{}{
-			"labels": map[string]string{
-				infrav1.HostServerIDLabel:   ctx.ElfMachine.Status.HostServerRef,
-				infrav1.HostServerNameLabel: ctx.ElfMachine.Status.HostServerName,
-				infrav1.TowerVMIDLabel:      *vm.ID,
-				infrav1.NodeGroupLabel:      nodeGroupName,
-			},
+			"labels": labels,
 		},
 	}
 	// providerID cannot be modified after setting a valid value.

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -78,6 +78,8 @@ func GetLabelValue(o metav1.Object, label string) string {
 	return val
 }
 
+// ConvertToLabelValue converts a string to a valid label value.
+// A valid label value must be an empty string or consist of alphanumeric characters, '-', '_' or '.'.
 func ConvertToLabelValue(str string) string {
 	result := noLabelCharReg.ReplaceAll([]byte(str), []byte("-"))
 

--- a/pkg/util/labels/helpers.go
+++ b/pkg/util/labels/helpers.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	// ClusterAutoscalerCAPIGPULabel is the label added to nodes with GPU resource, which will be used by clusterAutoscaler-CAPI.
+	// ref: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#special-note-on-gpu-instances
 	ClusterAutoscalerCAPIGPULabel = "cluster-api/accelerator"
 )
 

--- a/pkg/util/labels/helpers_test.go
+++ b/pkg/util/labels/helpers_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestConvertToLabelValue(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	testCases := []struct {
+		str        string
+		labelValue string
+	}{
+		{
+			str:        "test",
+			labelValue: "test",
+		}, {
+			str:        "Test",
+			labelValue: "Test",
+		}, {
+			str:        "TEST",
+			labelValue: "TEST",
+		}, {
+			str:        "Tesla V100-PCIE-16GB",
+			labelValue: "Tesla-V100-PCIE-16GB",
+		}, {
+			str:        "Tesla T4",
+			labelValue: "Tesla-T4",
+		}, {
+			str:        ".test.",
+			labelValue: "test",
+		}, {
+			str:        "-test-",
+			labelValue: "test",
+		}, {
+			str:        "_test_",
+			labelValue: "test",
+		}, {
+			str:        "_test_",
+			labelValue: "test",
+		}, {
+			str:        "!!! te st !!!",
+			labelValue: "te-st",
+		}, {
+			str:        "toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong",
+			labelValue: "toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			labelValue := ConvertToLabelValue(tc.str)
+			g.Expect(labelValue).To(gomega.Equal(tc.labelValue))
+		})
+	}
+}


### PR DESCRIPTION
问题
-
[\[SKS-1978\] 自动伸缩支持 GPU 资源 - Jira](http://jira.smartx.com/browse/SKS-1978)
slack: https://smartx1.slack.com/archives/C037V8QMKQA/p1698722686956959
pod 请求 GPU 触发自动扩容 GPU 节点后，在新节点 GPU 资源 ready 前，被缩容了。
原因是 Node 已经 ready，但 CA 不知道它是带 GPU 的节点。
需要按照 https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#special-note-on-gpu-instances 给 node 打 label，让 CA 知道 node 正在准备 GPU 资源。

修改
-
- 给带 GPU 的 node 打 label `cluster-api/accelerator`，值为第一个 GPU 或 vGPU 的类型

测试
-
创建 GPU 节点，在 Node 创建后，很快打上了 `cluster-api/accelerator` label：
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/22cbf469-4538-4c7f-96cc-cba0788273e0)
触发 GPU 自动扩容：
新 node 创建后也有 `cluster-api/accelerator` label：
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/ca6d9456-2cd5-4f9a-ab23-ec6e329c556f)
CA 日志显示该 node 的 GPU 资源还不 ready，pending 的 pod 可以被调度到 CA 模拟的正在扩容的节点上，不会触发缩容和额外的扩容：
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/97743b36-82e1-4acf-9fa5-d42e7203a7aa)
最终 GPU 资源 ready，pod 成功被调度，自动扩容流程顺利结束，event:
<img width="1430" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/b00c6169-b81f-48e3-a6ba-4316d727fcee">
删除 GPU 负载 Pod，自动缩容成功：
<img width="1433" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/f445d311-aed9-459b-bd6d-2fa55620aa1c">
<img width="1434" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/113499981/03b1854f-390a-4228-841d-69596d4a6fc3">





