### PR TITLE
Add support for vGPU

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -80,11 +80,11 @@ type ElfMachineSpec struct {
 	// +optional
 	DiskGiB int32 `json:"diskGiB,omitempty"`
 
-	// GPUDevices is the list of GPUs used by the virtual machine.
+	// GPUDevices is the list of physical GPUs used by the virtual machine.
 	// +optional
 	GPUDevices []GPUPassthroughDeviceSpec `json:"gpuDevices,omitempty"`
 
-	// VGPUDevices is the list of vGPUs used by the virtual machine.
+	// VGPUDevices is the list of virtual GPUs used by the virtual machine.
 	// +optional
 	VGPUDevices []VGPUDeviceSpec `json:"vgpuDevices,omitempty"`
 

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -318,11 +318,11 @@ func (m *ElfMachine) GetVMDisconnectionTimestamp() *metav1.Time {
 	return nil
 }
 
-func (m *ElfMachine) RequiresGPUOrVGPUDevices() bool {
-	return m.RequiresGPUDevices() || m.RequiresVGPUDevices()
+func (m *ElfMachine) RequiresGPUDevices() bool {
+	return m.RequiresPassThroughGPUDevices() || m.RequiresVGPUDevices()
 }
 
-func (m *ElfMachine) RequiresGPUDevices() bool {
+func (m *ElfMachine) RequiresPassThroughGPUDevices() bool {
 	return len(m.Spec.GPUDevices) > 0
 }
 

--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -318,8 +318,16 @@ func (m *ElfMachine) GetVMDisconnectionTimestamp() *metav1.Time {
 	return nil
 }
 
+func (m *ElfMachine) RequiresGPUOrVGPUDevices() bool {
+	return m.RequiresGPUDevices() || m.RequiresVGPUDevices()
+}
+
 func (m *ElfMachine) RequiresGPUDevices() bool {
-	return len(m.Spec.GPUDevices) > 0 || len(m.Spec.VGPUDevices) > 0
+	return len(m.Spec.GPUDevices) > 0
+}
+
+func (m *ElfMachine) RequiresVGPUDevices() bool {
+	return len(m.Spec.VGPUDevices) > 0
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -77,7 +77,8 @@ spec:
                   of the ElfDeploymentZone.
                 type: string
               gpuDevices:
-                description: GPUDevices is the list of GPUs used by the virtual machine.
+                description: GPUDevices is the list of physical GPUs used by the virtual
+                  machine.
                 items:
                   description: GPUPassthroughDeviceSpec defines virtual machine's
                     GPU configuration
@@ -202,7 +203,7 @@ spec:
                   new machines.
                 type: string
               vgpuDevices:
-                description: VGPUDevices is the list of vGPUs used by the virtual
+                description: VGPUDevices is the list of virtual GPUs used by the virtual
                   machine.
                 items:
                   description: VGPUDeviceSpec defines virtual machine's VGPU configuration

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
@@ -57,8 +57,8 @@ spec:
                           to the name of the ElfDeploymentZone.
                         type: string
                       gpuDevices:
-                        description: GPUDevices is the list of GPUs used by the virtual
-                          machine.
+                        description: GPUDevices is the list of physical GPUs used
+                          by the virtual machine.
                         items:
                           description: GPUPassthroughDeviceSpec defines virtual machine's
                             GPU configuration
@@ -186,8 +186,8 @@ spec:
                           to clone new machines.
                         type: string
                       vgpuDevices:
-                        description: VGPUDevices is the list of vGPUs used by the
-                          virtual machine.
+                        description: VGPUDevices is the list of virtual GPUs used
+                          by the virtual machine.
                         items:
                           description: VGPUDeviceSpec defines virtual machine's VGPU
                             configuration

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -887,6 +887,13 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		if taskDone {
 			ctx.ElfMachine.SetTask("")
 		}
+
+		// The task is completed but entityAsyncStatus may not be equal to nil.
+		// So need to wait for the current operation of the virtual machine to complete.
+		// Avoid resource lock conflicts caused by concurrent operations of ELF.
+		if vm != nil && vm.EntityAsyncStatus != nil {
+			taskDone = false
+		}
 	}()
 
 	switch *task.Status {

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -308,7 +308,7 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 		// locked by the virtual machine may not be unlocked.
 		// For example, the Cluster or ElfMachine was deleted during a pause.
 		if !ctrlutil.ContainsFinalizer(ctx.ElfMachine, infrav1.MachineFinalizer) &&
-			ctx.ElfMachine.RequiresGPUDevices() {
+			ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
 			unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 		}
 	}()
@@ -532,7 +532,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 		}
 
 		var hostID *string
-		var gpuDevices []*models.GpuDevice
+		var gpuDeviceInfos []*service.GPUDeviceInfo
 		// The virtual machine of the Control Plane does not support GPU Devices.
 		if machineutil.IsControlPlaneMachine(ctx.Machine) {
 			hostID, err = r.preCheckPlacementGroup(ctx)
@@ -540,7 +540,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 				return nil, false, err
 			}
 		} else {
-			hostID, gpuDevices, err = r.selectHostAndGPUsForVM(ctx, "")
+			hostID, gpuDeviceInfos, err = r.selectHostAndGPUsForVM(ctx, "")
 			if err != nil || hostID == nil {
 				return nil, false, err
 			}
@@ -548,7 +548,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 
 		ctx.Logger.Info("Create VM for ElfMachine")
 
-		withTaskVM, err := ctx.VMService.Clone(ctx.ElfCluster, ctx.ElfMachine, bootstrapData, *hostID, gpuDevices)
+		withTaskVM, err := ctx.VMService.Clone(ctx.ElfCluster, ctx.ElfMachine, bootstrapData, *hostID, gpuDeviceInfos)
 		if err != nil {
 			releaseTicketForCreateVM(ctx.ElfMachine.Name)
 
@@ -561,7 +561,7 @@ func (r *ElfMachineReconciler) reconcileVM(ctx *context.MachineContext) (*models
 				ctx.ElfMachine.SetVM(util.GetVMRef(vm))
 			} else {
 				// Duplicate VM error does not require unlocking GPU devices.
-				if ctx.ElfMachine.RequiresGPUDevices() {
+				if ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
 					unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 				}
 
@@ -907,11 +907,11 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 				setVMDuplicate(ctx.ElfMachine.Name)
 			}
 
-			if ctx.ElfMachine.RequiresGPUDevices() {
+			if ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
 				unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 			}
 		case service.IsPowerOnVMTask(task) || service.IsUpdateVMTask(task):
-			if ctx.ElfMachine.RequiresGPUDevices() {
+			if ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
 				unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 			}
 		case service.IsMemoryInsufficientError(errorMessage):
@@ -933,7 +933,7 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 		ctx.Logger.Info("VM task succeeded", "vmRef", vmRef, "taskRef", taskRef, "taskDescription", service.GetTowerString(task.Description))
 
 		if service.IsCloneVMTask(task) || service.IsUpdateVMTask(task) {
-			if ctx.ElfMachine.RequiresGPUDevices() {
+			if ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
 				unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 			}
 		}

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -932,10 +932,9 @@ func (r *ElfMachineReconciler) reconcileVMTask(ctx *context.MachineContext, vm *
 	case models.TaskStatusSUCCESSED:
 		ctx.Logger.Info("VM task succeeded", "vmRef", vmRef, "taskRef", taskRef, "taskDescription", service.GetTowerString(task.Description))
 
-		if service.IsCloneVMTask(task) || service.IsUpdateVMTask(task) {
-			if ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
-				unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
-			}
+		if ctx.ElfMachine.RequiresGPUOrVGPUDevices() &&
+			(service.IsCloneVMTask(task) || service.IsPowerOnVMTask(task) || service.IsUpdateVMTask(task)) {
+			unlockGPUDevicesLockedByVM(ctx.ElfCluster.Spec.Cluster, ctx.ElfMachine.Name)
 		}
 
 		if service.IsCloneVMTask(task) || service.IsPowerOnVMTask(task) {

--- a/controllers/elfmachine_controller_gpu.go
+++ b/controllers/elfmachine_controller_gpu.go
@@ -80,7 +80,7 @@ func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx *context.MachineContex
 
 	availableHosts := hosts.FilterAvailableHostsWithEnoughMemory(*service.TowerMemory(ctx.ElfMachine.Spec.MemoryMiB))
 	if len(availableHosts) == 0 {
-		ctx.Logger.V(2).Info("No available hosts for selecting GPUs")
+		ctx.Logger.V(2).Info("Waiting for enough available hosts")
 		return nil, nil, nil
 	}
 

--- a/controllers/elfmachine_controller_gpu.go
+++ b/controllers/elfmachine_controller_gpu.go
@@ -44,7 +44,7 @@ import (
 //
 // The return gpudevices: the GPU devices for virtual machine.
 func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx *context.MachineContext, preferredHostID string) (rethost *string, gpudevices []*service.GPUDeviceInfo, reterr error) {
-	if !ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
+	if !ctx.ElfMachine.RequiresGPUDevices() {
 		return pointer.String(""), nil, nil
 	}
 
@@ -98,7 +98,7 @@ func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx *context.MachineContex
 		gpuDeviceIDs[i] = *gpuDevices[i].ID
 	}
 	// Get GPU devices with VMs and allocation details.
-	gpuDeviceInfos, err := ctx.VMService.FindGPUDeviceInfos(gpuDeviceIDs)
+	gpuDeviceInfos, err := ctx.VMService.GetGPUDevicesAllocationInfo(gpuDeviceIDs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +144,7 @@ func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx *context.MachineContex
 		}
 
 		var selectedGPUDeviceInfos []*service.GPUDeviceInfo
-		if ctx.ElfMachine.RequiresGPUDevices() {
+		if ctx.ElfMachine.RequiresPassThroughGPUDevices() {
 			selectedGPUDeviceInfos = selectGPUDevicesForVM(hostGPUDeviceInfos, ctx.ElfMachine.Spec.GPUDevices)
 		} else {
 			selectedGPUDeviceInfos = selectVGPUDevicesForVM(hostGPUDeviceInfos, ctx.ElfMachine.Spec.VGPUDevices)
@@ -248,7 +248,7 @@ func selectVGPUDevicesForVM(hostGPUDeviceInfos service.GPUDeviceInfos, requiredV
 
 // reconcileGPUDevices ensures that the virtual machine has the expected GPU devices.
 func (r *ElfMachineReconciler) reconcileGPUDevices(ctx *context.MachineContext, vm *models.VM) (bool, error) {
-	if !ctx.ElfMachine.RequiresGPUOrVGPUDevices() {
+	if !ctx.ElfMachine.RequiresGPUDevices() {
 		return true, nil
 	}
 
@@ -359,17 +359,26 @@ func (r *ElfMachineReconciler) removeVMGPUDevices(ctx *context.MachineContext, v
 // checkGPUsCanBeUsedForVM checks whether GPU devices can be used by the specified virtual machine.
 // The return true means the GPU devices can be used for the virtual machine.
 func (r *ElfMachineReconciler) checkGPUsCanBeUsedForVM(ctx *context.MachineContext, gpuDeviceIDs []string) (bool, error) {
-	gpuDevices, err := ctx.VMService.FindGPUDevicesByIDs(gpuDeviceIDs)
-	if err != nil || len(gpuDevices) != len(gpuDeviceIDs) {
-		return false, err
-	}
+	gpuDeviceInfos := getGPUDeviceInfosFromCache(gpuDeviceIDs)
+	if gpuDeviceInfos.Len() != len(gpuDeviceIDs) {
+		gpuDevices, err := ctx.VMService.FindGPUDevicesByIDs(gpuDeviceIDs)
+		if err != nil || len(gpuDevices) != len(gpuDeviceIDs) {
+			return false, err
+		}
 
-	gpuDeviceInfos, err := ctx.VMService.FindGPUDeviceInfos(gpuDeviceIDs)
-	if err != nil {
-		return false, err
-	}
+		gpuDeviceInfos, err = ctx.VMService.GetGPUDevicesAllocationInfo(gpuDeviceIDs)
+		if err != nil {
+			return false, err
+		}
 
-	service.AggregateUnusedGPUDevicesToGPUDeviceInfos(gpuDeviceInfos, gpuDevices)
+		service.AggregateUnusedGPUDevicesToGPUDeviceInfos(gpuDeviceInfos, gpuDevices)
+
+		setGPUDeviceInfosCache(gpuDeviceInfos)
+
+		if gpuDeviceInfos.Len() != len(gpuDeviceIDs) {
+			return false, nil
+		}
+	}
 
 	if service.HasGPUsCanNotBeUsedForVM(gpuDeviceInfos, ctx.ElfMachine) {
 		return false, nil

--- a/controllers/elfmachine_controller_gpu_test.go
+++ b/controllers/elfmachine_controller_gpu_test.go
@@ -121,7 +121,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs([]string{*host.ID}, models.GpuDeviceUsagePASSTHROUGH).Return(gpusDevices, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gpuIDs).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gpuIDs).Return(gpusDeviceInfos, nil)
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -133,7 +133,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			Expect(gpus[0].AllocatedCount).To(Equal(int32(1)))
 
 			mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(gpusDevices, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gpuIDs).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gpuIDs).Return(gpusDeviceInfos, nil)
 			hostID, gpus, err = reconciler.selectHostAndGPUsForVM(machineContext, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*hostID).To(Equal(*host.ID))
@@ -143,6 +143,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			Expect(logBuffer.String()).To(ContainSubstring("Found locked VM GPU devices"))
 
 			logBuffer.Reset()
+			removeGPUDeviceInfosCache(gpuIDs)
 			gpu.Vms = []*models.NestedVM{{ID: service.TowerString("id"), Name: service.TowerString("vm")}}
 			gpusDeviceInfo := gpusDeviceInfos.Get(*gpu.ID)
 			gpusDeviceInfo.AllocatedCount = 1
@@ -150,7 +151,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			gpusDeviceInfo.VMs = []service.GPUDeviceVM{{ID: "id", Name: "vm"}}
 			mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(gpusDevices, nil)
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(nil, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gpuIDs).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gpuIDs).Return(gpusDeviceInfos, nil)
 			hostID, gpus, err = reconciler.selectHostAndGPUsForVM(machineContext, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hostID).To(BeNil())
@@ -188,7 +189,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host, preferredHost), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs(gomock.InAnyOrder([]string{*host.ID, *preferredHost.ID}), models.GpuDeviceUsagePASSTHROUGH).Return(gpusDevices, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gomock.InAnyOrder([]string{*gpu.ID, *preferredGPU.ID})).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gomock.InAnyOrder([]string{*gpu.ID, *preferredGPU.ID})).Return(gpusDeviceInfos, nil)
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -246,7 +247,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs([]string{*host.ID}, models.GpuDeviceUsageVGPU).Return(gpusDevices, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gomock.InAnyOrder([]string{*gpu1.ID, *gpu2.ID})).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gomock.InAnyOrder([]string{*gpu1.ID, *gpu2.ID})).Return(gpusDeviceInfos, nil)
 			hostID, gpus, err = reconciler.selectHostAndGPUsForVM(machineContext, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hostID).NotTo(BeNil())
@@ -273,7 +274,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			}})
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs([]string{*host.ID}, models.GpuDeviceUsageVGPU).Return(gpusDevices, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos(gomock.InAnyOrder([]string{*gpu1.ID, *gpu2.ID})).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gomock.InAnyOrder([]string{*gpu1.ID, *gpu2.ID})).Return(gpusDeviceInfos, nil)
 			hostID, gpus, err = reconciler.selectHostAndGPUsForVM(machineContext, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hostID).To(BeNil())
@@ -372,7 +373,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().FindGPUDevicesByIDs([]string{*gpu.ID}).Times(2).Return([]*models.GpuDevice{gpu}, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos([]string{*gpu.ID}).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo([]string{*gpu.ID}).Return(gpusDeviceInfos, nil)
 			mockVMService.EXPECT().RemoveGPUDevices(elfMachine.Status.VMRef, gomock.Len(1)).Return(nil, unexpectedError)
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -383,8 +384,9 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			Expect(ok).To(BeFalse())
 			Expect(logBuffer.String()).To(ContainSubstring("GPU devices of VM are already in use, so remove and reallocate"))
 
+			removeGPUDeviceInfosCache([]string{*gpu.ID})
 			gpusDeviceInfos.Get(*gpu.ID).VMs = []service.GPUDeviceVM{{Name: *vm.Name, AllocatedCount: 1}}
-			mockVMService.EXPECT().FindGPUDeviceInfos([]string{*gpu.ID}).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo([]string{*gpu.ID}).Return(gpusDeviceInfos, nil)
 			ok, err = reconciler.reconcileGPUDevices(machineContext, vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
@@ -417,7 +419,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Times(2).Return(service.NewHosts(host), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs([]string{*host.ID}, models.GpuDeviceUsagePASSTHROUGH).Times(2).Return([]*models.GpuDevice{gpu}, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos([]string{*gpu.ID}).Times(2).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo([]string{*gpu.ID}).Times(2).Return(gpusDeviceInfos, nil)
 			mockVMService.EXPECT().Migrate(*vm.ID, *host.ID).Return(withTaskVM, nil)
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -458,7 +460,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Times(2).Return(service.NewHosts(host), nil)
 			mockVMService.EXPECT().FindGPUDevicesByHostIDs([]string{*host.ID}, models.GpuDeviceUsagePASSTHROUGH).Times(2).Return([]*models.GpuDevice{gpu}, nil)
-			mockVMService.EXPECT().FindGPUDeviceInfos([]string{*gpu.ID}).Times(2).Return(gpusDeviceInfos, nil)
+			mockVMService.EXPECT().GetGPUDevicesAllocationInfo([]string{*gpu.ID}).Times(2).Return(gpusDeviceInfos, nil)
 			mockVMService.EXPECT().AddGPUDevices(elfMachine.Status.VMRef, gomock.Any()).Return(task, nil)
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -581,8 +583,8 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 		elfMachine.Spec.GPUDevices = append(elfMachine.Spec.GPUDevices, infrav1.GPUPassthroughDeviceSpec{Model: "A16", Count: 1})
 		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-		mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(nil, nil)
 
+		mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(nil, nil)
 		machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 		ok, err := reconciler.checkGPUsCanBeUsedForVM(machineContext, gpuIDs)
@@ -590,16 +592,23 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 		Expect(ok).To(BeFalse())
 
 		mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(gpusDevices, nil)
-		mockVMService.EXPECT().FindGPUDeviceInfos(gpuIDs).Return(gpusDeviceInfos, nil)
+		mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gpuIDs).Return(gpusDeviceInfos, nil)
 		ok, err = reconciler.checkGPUsCanBeUsedForVM(machineContext, gpuIDs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeTrue())
 
-		gpusDeviceInfos.Insert(&service.GPUDeviceInfo{
+		// Use cache
+		ok, err = reconciler.checkGPUsCanBeUsedForVM(machineContext, gpuIDs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		removeGPUDeviceInfosCache(gpuIDs)
+		gpusDeviceInfos = service.NewGPUDeviceInfos(&service.GPUDeviceInfo{
+			ID:  *gpu.ID,
 			VMs: []service.GPUDeviceVM{{ID: "vm1", Name: "vm1"}},
 		})
 		mockVMService.EXPECT().FindGPUDevicesByIDs(gpuIDs).Return(gpusDevices, nil)
-		mockVMService.EXPECT().FindGPUDeviceInfos(gpuIDs).Return(gpusDeviceInfos, nil)
+		mockVMService.EXPECT().GetGPUDevicesAllocationInfo(gpuIDs).Return(gpusDeviceInfos, nil)
 		ok, err = reconciler.checkGPUsCanBeUsedForVM(machineContext, gpuIDs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeFalse())

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -3121,6 +3121,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				{"Create a VM", models.TaskStatusFAILED},
 				{"Start VM", models.TaskStatusFAILED},
 				{"Edit VM", models.TaskStatusFAILED},
+				{"performing a cold migration", models.TaskStatusFAILED},
 				{"Create a VM", models.TaskStatusSUCCESSED},
 				{"Start VM", models.TaskStatusSUCCESSED},
 				{"Edit VM", models.TaskStatusSUCCESSED},

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
@@ -170,31 +171,31 @@ func getKeyForDuplicatePlacementGroupError(placementGroup string) string {
 // gpuCacheDuration is the lifespan of gpu cache.
 const gpuCacheDuration = 3 * time.Second
 
-func getKeyForGPUDeviceInfo(gpuID string) string {
-	return fmt.Sprintf("gpu:device:info:%s", gpuID)
+func getKeyForGPUVMInfo(gpuID string) string {
+	return fmt.Sprintf("gpu:vm:info:%s", gpuID)
 }
 
-// setGPUDeviceInfosCache saves the specified GPU device infos to the memory,
+// setGPUVMInfosCache saves the specified GPU device infos to the memory,
 // which can reduce access to the Tower service.
-func setGPUDeviceInfosCache(gpuDeviceInfos service.GPUDeviceInfos) {
-	gpuDeviceInfos.Iterate(func(g *service.GPUDeviceInfo) {
-		vmTaskErrorCache.Set(getKeyForGPUDeviceInfo(g.ID), *g, gpuCacheDuration)
+func setGPUVMInfosCache(gpuVMInfos service.GPUVMInfos) {
+	gpuVMInfos.Iterate(func(g *models.GpuVMInfo) {
+		vmTaskErrorCache.Set(getKeyForGPUVMInfo(*g.ID), *g, gpuCacheDuration)
 	})
 }
 
 // setGPUDeviceInfosCache gets the specified GPU device infos from the memory.
-func getGPUDeviceInfosFromCache(gpuIDs []string) service.GPUDeviceInfos {
-	gpuDeviceInfos := service.NewGPUDeviceInfos()
+func getGPUVMInfosFromCache(gpuIDs []string) service.GPUVMInfos {
+	gpuVMInfos := service.NewGPUVMInfos()
 	for i := 0; i < len(gpuIDs); i++ {
-		key := getKeyForGPUDeviceInfo(gpuIDs[i])
+		key := getKeyForGPUVMInfo(gpuIDs[i])
 		if val, found := vmTaskErrorCache.Get(key); found {
-			if gpuDeviceInfo, ok := val.(service.GPUDeviceInfo); ok {
-				gpuDeviceInfos.Insert(&gpuDeviceInfo)
+			if gpuVMInfo, ok := val.(models.GpuVMInfo); ok {
+				gpuVMInfos.Insert(&gpuVMInfo)
 			}
 			// Delete unexpected data.
 			vmTaskErrorCache.Delete(key)
 		}
 	}
 
-	return gpuDeviceInfos
+	return gpuVMInfos
 }

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
@@ -171,20 +172,20 @@ var _ = Describe("TowerCache", func() {
 
 	It("GPU Cache", func() {
 		gpuID := "gpu"
-		gpuDeviceInfo := service.GPUDeviceInfo{ID: gpuID}
-		gpuDeviceInfos := service.NewGPUDeviceInfos(&gpuDeviceInfo)
-		setGPUDeviceInfosCache(gpuDeviceInfos)
-		cachedGPUDeviceInfos := getGPUDeviceInfosFromCache([]string{gpuID})
+		gpuVMInfo := models.GpuVMInfo{ID: service.TowerString(gpuID)}
+		gpuVMInfos := service.NewGPUVMInfos(&gpuVMInfo)
+		setGPUVMInfosCache(gpuVMInfos)
+		cachedGPUDeviceInfos := getGPUVMInfosFromCache([]string{gpuID})
 		Expect(cachedGPUDeviceInfos.Len()).To(Equal(1))
-		Expect(*cachedGPUDeviceInfos.Get(gpuDeviceInfo.ID)).To(Equal(gpuDeviceInfo))
+		Expect(*cachedGPUDeviceInfos.Get(*gpuVMInfo.ID)).To(Equal(gpuVMInfo))
 		time.Sleep(gpuCacheDuration)
-		Expect(getGPUDeviceInfosFromCache([]string{gpuID})).To(BeEmpty())
+		Expect(getGPUVMInfosFromCache([]string{gpuID})).To(BeEmpty())
 	})
 })
 
-func removeGPUDeviceInfosCache(gpuIDs []string) {
+func removeGPUVMInfosCache(gpuIDs []string) {
 	for i := 0; i < len(gpuIDs); i++ {
-		vmTaskErrorCache.Delete(getKeyForGPUDeviceInfo(gpuIDs[i]))
+		vmTaskErrorCache.Delete(getKeyForGPUVMInfo(gpuIDs[i]))
 	}
 }
 

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -229,11 +229,7 @@ func getGPUDevicesLockedByVM(clusterID, vmName string) *lockedVMGPUs {
 
 	lockedClusterGPUs := getLockedClusterGPUsWithoutLock(clusterID)
 	if vmGPUs, ok := lockedClusterGPUs[vmName]; ok {
-		if time.Now().Before(vmGPUs.LockedAt.Add(gpuLockTimeout)) {
-			return &vmGPUs
-		}
-
-		delete(lockedClusterGPUs, vmName)
+		return &vmGPUs
 	}
 
 	return nil

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
 
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/config"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
@@ -207,15 +208,16 @@ func lockGPUDevicesForVM(clusterID, vmName, hostID string, gpuDeviceInfos []*ser
 	return true
 }
 
-func filterGPUDeviceInfosByLockGPUDevices(clusterID string, gpuDeviceInfos service.GPUDeviceInfos) service.GPUDeviceInfos {
+func filterGPUVMInfosByLockGPUDevices(clusterID string, gpuVMInfos service.GPUVMInfos) service.GPUVMInfos {
 	gpuLock.Lock()
 	defer gpuLock.Unlock()
 
 	lockedClusterGPUs := getLockedClusterGPUsWithoutLock(clusterID)
 	lockedCountMap := getLockedCountMapWithoutLock(lockedClusterGPUs)
 
-	return gpuDeviceInfos.Filter(func(g *service.GPUDeviceInfo) bool {
-		if lockedCount, ok := lockedCountMap[g.ID]; ok && lockedCount >= g.AvailableCount {
+	return gpuVMInfos.Filter(func(g *models.GpuVMInfo) bool {
+		availableCount := service.GetAvailableCountFromGPUVMInfo(g)
+		if lockedCount, ok := lockedCountMap[*g.ID]; ok && lockedCount >= availableCount {
 			return false
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2
+	github.com/smartxworks/cloudtower-go-sdk/v2 v2.13.1-0.20231116110941-d411454388af
 	golang.org/x/mod v0.12.0
 	k8s.io/api v0.27.2
 	k8s.io/apiextensions-apiserver v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cloudtower-go-sdk/v2 v2.11.1-rc-2023-09-14
+	github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2
 	golang.org/x/mod v0.12.0
 	k8s.io/api v0.27.2
 	k8s.io/apiextensions-apiserver v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2 h1:UXS2xA1dmSdR5B9BPmArlKHDAmpjGytY7XVPbVadBqU=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2/go.mod h1:X6R9+L438SMnLJXykSCV3fJ+AZul0hlyjITsZgrSRtM=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.13.1-0.20231116110941-d411454388af h1:rV7FO8PZAzurE2zLEtXVrcKZkF544w98rXjvv2bDaqI=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.13.1-0.20231116110941-d411454388af/go.mod h1:X6R9+L438SMnLJXykSCV3fJ+AZul0hlyjITsZgrSRtM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.11.1-rc-2023-09-14 h1:CHJLqIwjPHMKpnlR7wXmKUr9n2Ba7KhR5LG63S4TqQY=
-github.com/smartxworks/cloudtower-go-sdk/v2 v2.11.1-rc-2023-09-14/go.mod h1:X6R9+L438SMnLJXykSCV3fJ+AZul0hlyjITsZgrSRtM=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2 h1:UXS2xA1dmSdR5B9BPmArlKHDAmpjGytY7XVPbVadBqU=
+github.com/smartxworks/cloudtower-go-sdk/v2 v2.12.1-0.20231102021857-ae16239443e2/go.mod h1:X6R9+L438SMnLJXykSCV3fJ+AZul0hlyjITsZgrSRtM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/service/collections.go
+++ b/pkg/service/collections.go
@@ -168,3 +168,86 @@ func (s Hosts) IDs() []string {
 	}
 	return res
 }
+
+// GPUDeviceInfos is a set of GPUDeviceInfos.
+type GPUDeviceInfos map[string]*GPUDeviceInfo
+
+// NewGPUDeviceInfos creates a GPUDeviceInfos. from a list of values.
+func NewGPUDeviceInfos(gpuDeviceInfo ...*GPUDeviceInfo) GPUDeviceInfos {
+	ss := make(GPUDeviceInfos, len(gpuDeviceInfo))
+	ss.Insert(gpuDeviceInfo...)
+	return ss
+}
+
+func (s GPUDeviceInfos) Insert(gpuDeviceInfos ...*GPUDeviceInfo) {
+	for i := range gpuDeviceInfos {
+		if gpuDeviceInfos[i] != nil {
+			g := gpuDeviceInfos[i]
+			s[g.ID] = g
+		}
+	}
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s GPUDeviceInfos) UnsortedList() []*GPUDeviceInfo {
+	res := make([]*GPUDeviceInfo, 0, len(s))
+	for _, value := range s {
+		res = append(res, value)
+	}
+	return res
+}
+
+// Get returns a GPUDeviceInfo of the specified gpuID.
+func (s GPUDeviceInfos) Get(gpuID string) *GPUDeviceInfo {
+	if gpuDeviceInfo, ok := s[gpuID]; ok {
+		return gpuDeviceInfo
+	}
+	return nil
+}
+
+func (s GPUDeviceInfos) Contains(gpuID string) bool {
+	_, ok := s[gpuID]
+	return ok
+}
+
+func (s GPUDeviceInfos) Len() int {
+	return len(s)
+}
+
+func (s GPUDeviceInfos) Iterate(fn func(*GPUDeviceInfo)) {
+	for _, g := range s {
+		fn(g)
+	}
+}
+
+// Filter returns a GPUDeviceInfos containing only the GPUDeviceInfos that match all of the given GPUDeviceInfoFilters.
+func (s GPUDeviceInfos) Filter(filters ...GPUDeviceInfoFilterFunc) GPUDeviceInfos {
+	return newFilteredGPUDeviceInfoCollection(GPUDeviceInfoFilterAnd(filters...), s.UnsortedList()...)
+}
+
+// newFilteredGPUDeviceInfoCollection creates a GPUDeviceInfos from a filtered list of values.
+func newFilteredGPUDeviceInfoCollection(filter GPUDeviceInfoFilterFunc, gpuDeviceInfos ...*GPUDeviceInfo) GPUDeviceInfos {
+	ss := make(GPUDeviceInfos, len(gpuDeviceInfos))
+	for i := range gpuDeviceInfos {
+		g := gpuDeviceInfos[i]
+		if filter(g) {
+			ss.Insert(g)
+		}
+	}
+	return ss
+}
+
+// GPUDeviceInfoFilterFunc is the functon definition for a filter.
+type GPUDeviceInfoFilterFunc func(*GPUDeviceInfo) bool
+
+// GPUDeviceInfoFilterAnd returns a filter that returns true if all of the given filters returns true.
+func GPUDeviceInfoFilterAnd(filters ...GPUDeviceInfoFilterFunc) GPUDeviceInfoFilterFunc {
+	return func(g *GPUDeviceInfo) bool {
+		for _, f := range filters {
+			if !f(g) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/pkg/service/collections.go
+++ b/pkg/service/collections.go
@@ -169,67 +169,76 @@ func (s Hosts) IDs() []string {
 	return res
 }
 
-// GPUDeviceInfos is a set of GPUDeviceInfos.
-type GPUDeviceInfos map[string]*GPUDeviceInfo
+// GPUVMInfos is a set of GPUVMInfos.
+type GPUVMInfos map[string]*models.GpuVMInfo
 
-// NewGPUDeviceInfos creates a GPUDeviceInfos. from a list of values.
-func NewGPUDeviceInfos(gpuDeviceInfo ...*GPUDeviceInfo) GPUDeviceInfos {
-	ss := make(GPUDeviceInfos, len(gpuDeviceInfo))
-	ss.Insert(gpuDeviceInfo...)
+// NewGPUVMInfos creates a GPUVMInfos. from a list of values.
+func NewGPUVMInfos(gpuVMInfo ...*models.GpuVMInfo) GPUVMInfos {
+	ss := make(GPUVMInfos, len(gpuVMInfo))
+	ss.Insert(gpuVMInfo...)
 	return ss
 }
 
-func (s GPUDeviceInfos) Insert(gpuDeviceInfos ...*GPUDeviceInfo) {
-	for i := range gpuDeviceInfos {
-		if gpuDeviceInfos[i] != nil {
-			g := gpuDeviceInfos[i]
-			s[g.ID] = g
+// NewGPUVMInfosFromList creates a Hosts from the given host slice.
+func NewGPUVMInfosFromList(gpuVMInfos []*models.GpuVMInfo) GPUVMInfos {
+	ss := make(GPUVMInfos, len(gpuVMInfos))
+	for i := range gpuVMInfos {
+		ss.Insert(gpuVMInfos[i])
+	}
+	return ss
+}
+
+func (s GPUVMInfos) Insert(gpuVMInfos ...*models.GpuVMInfo) {
+	for i := range gpuVMInfos {
+		if gpuVMInfos[i] != nil {
+			g := gpuVMInfos[i]
+			s[*g.ID] = g
 		}
 	}
 }
 
 // UnsortedList returns the slice with contents in random order.
-func (s GPUDeviceInfos) UnsortedList() []*GPUDeviceInfo {
-	res := make([]*GPUDeviceInfo, 0, len(s))
+func (s GPUVMInfos) UnsortedList() []*models.GpuVMInfo {
+	res := make([]*models.GpuVMInfo, 0, len(s))
 	for _, value := range s {
 		res = append(res, value)
 	}
 	return res
 }
 
-// Get returns a GPUDeviceInfo of the specified gpuID.
-func (s GPUDeviceInfos) Get(gpuID string) *GPUDeviceInfo {
-	if gpuDeviceInfo, ok := s[gpuID]; ok {
-		return gpuDeviceInfo
+// Get returns a GPUVMInfo of the specified gpuID.
+func (s GPUVMInfos) Get(gpuID string) *models.GpuVMInfo {
+	if gpuVMInfo, ok := s[gpuID]; ok {
+		return gpuVMInfo
 	}
 	return nil
 }
 
-func (s GPUDeviceInfos) Contains(gpuID string) bool {
+func (s GPUVMInfos) Contains(gpuID string) bool {
 	_, ok := s[gpuID]
 	return ok
 }
 
-func (s GPUDeviceInfos) Len() int {
+func (s GPUVMInfos) Len() int {
 	return len(s)
 }
 
-func (s GPUDeviceInfos) Iterate(fn func(*GPUDeviceInfo)) {
+func (s GPUVMInfos) Iterate(fn func(*models.GpuVMInfo)) {
 	for _, g := range s {
 		fn(g)
 	}
 }
 
-// Filter returns a GPUDeviceInfos containing only the GPUDeviceInfos that match all of the given GPUDeviceInfoFilters.
-func (s GPUDeviceInfos) Filter(filters ...GPUDeviceInfoFilterFunc) GPUDeviceInfos {
-	return newFilteredGPUDeviceInfoCollection(GPUDeviceInfoFilterAnd(filters...), s.UnsortedList()...)
+// Filter returns a GPUVMInfos containing only the GPUVMInfos that match all of the given GPUVMInfoFilters.
+func (s GPUVMInfos) Filter(filters ...GPUVMInfoFilterFunc) GPUVMInfos {
+	return newFilteredGPUVMInfoCollection(GPUVMInfoFilterAnd(filters...), s.UnsortedList()...)
 }
 
-// newFilteredGPUDeviceInfoCollection creates a GPUDeviceInfos from a filtered list of values.
-func newFilteredGPUDeviceInfoCollection(filter GPUDeviceInfoFilterFunc, gpuDeviceInfos ...*GPUDeviceInfo) GPUDeviceInfos {
-	ss := make(GPUDeviceInfos, len(gpuDeviceInfos))
-	for i := range gpuDeviceInfos {
-		g := gpuDeviceInfos[i]
+// newFilteredGPUVMInfoCollection creates a GPUVMInfos from a filtered list of values.
+func newFilteredGPUVMInfoCollection(filter GPUVMInfoFilterFunc, gpuVMInfos ...*models.GpuVMInfo) GPUVMInfos {
+	ss := make(GPUVMInfos, len(gpuVMInfos))
+	for i := range gpuVMInfos {
+		g := gpuVMInfos[i]
 		if filter(g) {
 			ss.Insert(g)
 		}
@@ -237,12 +246,12 @@ func newFilteredGPUDeviceInfoCollection(filter GPUDeviceInfoFilterFunc, gpuDevic
 	return ss
 }
 
-// GPUDeviceInfoFilterFunc is the functon definition for a filter.
-type GPUDeviceInfoFilterFunc func(*GPUDeviceInfo) bool
+// GPUVMInfoFilterFunc is the functon definition for a filter.
+type GPUVMInfoFilterFunc func(*models.GpuVMInfo) bool
 
-// GPUDeviceInfoFilterAnd returns a filter that returns true if all of the given filters returns true.
-func GPUDeviceInfoFilterAnd(filters ...GPUDeviceInfoFilterFunc) GPUDeviceInfoFilterFunc {
-	return func(g *GPUDeviceInfo) bool {
+// GPUVMInfoFilterAnd returns a filter that returns true if all of the given filters returns true.
+func GPUVMInfoFilterAnd(filters ...GPUVMInfoFilterFunc) GPUVMInfoFilterFunc {
+	return func(g *models.GpuVMInfo) bool {
 		for _, f := range filters {
 			if !f(g) {
 				return false
@@ -250,4 +259,17 @@ func GPUDeviceInfoFilterAnd(filters ...GPUDeviceInfoFilterFunc) GPUDeviceInfoFil
 		}
 		return true
 	}
+}
+
+// FilterAvailableGPUVMInfos returns a GPUVMInfos containing the GPUs
+// which can allocatable for virtual machines.
+func (s GPUVMInfos) FilterAvailableGPUVMInfos() GPUVMInfos {
+	return s.Filter(func(gpuVMInfo *models.GpuVMInfo) bool {
+		if (*gpuVMInfo.UserUsage == models.GpuDeviceUsagePASSTHROUGH && len(gpuVMInfo.Vms) > 0) ||
+			(*gpuVMInfo.UserUsage == models.GpuDeviceUsageVGPU && *gpuVMInfo.AvailableVgpusNum <= 0) {
+			return false
+		}
+
+		return true
+	})
 }

--- a/pkg/service/collections.go
+++ b/pkg/service/collections.go
@@ -169,7 +169,9 @@ func (s Hosts) IDs() []string {
 	return res
 }
 
-// GPUVMInfos is a set of GPUVMInfos.
+// GPUVMInfos is a set of GpuVMInfos.
+// Key is the ID of GPU device.
+// Value is the GpuVMInfo type with VMs and allocation details.
 type GPUVMInfos map[string]*models.GpuVMInfo
 
 // NewGPUVMInfos creates a GPUVMInfos. from a list of values.

--- a/pkg/service/collections_test.go
+++ b/pkg/service/collections_test.go
@@ -82,35 +82,46 @@ func TestHostCollection(t *testing.T) {
 	})
 }
 
-func TestGPUDeviceInfoCollection(t *testing.T) {
+func TestGPUVMInfoCollection(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	t.Run("Find", func(t *testing.T) {
-		gpuDeviceInfo1 := &GPUDeviceInfo{ID: "gpu1"}
-		gpuDeviceInfo2 := &GPUDeviceInfo{ID: "gpu2"}
+		gpuVMInfo1 := &models.GpuVMInfo{ID: TowerString("gpu1")}
+		gpuVMInfo2 := &models.GpuVMInfo{ID: TowerString("gpu2")}
 
-		gpuDeviceInfos := NewGPUDeviceInfos()
-		g.Expect(gpuDeviceInfos.Get("404")).To(gomega.BeNil())
-		g.Expect(gpuDeviceInfos.Len()).To(gomega.Equal(0))
+		gpuVMInfos := NewGPUVMInfos()
+		g.Expect(gpuVMInfos.Get("404")).To(gomega.BeNil())
+		g.Expect(gpuVMInfos.Len()).To(gomega.Equal(0))
 
-		gpuDeviceInfos.Insert(gpuDeviceInfo1)
-		g.Expect(gpuDeviceInfos.Contains("gpu1")).To(gomega.BeTrue())
-		g.Expect(gpuDeviceInfos.Get("gpu1")).To(gomega.Equal(gpuDeviceInfo1))
-		g.Expect(gpuDeviceInfos.UnsortedList()).To(gomega.Equal([]*GPUDeviceInfo{gpuDeviceInfo1}))
+		gpuVMInfos.Insert(gpuVMInfo1)
+		g.Expect(gpuVMInfos.Contains("gpu1")).To(gomega.BeTrue())
+		g.Expect(gpuVMInfos.Get("gpu1")).To(gomega.Equal(gpuVMInfo1))
+		g.Expect(gpuVMInfos.UnsortedList()).To(gomega.Equal([]*models.GpuVMInfo{gpuVMInfo1}))
 		count := 0
-		gpuID := gpuDeviceInfo1.ID
-		gpuDeviceInfos.Iterate(func(g *GPUDeviceInfo) {
+		gpuID := *gpuVMInfo1.ID
+		gpuVMInfos.Iterate(func(g *models.GpuVMInfo) {
 			count += 1
-			gpuID = g.ID
+			gpuID = *g.ID
 		})
 		g.Expect(count).To(gomega.Equal(1))
-		g.Expect(gpuID).To(gomega.Equal(gpuDeviceInfo1.ID))
+		g.Expect(gpuID).To(gomega.Equal(*gpuVMInfo1.ID))
 
-		gpuDeviceInfos = NewGPUDeviceInfos(gpuDeviceInfo1, gpuDeviceInfo2)
-		filteredGPUDeviceInfos := gpuDeviceInfos.Filter(func(g *GPUDeviceInfo) bool {
-			return g.ID != gpuDeviceInfo1.ID
+		gpuVMInfos = NewGPUVMInfosFromList([]*models.GpuVMInfo{gpuVMInfo1, gpuVMInfo2})
+		filteredGPUVMInfos := gpuVMInfos.Filter(func(g *models.GpuVMInfo) bool {
+			return g.ID != gpuVMInfo1.ID
 		})
-		g.Expect(filteredGPUDeviceInfos.Len()).To(gomega.Equal(1))
-		g.Expect(filteredGPUDeviceInfos.Contains(gpuDeviceInfo2.ID)).To(gomega.BeTrue())
+		g.Expect(filteredGPUVMInfos.Len()).To(gomega.Equal(1))
+		g.Expect(filteredGPUVMInfos.Contains(*gpuVMInfo2.ID)).To(gomega.BeTrue())
+
+		gpuVMInfo1.UserUsage = models.NewGpuDeviceUsage(models.GpuDeviceUsagePASSTHROUGH)
+		g.Expect(NewGPUVMInfos(gpuVMInfo1).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(1))
+		gpuVMInfo1.Vms = []*models.GpuVMDetail{{}}
+		g.Expect(NewGPUVMInfos(gpuVMInfo1).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(0))
+
+		gpuVMInfo2.UserUsage = models.NewGpuDeviceUsage(models.GpuDeviceUsageVGPU)
+		gpuVMInfo2.AvailableVgpusNum = TowerInt32(1)
+		g.Expect(NewGPUVMInfos(gpuVMInfo2).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(1))
+		gpuVMInfo2.AvailableVgpusNum = TowerInt32(0)
+		g.Expect(NewGPUVMInfos(gpuVMInfo2).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(0))
 	})
 }

--- a/pkg/service/collections_test.go
+++ b/pkg/service/collections_test.go
@@ -81,3 +81,36 @@ func TestHostCollection(t *testing.T) {
 		g.Expect(NewHosts(host1, host2).Difference(NewHosts(host2)).Contains(*host1.ID)).To(gomega.BeTrue())
 	})
 }
+
+func TestGPUDeviceInfoCollection(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("Find", func(t *testing.T) {
+		gpuDeviceInfo1 := &GPUDeviceInfo{ID: "gpu1"}
+		gpuDeviceInfo2 := &GPUDeviceInfo{ID: "gpu2"}
+
+		gpuDeviceInfos := NewGPUDeviceInfos()
+		g.Expect(gpuDeviceInfos.Get("404")).To(gomega.BeNil())
+		g.Expect(gpuDeviceInfos.Len()).To(gomega.Equal(0))
+
+		gpuDeviceInfos.Insert(gpuDeviceInfo1)
+		g.Expect(gpuDeviceInfos.Contains("gpu1")).To(gomega.BeTrue())
+		g.Expect(gpuDeviceInfos.Get("gpu1")).To(gomega.Equal(gpuDeviceInfo1))
+		g.Expect(gpuDeviceInfos.UnsortedList()).To(gomega.Equal([]*GPUDeviceInfo{gpuDeviceInfo1}))
+		count := 0
+		gpuID := gpuDeviceInfo1.ID
+		gpuDeviceInfos.Iterate(func(g *GPUDeviceInfo) {
+			count += 1
+			gpuID = g.ID
+		})
+		g.Expect(count).To(gomega.Equal(1))
+		g.Expect(gpuID).To(gomega.Equal(gpuDeviceInfo1.ID))
+
+		gpuDeviceInfos = NewGPUDeviceInfos(gpuDeviceInfo1, gpuDeviceInfo2)
+		filteredGPUDeviceInfos := gpuDeviceInfos.Filter(func(g *GPUDeviceInfo) bool {
+			return g.ID != gpuDeviceInfo1.ID
+		})
+		g.Expect(filteredGPUDeviceInfos.Len()).To(gomega.Equal(1))
+		g.Expect(filteredGPUDeviceInfos.Contains(gpuDeviceInfo2.ID)).To(gomega.BeTrue())
+	})
+}

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -27,6 +27,7 @@ const (
 	HostNotFound              = "HOST_NOT_FOUND"
 	VMTemplateNotFound        = "VM_TEMPLATE_NOT_FOUND"
 	VMNotFound                = "VM_NOT_FOUND"
+	VMGPUInfoNotFound         = "VM_GPU_INFO_NOT_FOUND"
 	VMDuplicate               = "VM_DUPLICATE"
 	TaskNotFound              = "TASK_NOT_FOUND"
 	VlanNotFound              = "VLAN_NOT_FOUND"
@@ -41,6 +42,7 @@ const (
 	PlacementGroupPriorError  = "PlacementGroupPriorFilter"
 	VMDuplicateError          = "VM_DUPLICATED_NAME"
 	GPUAssignFailed           = "GPU_ASSIGN_FAILED"
+	VGPUInsufficientError     = "PRECHECK_REQUEST_VGPU_COUNT_MORE_THAN_AVAILABLE"
 )
 
 func IsVMNotFound(err error) bool {
@@ -61,6 +63,10 @@ func IsShutDownTimeout(message string) bool {
 
 func IsGPUAssignFailed(message string) bool {
 	return strings.Contains(message, GPUAssignFailed)
+}
+
+func IsVGPUInsufficientError(message string) bool {
+	return strings.Contains(message, VGPUInsufficientError)
 }
 
 func IsTaskNotFound(err error) bool {

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -338,6 +338,21 @@ func (mr *MockVMServiceMockRecorder) GetTask(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockVMService)(nil).GetTask), id)
 }
 
+// GetVMGPUAllocationInfo mocks base method.
+func (m *MockVMService) GetVMGPUAllocationInfo(id string) (*models.VMGpuInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMGPUAllocationInfo", id)
+	ret0, _ := ret[0].(*models.VMGpuInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMGPUAllocationInfo indicates an expected call of GetVMGPUAllocationInfo.
+func (mr *MockVMServiceMockRecorder) GetVMGPUAllocationInfo(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMGPUAllocationInfo", reflect.TypeOf((*MockVMService)(nil).GetVMGPUAllocationInfo), id)
+}
+
 // GetVMNics mocks base method.
 func (m *MockVMService) GetVMNics(vmID string) ([]*models.VMNic, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -444,18 +444,18 @@ func (mr *MockVMServiceMockRecorder) PowerOff(uuid interface{}) *gomock.Call {
 }
 
 // PowerOn mocks base method.
-func (m *MockVMService) PowerOn(uuid string) (*models.Task, error) {
+func (m *MockVMService) PowerOn(id, hostID string) (*models.Task, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PowerOn", uuid)
+	ret := m.ctrl.Call(m, "PowerOn", id, hostID)
 	ret0, _ := ret[0].(*models.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PowerOn indicates an expected call of PowerOn.
-func (mr *MockVMServiceMockRecorder) PowerOn(uuid interface{}) *gomock.Call {
+func (mr *MockVMServiceMockRecorder) PowerOn(id, hostID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PowerOn", reflect.TypeOf((*MockVMService)(nil).PowerOn), uuid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PowerOn", reflect.TypeOf((*MockVMService)(nil).PowerOn), id, hostID)
 }
 
 // RemoveGPUDevices mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -188,36 +188,6 @@ func (mr *MockVMServiceMockRecorder) FindByIDs(ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDs", reflect.TypeOf((*MockVMService)(nil).FindByIDs), ids)
 }
 
-// FindGPUDevicesByHostIDs mocks base method.
-func (m *MockVMService) FindGPUDevicesByHostIDs(hostIDs []string, gpuDeviceUsage models.GpuDeviceUsage) ([]*models.GpuDevice, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindGPUDevicesByHostIDs", hostIDs, gpuDeviceUsage)
-	ret0, _ := ret[0].([]*models.GpuDevice)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindGPUDevicesByHostIDs indicates an expected call of FindGPUDevicesByHostIDs.
-func (mr *MockVMServiceMockRecorder) FindGPUDevicesByHostIDs(hostIDs, gpuDeviceUsage interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDevicesByHostIDs", reflect.TypeOf((*MockVMService)(nil).FindGPUDevicesByHostIDs), hostIDs, gpuDeviceUsage)
-}
-
-// FindGPUDevicesByIDs mocks base method.
-func (m *MockVMService) FindGPUDevicesByIDs(gpuIDs []string) ([]*models.GpuDevice, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindGPUDevicesByIDs", gpuIDs)
-	ret0, _ := ret[0].([]*models.GpuDevice)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindGPUDevicesByIDs indicates an expected call of FindGPUDevicesByIDs.
-func (mr *MockVMServiceMockRecorder) FindGPUDevicesByIDs(gpuIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDevicesByIDs", reflect.TypeOf((*MockVMService)(nil).FindGPUDevicesByIDs), gpuIDs)
-}
-
 // FindVMsByName mocks base method.
 func (m *MockVMService) FindVMsByName(name string) ([]*models.VM, error) {
 	m.ctrl.T.Helper()
@@ -278,19 +248,34 @@ func (mr *MockVMServiceMockRecorder) GetCluster(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockVMService)(nil).GetCluster), id)
 }
 
-// GetGPUDevicesAllocationInfo mocks base method.
-func (m *MockVMService) GetGPUDevicesAllocationInfo(gpuIDs []string) (service.GPUDeviceInfos, error) {
+// GetGPUDevicesAllocationInfoByHostIDs mocks base method.
+func (m *MockVMService) GetGPUDevicesAllocationInfoByHostIDs(hostIDs []string, gpuDeviceUsage models.GpuDeviceUsage) (service.GPUVMInfos, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGPUDevicesAllocationInfo", gpuIDs)
-	ret0, _ := ret[0].(service.GPUDeviceInfos)
+	ret := m.ctrl.Call(m, "GetGPUDevicesAllocationInfoByHostIDs", hostIDs, gpuDeviceUsage)
+	ret0, _ := ret[0].(service.GPUVMInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetGPUDevicesAllocationInfo indicates an expected call of GetGPUDevicesAllocationInfo.
-func (mr *MockVMServiceMockRecorder) GetGPUDevicesAllocationInfo(gpuIDs interface{}) *gomock.Call {
+// GetGPUDevicesAllocationInfoByHostIDs indicates an expected call of GetGPUDevicesAllocationInfoByHostIDs.
+func (mr *MockVMServiceMockRecorder) GetGPUDevicesAllocationInfoByHostIDs(hostIDs, gpuDeviceUsage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDevicesAllocationInfo", reflect.TypeOf((*MockVMService)(nil).GetGPUDevicesAllocationInfo), gpuIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDevicesAllocationInfoByHostIDs", reflect.TypeOf((*MockVMService)(nil).GetGPUDevicesAllocationInfoByHostIDs), hostIDs, gpuDeviceUsage)
+}
+
+// GetGPUDevicesAllocationInfoByIDs mocks base method.
+func (m *MockVMService) GetGPUDevicesAllocationInfoByIDs(gpuIDs []string) (service.GPUVMInfos, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGPUDevicesAllocationInfoByIDs", gpuIDs)
+	ret0, _ := ret[0].(service.GPUVMInfos)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGPUDevicesAllocationInfoByIDs indicates an expected call of GetGPUDevicesAllocationInfoByIDs.
+func (mr *MockVMServiceMockRecorder) GetGPUDevicesAllocationInfoByIDs(gpuIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDevicesAllocationInfoByIDs", reflect.TypeOf((*MockVMService)(nil).GetGPUDevicesAllocationInfoByIDs), gpuIDs)
 }
 
 // GetHost mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -39,18 +39,18 @@ func (m *MockVMService) EXPECT() *MockVMServiceMockRecorder {
 }
 
 // AddGPUDevices mocks base method.
-func (m *MockVMService) AddGPUDevices(id string, gpus []*models.VMGpuOperationParams) (*models.Task, error) {
+func (m *MockVMService) AddGPUDevices(id string, gpuDeviceInfo []*service.GPUDeviceInfo) (*models.Task, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddGPUDevices", id, gpus)
+	ret := m.ctrl.Call(m, "AddGPUDevices", id, gpuDeviceInfo)
 	ret0, _ := ret[0].(*models.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddGPUDevices indicates an expected call of AddGPUDevices.
-func (mr *MockVMServiceMockRecorder) AddGPUDevices(id, gpus interface{}) *gomock.Call {
+func (mr *MockVMServiceMockRecorder) AddGPUDevices(id, gpuDeviceInfo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGPUDevices", reflect.TypeOf((*MockVMService)(nil).AddGPUDevices), id, gpus)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGPUDevices", reflect.TypeOf((*MockVMService)(nil).AddGPUDevices), id, gpuDeviceInfo)
 }
 
 // AddLabelsToVM mocks base method.
@@ -84,7 +84,7 @@ func (mr *MockVMServiceMockRecorder) AddVMsToPlacementGroup(placementGroup, vmID
 }
 
 // Clone mocks base method.
-func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, elfMachine *v1beta1.ElfMachine, bootstrapData, host string, machineGPUDevices []*models.GpuDevice) (*models.WithTaskVM, error) {
+func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, elfMachine *v1beta1.ElfMachine, bootstrapData, host string, machineGPUDevices []*service.GPUDeviceInfo) (*models.WithTaskVM, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone", elfCluster, elfMachine, bootstrapData, host, machineGPUDevices)
 	ret0, _ := ret[0].(*models.WithTaskVM)
@@ -188,19 +188,34 @@ func (mr *MockVMServiceMockRecorder) FindByIDs(ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDs", reflect.TypeOf((*MockVMService)(nil).FindByIDs), ids)
 }
 
-// FindGPUDevicesByHostIDs mocks base method.
-func (m *MockVMService) FindGPUDevicesByHostIDs(hostIDs []string) ([]*models.GpuDevice, error) {
+// FindGPUDeviceInfos mocks base method.
+func (m *MockVMService) FindGPUDeviceInfos(gpuIDs []string) (service.GPUDeviceInfos, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindGPUDevicesByHostIDs", hostIDs)
+	ret := m.ctrl.Call(m, "FindGPUDeviceInfos", gpuIDs)
+	ret0, _ := ret[0].(service.GPUDeviceInfos)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindGPUDeviceInfos indicates an expected call of FindGPUDeviceInfos.
+func (mr *MockVMServiceMockRecorder) FindGPUDeviceInfos(gpuIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDeviceInfos", reflect.TypeOf((*MockVMService)(nil).FindGPUDeviceInfos), gpuIDs)
+}
+
+// FindGPUDevicesByHostIDs mocks base method.
+func (m *MockVMService) FindGPUDevicesByHostIDs(hostIDs []string, gpuDeviceUsage models.GpuDeviceUsage) ([]*models.GpuDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindGPUDevicesByHostIDs", hostIDs, gpuDeviceUsage)
 	ret0, _ := ret[0].([]*models.GpuDevice)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindGPUDevicesByHostIDs indicates an expected call of FindGPUDevicesByHostIDs.
-func (mr *MockVMServiceMockRecorder) FindGPUDevicesByHostIDs(hostIDs interface{}) *gomock.Call {
+func (mr *MockVMServiceMockRecorder) FindGPUDevicesByHostIDs(hostIDs, gpuDeviceUsage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDevicesByHostIDs", reflect.TypeOf((*MockVMService)(nil).FindGPUDevicesByHostIDs), hostIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDevicesByHostIDs", reflect.TypeOf((*MockVMService)(nil).FindGPUDevicesByHostIDs), hostIDs, gpuDeviceUsage)
 }
 
 // FindGPUDevicesByIDs mocks base method.

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -188,21 +188,6 @@ func (mr *MockVMServiceMockRecorder) FindByIDs(ids interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIDs", reflect.TypeOf((*MockVMService)(nil).FindByIDs), ids)
 }
 
-// FindGPUDeviceInfos mocks base method.
-func (m *MockVMService) FindGPUDeviceInfos(gpuIDs []string) (service.GPUDeviceInfos, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindGPUDeviceInfos", gpuIDs)
-	ret0, _ := ret[0].(service.GPUDeviceInfos)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindGPUDeviceInfos indicates an expected call of FindGPUDeviceInfos.
-func (mr *MockVMServiceMockRecorder) FindGPUDeviceInfos(gpuIDs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindGPUDeviceInfos", reflect.TypeOf((*MockVMService)(nil).FindGPUDeviceInfos), gpuIDs)
-}
-
 // FindGPUDevicesByHostIDs mocks base method.
 func (m *MockVMService) FindGPUDevicesByHostIDs(hostIDs []string, gpuDeviceUsage models.GpuDeviceUsage) ([]*models.GpuDevice, error) {
 	m.ctrl.T.Helper()
@@ -291,6 +276,21 @@ func (m *MockVMService) GetCluster(id string) (*models.Cluster, error) {
 func (mr *MockVMServiceMockRecorder) GetCluster(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockVMService)(nil).GetCluster), id)
+}
+
+// GetGPUDevicesAllocationInfo mocks base method.
+func (m *MockVMService) GetGPUDevicesAllocationInfo(gpuIDs []string) (service.GPUDeviceInfos, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGPUDevicesAllocationInfo", gpuIDs)
+	ret0, _ := ret[0].(service.GPUDeviceInfos)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGPUDevicesAllocationInfo indicates an expected call of GetGPUDevicesAllocationInfo.
+func (mr *MockVMServiceMockRecorder) GetGPUDevicesAllocationInfo(gpuIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDevicesAllocationInfo", reflect.TypeOf((*MockVMService)(nil).GetGPUDevicesAllocationInfo), gpuIDs)
 }
 
 // GetHost mocks base method.

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -18,50 +18,15 @@ package service
 
 import "fmt"
 
-type GPUDeviceVM struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	AllocatedCount int32  `json:"allocatedCount"`
-}
-
 type GPUDeviceInfo struct {
-	ID       string `json:"id"`
-	HostID   string `json:"hostId"`
-	Model    string `json:"model"`
-	VGPUType string `json:"vGpuType"`
+	ID     string `json:"id"`
+	HostID string `json:"hostId"`
 	// AllocatedCount  the number that has been allocated.
-	// For GPU devices, can be 0 or larger than 0.
-	// For vGPU devices, can larger than vgpuInstanceNum.
 	AllocatedCount int32 `json:"allocatedCount"`
 	// AvailableCount is the number of GPU that can be allocated.
-	// For GPU devices, can be 0 or 1.
-	// For vGPU devices, can be 0 - vgpuInstanceNum.
 	AvailableCount int32 `json:"availableCount"`
-	// VMs(including STOPPED) allocated to the current GPU.
-	VMs []GPUDeviceVM `json:"vms"`
-}
-
-func (g *GPUDeviceInfo) GetVMCount() int {
-	return len(g.VMs)
-}
-
-func (g *GPUDeviceInfo) FirstVMIs(vm string) bool {
-	if len(g.VMs) == 0 {
-		return false
-	}
-	return g.VMs[0].ID == vm || g.VMs[0].Name == vm
-}
-
-func (g *GPUDeviceInfo) ContainsVM(vm string) bool {
-	for i := 0; i < len(g.VMs); i++ {
-		if g.VMs[i].ID == vm || g.VMs[i].Name == vm {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (g *GPUDeviceInfo) String() string {
-	return fmt.Sprintf("{id:%s, hostId:%s, model:%s, vGPUType:%s, allocatedCount:%d, availableCount:%d}", g.ID, g.HostID, g.Model, g.VGPUType, g.AllocatedCount, g.AvailableCount)
+	return fmt.Sprintf("{id:%s, hostId:%s, allocatedCount:%d, availableCount:%d}", g.ID, g.HostID, g.AllocatedCount, g.AvailableCount)
 }

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import "fmt"
+
+type GPUDeviceVM struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	AllocatedCount int32  `json:"allocatedCount"`
+}
+
+type GPUDeviceInfo struct {
+	ID       string `json:"id"`
+	HostID   string `json:"hostId"`
+	Model    string `json:"model"`
+	VGPUType string `json:"vGpuType"`
+	// AllocatedCount  the number that has been allocated.
+	// For GPU devices, can be 0 or larger than 0.
+	// For vGPU devices, can larger than vgpuInstanceNum.
+	AllocatedCount int32 `json:"allocatedCount"`
+	// AvailableCount is the number of GPU that can be allocated.
+	// For GPU devices, can be 0 or 1.
+	// For vGPU devices, can be 0 - vgpuInstanceNum.
+	AvailableCount int32 `json:"availableCount"`
+	// VMs(including STOPPED) allocated to the current GPU.
+	VMs []GPUDeviceVM `json:"vms"`
+}
+
+func (g *GPUDeviceInfo) GetVMCount() int {
+	return len(g.VMs)
+}
+
+func (g *GPUDeviceInfo) ContainsVM(vm string) bool {
+	for i := 0; i < len(g.VMs); i++ {
+		if g.VMs[i].ID == vm || g.VMs[i].Name == vm {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (g *GPUDeviceInfo) String() string {
+	return fmt.Sprintf("{id:%s, hostId:%s, model:%s, vGPUType:%s, allocatedCount:%d, availableCount:%d}", g.ID, g.HostID, g.Model, g.VGPUType, g.AllocatedCount, g.AvailableCount)
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -45,6 +45,13 @@ func (g *GPUDeviceInfo) GetVMCount() int {
 	return len(g.VMs)
 }
 
+func (g *GPUDeviceInfo) FirstVMIs(vm string) bool {
+	if len(g.VMs) == 0 {
+		return false
+	}
+	return g.VMs[0].ID == vm || g.VMs[0].Name == vm
+}
+
 func (g *GPUDeviceInfo) ContainsVM(vm string) bool {
 	for i := 0; i < len(g.VMs); i++ {
 		if g.VMs[i].ID == vm || g.VMs[i].Name == vm {

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -74,7 +74,7 @@ type VMService interface {
 	DeleteVMPlacementGroupsByNamePrefix(ctx goctx.Context, placementGroupName string) (int, error)
 	FindGPUDevicesByHostIDs(hostIDs []string, gpuDeviceUsage models.GpuDeviceUsage) ([]*models.GpuDevice, error)
 	FindGPUDevicesByIDs(gpuIDs []string) ([]*models.GpuDevice, error)
-	FindGPUDeviceInfos(gpuIDs []string) (GPUDeviceInfos, error)
+	GetGPUDevicesAllocationInfo(gpuIDs []string) (GPUDeviceInfos, error)
 }
 
 type NewVMServiceFunc func(ctx goctx.Context, auth infrav1.Tower, logger logr.Logger) (VMService, error)
@@ -984,7 +984,8 @@ func (svr *TowerVMService) FindGPUDevicesByIDs(gpuIDs []string) ([]*models.GpuDe
 	return getGpuDevicesResp.Payload, nil
 }
 
-func (svr *TowerVMService) FindGPUDeviceInfos(gpuIDs []string) (GPUDeviceInfos, error) {
+// GetGPUDevicesAllocationInfo returns the specified GPU devices with VMs and allocation details.
+func (svr *TowerVMService) GetGPUDevicesAllocationInfo(gpuIDs []string) (GPUDeviceInfos, error) {
 	getVMGpuDeviceInfoParams := clientvm.NewGetVMGpuDeviceInfoParams()
 	getVMGpuDeviceInfoParams.RequestBody = &models.GetVmsRequestBody{
 		Where: &models.VMWhereInput{

--- a/test/e2e/vm_helpers.go
+++ b/test/e2e/vm_helpers.go
@@ -64,7 +64,7 @@ type PowerOnVMInput struct {
 
 // PowerOnVM power on a VM.
 func PowerOnVM(ctx context.Context, input PowerOnVMInput, intervals ...interface{}) {
-	task, err := input.VMService.PowerOn(input.UUID)
+	task, err := input.VMService.PowerOn(input.UUID, "")
 	Expect(err).ShouldNot(HaveOccurred())
 
 	Eventually(func() (bool, error) {
@@ -76,7 +76,7 @@ func PowerOnVM(ctx context.Context, input PowerOnVMInput, intervals ...interface
 		if *task.Status == models.TaskStatusSUCCESSED {
 			return true, nil
 		} else if *task.Status == models.TaskStatusFAILED {
-			task, err = input.VMService.PowerOn(input.UUID)
+			task, err = input.VMService.PowerOn(input.UUID, "")
 
 			return false, err
 		}

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -151,8 +151,8 @@ func NewWithTaskVMPlacementGroup(placementGroup *models.VMPlacementGroup, task *
 	}
 }
 
-func NewTowerGPU() *models.GpuDevice {
-	return &models.GpuDevice{
+func NewTowerGPUVMInfo() *models.GpuVMInfo {
+	return &models.GpuVMInfo{
 		ID:               pointer.String(ID()),
 		LocalID:          pointer.String(UUID()),
 		Name:             pointer.String(ID()),
@@ -162,13 +162,14 @@ func NewTowerGPU() *models.GpuDevice {
 	}
 }
 
-func NewTowerVGPU(vGPUCount int32) *models.GpuDevice {
-	return &models.GpuDevice{
+func NewTowerVGPUVMInfo(vGPUCount int32) *models.GpuVMInfo {
+	return &models.GpuVMInfo{
 		ID:                pointer.String(ID()),
 		LocalID:           pointer.String(UUID()),
 		Name:              pointer.String(ID()),
 		UserVgpuTypeName:  pointer.String("V100"),
 		UserUsage:         models.NewGpuDeviceUsage(models.GpuDeviceUsageVGPU),
+		VgpuInstanceNum:   pointer.Int32(vGPUCount),
 		AvailableVgpusNum: pointer.Int32(vGPUCount),
 		AssignedVgpusNum:  pointer.Int32(0),
 		Model:             pointer.String(""),

--- a/test/fake/tower.go
+++ b/test/fake/tower.go
@@ -153,9 +153,24 @@ func NewWithTaskVMPlacementGroup(placementGroup *models.VMPlacementGroup, task *
 
 func NewTowerGPU() *models.GpuDevice {
 	return &models.GpuDevice{
-		ID:      pointer.String(ID()),
-		LocalID: pointer.String(UUID()),
-		Name:    pointer.String(ID()),
-		Model:   pointer.String("A16"),
+		ID:               pointer.String(ID()),
+		LocalID:          pointer.String(UUID()),
+		Name:             pointer.String(ID()),
+		Model:            pointer.String("A16"),
+		UserUsage:        models.NewGpuDeviceUsage(models.GpuDeviceUsagePASSTHROUGH),
+		UserVgpuTypeName: pointer.String(""),
+	}
+}
+
+func NewTowerVGPU(vGPUCount int32) *models.GpuDevice {
+	return &models.GpuDevice{
+		ID:                pointer.String(ID()),
+		LocalID:           pointer.String(UUID()),
+		Name:              pointer.String(ID()),
+		UserVgpuTypeName:  pointer.String("V100"),
+		UserUsage:         models.NewGpuDeviceUsage(models.GpuDeviceUsageVGPU),
+		AvailableVgpusNum: pointer.Int32(vGPUCount),
+		AssignedVgpusNum:  pointer.Int32(0),
+		Model:             pointer.String(""),
 	}
 }


### PR DESCRIPTION
### 增加 vGPU 支持

相关文档 [CAPE 支持 GPU](https://docs.google.com/document/d/1tAinrp-iE6l2WkmRsKis1SaXdTGqKH15KajZ5qcaNSk/edit#heading=h.jv4qcx1lypv)

### 测试
测试环境
host1: 1 张 Tesla T4，host2：2 张 Tesla T4 + 1 张 Tesla V100，host3：1 张  Tesla T4 + 1 张 V100（4 vGPU）

1. 创 1 V100 的节点组，可以创建出来 4 个 workers，剩余的 2 个 worker 没有足够的 vGPU 没有创建出来，没有出现 GPU 重复挂载和卸载。
```yaml
name: workergroup1
  replicas: 6
  nodeConfig:
  cpuCores: 8
  memoryMB: 12288
  cloneMode: FastClone
  vgpuDevices:
  - type: "GRID V100-4C"
    count: 1
```

2. 创 2 V100 的节点组，可以创建出来 2 个 workers，剩余的 4 个 worker 没有足够的 vGPU 没有创建出来，没有出现 GPU 重复挂载和卸载。
```yaml
name: workergroup1
  replicas: 6
  nodeConfig:
  cpuCores: 8
  memoryMB: 12288
  cloneMode: FastClone
  vgpuDevices:
  - type: "GRID V100-4C"
    count: 2
```

3. 创 3 V100 的节点组，可以创建出来 1 个 workers，剩余的 5 个 worker 没有足够的 vGPU 没有创建出来，没有出现 GPU 重复挂载和卸载。
```yaml
name: workergroup1
  replicas: 6
  nodeConfig:
  cpuCores: 8
  memoryMB: 12288
  cloneMode: FastClone
  vgpuDevices:
  - type: "GRID V100-4C"
    count: 3
```

4. 选择其中一个节点，关机再把  GPU/vGPU 分配到其他的临时虚拟机启动，再启动被移除  GPU/vGPU  的节点，会自动移除对应的  GPU/vGPU，并重新选择新的  GPU/vGPU 。 新的  GPU/vGPU 和节点再不同主机的情况下，发现了虚拟机冷迁移。
