### PR TITLE
SKS-2097: Ensure CAPE Deployment can work when a node in the cluster is disconnected

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,12 +9,24 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    cluster.x-k8s.io/provider: infrastructure-elf
+                    control-plane: controller-manager
+                topologyKey: kubernetes.io/hostname
+                namespaces:
+                  - cape-system
+              weight: 1
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
### Issue
[[SKS-2097] 集群有一个节点失联时应保证已有Deployment能正常工作 - Jira](http://jira.smartx.com/browse/SKS-2097)