### PR TITLE
SKS-2160: Fix 'where' condition when getting GPU device allocation details

### DIFF
--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -970,21 +970,19 @@ func (svr *TowerVMService) GetGPUDevicesAllocationInfoByHostIDs(hostIDs []string
 		return NewGPUVMInfos(), nil
 	}
 
-	where := &models.GpuDeviceWhereInput{
-		UserUsage: models.NewGpuDeviceUsage(gpuDeviceUsage),
-		Host: &models.HostWhereInput{
-			IDIn: hostIDs,
+	getDetailVMInfoByGpuDevicesParams := clientgpu.NewGetDetailVMInfoByGpuDevicesParams()
+	getDetailVMInfoByGpuDevicesParams.RequestBody = &models.GetGpuDevicesRequestBody{
+		Where: &models.GpuDeviceWhereInput{
+			UserUsage: models.NewGpuDeviceUsage(gpuDeviceUsage),
+			Host: &models.HostWhereInput{
+				IDIn: hostIDs,
+			},
 		},
 	}
 
 	// Filter GPU devices whose vGPU has been fully used
 	if gpuDeviceUsage == models.GpuDeviceUsageVGPU {
-		where.AvailableVgpusNumGt = TowerInt32(0)
-	}
-
-	getDetailVMInfoByGpuDevicesParams := clientgpu.NewGetDetailVMInfoByGpuDevicesParams()
-	getDetailVMInfoByGpuDevicesParams.RequestBody = &models.GetGpuDevicesRequestBody{
-		Where: &models.GpuDeviceWhereInput{},
+		getDetailVMInfoByGpuDevicesParams.RequestBody.Where.AvailableVgpusNumGt = TowerInt32(0)
 	}
 
 	getDetailVMInfoByGpuDevicesResp, err := svr.Session.GpuDevice.GetDetailVMInfoByGpuDevices(getDetailVMInfoByGpuDevicesParams)


### PR DESCRIPTION
### Issue
SKS 创建 GPU 直通集群时，虚拟机配置了 GPU，但是实际挂载的是 vGPU。

<img width="744" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/c17e5d0d-5f08-449e-9d32-051cc4ddfdd6">

如图所示，where 实际没有设置值，所以没有生效，导致返回了 GPU + vGPU 设备。gpuDeviceUsage 没有指定，而 GPU 和 vGPU 的 model（Tesla T4） 是一样的，导致 vGPU 设备被判断成 GPU。

#### 复现步骤
1. 集群有三张 Tesla T4 卡，把其中一张卡切成 vGPU。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/b6686a94-24b8-4b71-bcfb-5d19b67dc13b)

2. 创建 1CP + 3Worker 集群，每个 Worker 配置一张 Tesla T4 直通。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/34c7f796-5df8-45dd-84e5-b7bf288a07ee)


3. 集群创建完成，观察到其中一个 Worker 挂载了 vGPU

![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/27fed81f-3462-42a0-adf7-af5be738b21c)



### Change
查询 GPU 信息的时候指定正确的 where （gpuDeviceUsage 和主机 ID）查询条件。


### Test
1. 集群有三张 Tesla T4 卡，把其中一张卡切成 vGPU。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/b6686a94-24b8-4b71-bcfb-5d19b67dc13b)

2. 创建 1CP + 3Worker 集群，每个 Worker 配置一张 Tesla T4 直通。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/34c7f796-5df8-45dd-84e5-b7bf288a07ee)


3. 集群创建有两个 Worker 挂载了 Tesla T4，剩下的一个 Worker haijian-gpu-workergroup1-ltp5m 没有挂载 vGPU，在等待足够可用的 GPU 直通设备。
```bash
No host with the required GPU devices for the virtual machine, so wait for enough available hosts" namespace="default" elfCluster="haijian-gpu" elfMachine="haijian-gpu-workergroup1-ltp5m" machine="haijian-gpu-workergroup1-nwfxx-nd6q5"
```

被切成 vGPU 的 Tesla T4 没有被使用。
<img width="1267" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/61211066-ace4-44b7-a482-5f5076a2483f">

4. 把 vGPU 改成直通，上述的 Worker haijian-gpu-workergroup1-ltp5m 挂载了 Tesla T4。
<img width="611" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/9ef7cb8e-0736-4917-8a9a-ecfc4b09a645">

