### PR TITLE
SKS-2157: Cache placement group to reduce Tower API requests

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -231,10 +231,13 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (rec
 
 func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx *context.ClusterContext) (bool, error) {
 	placementGroupPrefix := towerresources.GetVMPlacementGroupNamePrefix(ctx.Cluster)
-	if pgCount, err := ctx.VMService.DeleteVMPlacementGroupsByNamePrefix(ctx, placementGroupPrefix); err != nil {
+	if pgNames, err := ctx.VMService.DeleteVMPlacementGroupsByNamePrefix(ctx, placementGroupPrefix); err != nil {
 		return false, err
-	} else if pgCount > 0 {
-		ctx.Logger.Info(fmt.Sprintf("Waiting for the placement groups with name prefix %s to be deleted", placementGroupPrefix), "count", pgCount)
+	} else if len(pgNames) > 0 {
+		ctx.Logger.Info(fmt.Sprintf("Waiting for the placement groups with name prefix %s to be deleted", placementGroupPrefix), "count", len(pgNames))
+
+		// Delete placement group caches.
+		delPGCaches(pgNames)
 
 		return false, nil
 	} else {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -259,7 +259,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should create a new VM if none exists", func() {
-			resetVMTaskErrorCache()
+			resetMemoryCache()
 			vm := fake.NewTowerVM()
 			vm.Name = &elfMachine.Name
 			elfCluster.Spec.Cluster = clusterKey
@@ -297,7 +297,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			Expect(elfMachine.Status.VMRef).To(Equal(*vm.ID))
 			Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
-			resetVMTaskErrorCache()
+			resetMemoryCache()
 		})
 
 		It("should recover from lost task", func() {
@@ -822,7 +822,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		Context("powerOnVM", func() {
 			It("should", func() {
-				resetVMTaskErrorCache()
+				resetMemoryCache()
 				vm := fake.NewTowerVM()
 				vm.Host = &models.NestedHost{ID: service.TowerString(fake.ID())}
 				elfMachine.Status.VMRef = *vm.LocalID
@@ -844,7 +844,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(logBuffer.String()).To(ContainSubstring("and the retry silence period passes, will try to power on the VM again"))
 				expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.PoweringOnReason}})
-				resetVMTaskErrorCache()
+				resetMemoryCache()
 
 				// GPU
 				unexpectedError := errors.New("unexpected error")
@@ -2956,7 +2956,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
-			resetVMTaskErrorCache()
+			resetMemoryCache()
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
@@ -2970,7 +2970,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			logBuffer = new(bytes.Buffer)
 			klog.SetOutput(logBuffer)
-			resetVMTaskErrorCache()
+			resetMemoryCache()
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(nil, errors.New(service.VMPlacementGroupNotFound))
 			mockVMService.EXPECT().GetCluster(elfCluster.Spec.Cluster).Return(towerCluster, nil)
 			mockVMService.EXPECT().CreateVMPlacementGroup(gomock.Any(), *towerCluster.ID, towerresources.GetVMPlacementGroupPolicy(machine)).Return(withTaskVMPlacementGroup, nil)
@@ -3152,7 +3152,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should handle failed/succeeded task", func() {
 			elfMachine.Spec.GPUDevices = []infrav1.GPUPassthroughDeviceSpec{{Model: "A16", Count: 1}}
 
-			resetVMTaskErrorCache()
+			resetMemoryCache()
 			task := fake.NewTowerTask()
 			task.Status = models.NewTaskStatus(models.TaskStatusFAILED)
 			elfMachine.Status.TaskRef = *task.ID

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -79,9 +79,9 @@ func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, er
 func recordElfClusterMemoryInsufficient(ctx *context.MachineContext, isInsufficient bool) {
 	key := getKeyForInsufficientMemoryError(ctx.ElfCluster.Spec.Cluster)
 	if isInsufficient {
-		vmTaskErrorCache.Set(key, newClusterResource(), resourceDuration)
+		memoryCache.Set(key, newClusterResource(), resourceDuration)
 	} else {
-		vmTaskErrorCache.Delete(key)
+		memoryCache.Delete(key)
 	}
 }
 
@@ -94,9 +94,9 @@ func recordPlacementGroupPolicyNotSatisfied(ctx *context.MachineContext, isPGPol
 
 	key := getKeyForDuplicatePlacementGroupError(placementGroupName)
 	if isPGPolicyNotSatisfied {
-		vmTaskErrorCache.Set(key, newClusterResource(), resourceDuration)
+		memoryCache.Set(key, newClusterResource(), resourceDuration)
 	} else {
-		vmTaskErrorCache.Delete(key)
+		memoryCache.Delete(key)
 	}
 
 	return nil
@@ -146,13 +146,13 @@ func canRetry(key string) bool {
 }
 
 func getClusterResource(key string) *clusterResource {
-	if val, found := vmTaskErrorCache.Get(key); found {
+	if val, found := memoryCache.Get(key); found {
 		if resource, ok := val.(*clusterResource); ok {
 			return resource
 		}
 
 		// Delete unexpected data.
-		vmTaskErrorCache.Delete(key)
+		memoryCache.Delete(key)
 	}
 
 	return nil
@@ -167,7 +167,7 @@ func getKeyForDuplicatePlacementGroupError(placementGroup string) string {
 }
 
 // pgCacheDuration is the lifespan of placement group cache.
-const pgCacheDuration = 10 * time.Second
+const pgCacheDuration = 20 * time.Second
 
 func getKeyForPGCache(pgName string) string {
 	return fmt.Sprintf("pg:%s:cache", pgName)
@@ -176,25 +176,25 @@ func getKeyForPGCache(pgName string) string {
 // setPGCache saves the specified placement group to the memory,
 // which can reduce access to the Tower service.
 func setPGCache(pg *models.VMPlacementGroup) {
-	vmTaskErrorCache.Set(getKeyForPGCache(*pg.Name), *pg, gpuCacheDuration)
+	memoryCache.Set(getKeyForPGCache(*pg.Name), *pg, gpuCacheDuration)
 }
 
 // delPGCaches deletes the specified placement group caches.
 func delPGCaches(pgNames []string) {
 	for i := 0; i < len(pgNames); i++ {
-		vmTaskErrorCache.Delete(getKeyForPGCache(pgNames[i]))
+		memoryCache.Delete(getKeyForPGCache(pgNames[i]))
 	}
 }
 
 // getPGFromCache gets the specified placement group from the memory.
 func getPGFromCache(pgName string) *models.VMPlacementGroup {
 	key := getKeyForPGCache(pgName)
-	if val, found := vmTaskErrorCache.Get(key); found {
+	if val, found := memoryCache.Get(key); found {
 		if pg, ok := val.(models.VMPlacementGroup); ok {
 			return &pg
 		}
 		// Delete unexpected data.
-		vmTaskErrorCache.Delete(key)
+		memoryCache.Delete(key)
 	}
 
 	return nil
@@ -213,7 +213,7 @@ func getKeyForGPUVMInfo(gpuID string) string {
 // which can reduce access to the Tower service.
 func setGPUVMInfosCache(gpuVMInfos service.GPUVMInfos) {
 	gpuVMInfos.Iterate(func(g *models.GpuVMInfo) {
-		vmTaskErrorCache.Set(getKeyForGPUVMInfo(*g.ID), *g, gpuCacheDuration)
+		memoryCache.Set(getKeyForGPUVMInfo(*g.ID), *g, gpuCacheDuration)
 	})
 }
 
@@ -222,12 +222,12 @@ func getGPUVMInfosFromCache(gpuIDs []string) service.GPUVMInfos {
 	gpuVMInfos := service.NewGPUVMInfos()
 	for i := 0; i < len(gpuIDs); i++ {
 		key := getKeyForGPUVMInfo(gpuIDs[i])
-		if val, found := vmTaskErrorCache.Get(key); found {
+		if val, found := memoryCache.Get(key); found {
 			if gpuVMInfo, ok := val.(models.GpuVMInfo); ok {
 				gpuVMInfos.Insert(&gpuVMInfo)
 			}
 			// Delete unexpected data.
-			vmTaskErrorCache.Delete(key)
+			memoryCache.Delete(key)
 		}
 	}
 

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -56,11 +56,11 @@ var _ = Describe("TowerCache", func() {
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, nil)
 			key := getKey(machineContext, name)
 
-			_, found := memoryCache.Get(key)
+			_, found := inMemoryCache.Get(key)
 			Expect(found).To(BeFalse())
 
 			recordIsUnmet(machineContext, name, true)
-			_, found = memoryCache.Get(key)
+			_, found = inMemoryCache.Get(key)
 			Expect(found).To(BeTrue())
 			resource := getClusterResource(key)
 			Expect(resource.LastDetected).To(Equal(resource.LastRetried))
@@ -76,12 +76,12 @@ var _ = Describe("TowerCache", func() {
 			Expect(resource).To(BeNil())
 
 			resetMemoryCache()
-			_, found = memoryCache.Get(key)
+			_, found = inMemoryCache.Get(key)
 			Expect(found).To(BeFalse())
 
 			recordIsUnmet(machineContext, name, false)
 			resource = getClusterResource(key)
-			_, found = memoryCache.Get(key)
+			_, found = inMemoryCache.Get(key)
 			Expect(found).To(BeFalse())
 			Expect(resource).To(BeNil())
 
@@ -90,7 +90,7 @@ var _ = Describe("TowerCache", func() {
 			Expect(resource).To(BeNil())
 
 			recordIsUnmet(machineContext, name, true)
-			_, found = memoryCache.Get(key)
+			_, found = inMemoryCache.Get(key)
 			Expect(found).To(BeTrue())
 			resource = getClusterResource(key)
 			Expect(resource.LastDetected).To(Equal(resource.LastRetried))
@@ -110,7 +110,7 @@ var _ = Describe("TowerCache", func() {
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, nil)
 			key := getKey(machineContext, name)
 
-			_, found := memoryCache.Get(key)
+			_, found := inMemoryCache.Get(key)
 			Expect(found).To(BeFalse())
 			ok, err := canRetryVMOperation(machineContext)
 			Expect(ok).To(BeFalse())
@@ -201,7 +201,7 @@ var _ = Describe("TowerCache", func() {
 
 func removeGPUVMInfosCache(gpuIDs []string) {
 	for i := 0; i < len(gpuIDs); i++ {
-		memoryCache.Delete(getKeyForGPUVMInfo(gpuIDs[i]))
+		inMemoryCache.Delete(getKeyForGPUVMInfo(gpuIDs[i]))
 	}
 }
 
@@ -230,5 +230,5 @@ func expireELFScheduleVMError(ctx *context.MachineContext, name string) {
 	resource := getClusterResource(key)
 	resource.LastDetected = resource.LastDetected.Add(-resourceSilenceTime)
 	resource.LastRetried = resource.LastRetried.Add(-resourceSilenceTime)
-	memoryCache.Set(key, resource, resourceDuration)
+	inMemoryCache.Set(key, resource, resourceDuration)
 }

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -170,6 +170,22 @@ var _ = Describe("TowerCache", func() {
 		expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForPlacementGroupPolicySatisfiedReason}})
 	})
 
+	It("PG Cache", func() {
+		pgName := "pg"
+		pg := fake.NewVMPlacementGroup(nil)
+		pg.Name = &pgName
+		Expect(getPGFromCache(pgName)).To(BeNil())
+
+		setPGCache(pg)
+		Expect(getPGFromCache(pgName)).To(Equal(pg))
+		time.Sleep(pgCacheDuration)
+		Expect(getPGFromCache(pgName)).To(BeNil())
+
+		setPGCache(pg)
+		delPGCaches([]string{pgName})
+		Expect(getPGFromCache(pgName)).To(BeNil())
+	})
+
 	It("GPU Cache", func() {
 		gpuID := "gpu"
 		gpuVMInfo := models.GpuVMInfo{ID: service.TowerString(gpuID)}

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -38,7 +38,7 @@ const (
 	placementGroupSilenceTime = time.Minute * 5
 )
 
-var vmTaskErrorCache = cache.New(5*time.Minute, 10*time.Minute)
+var memoryCache = cache.New(5*time.Minute, 10*time.Minute)
 var vmConcurrentCache = cache.New(5*time.Minute, 6*time.Minute)
 
 var vmOperationLock sync.Mutex
@@ -50,7 +50,7 @@ func acquireTicketForCreateVM(vmName string, isControlPlaneVM bool) (bool, strin
 	vmOperationLock.Lock()
 	defer vmOperationLock.Unlock()
 
-	if _, found := vmTaskErrorCache.Get(getKeyForVMDuplicate(vmName)); found {
+	if _, found := memoryCache.Get(getKeyForVMDuplicate(vmName)); found {
 		return false, "Duplicate virtual machine detected"
 	}
 
@@ -79,18 +79,18 @@ func releaseTicketForCreateVM(vmName string) {
 // Tower API currently does not have a concurrency limit for operations on the same virtual machine,
 // which may cause task to fail.
 func acquireTicketForUpdatingVM(vmName string) bool {
-	if _, found := vmTaskErrorCache.Get(getKeyForVM(vmName)); found {
+	if _, found := memoryCache.Get(getKeyForVM(vmName)); found {
 		return false
 	}
 
-	vmTaskErrorCache.Set(getKeyForVM(vmName), nil, vmOperationRateLimit)
+	memoryCache.Set(getKeyForVM(vmName), nil, vmOperationRateLimit)
 
 	return true
 }
 
 // setVMDuplicate sets whether virtual machine is duplicated.
 func setVMDuplicate(vmName string) {
-	vmTaskErrorCache.Set(getKeyForVMDuplicate(vmName), nil, vmSilenceTime)
+	memoryCache.Set(getKeyForVMDuplicate(vmName), nil, vmSilenceTime)
 }
 
 // acquireTicketForPlacementGroupOperation returns whether placement group operation
@@ -99,28 +99,28 @@ func acquireTicketForPlacementGroupOperation(groupName string) bool {
 	placementGroupOperationLock.Lock()
 	defer placementGroupOperationLock.Unlock()
 
-	if _, found := vmTaskErrorCache.Get(getKeyForPlacementGroup(groupName)); found {
+	if _, found := memoryCache.Get(getKeyForPlacementGroup(groupName)); found {
 		return false
 	}
 
-	vmTaskErrorCache.Set(getKeyForPlacementGroup(groupName), nil, cache.NoExpiration)
+	memoryCache.Set(getKeyForPlacementGroup(groupName), nil, cache.NoExpiration)
 
 	return true
 }
 
 // releaseTicketForPlacementGroupOperation releases the placement group being operated.
 func releaseTicketForPlacementGroupOperation(groupName string) {
-	vmTaskErrorCache.Delete(getKeyForPlacementGroup(groupName))
+	memoryCache.Delete(getKeyForPlacementGroup(groupName))
 }
 
 // setPlacementGroupDuplicate sets whether placement group is duplicated.
 func setPlacementGroupDuplicate(groupName string) {
-	vmTaskErrorCache.Set(getKeyForPlacementGroupDuplicate(groupName), nil, placementGroupSilenceTime)
+	memoryCache.Set(getKeyForPlacementGroupDuplicate(groupName), nil, placementGroupSilenceTime)
 }
 
 // canCreatePlacementGroup returns whether placement group creation can be performed.
 func canCreatePlacementGroup(groupName string) bool {
-	_, found := vmTaskErrorCache.Get(getKeyForPlacementGroupDuplicate(groupName))
+	_, found := memoryCache.Get(getKeyForPlacementGroupDuplicate(groupName))
 
 	return !found
 }

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -41,16 +41,16 @@ var _ = Describe("VMLimiter", func() {
 		ok, msg := acquireTicketForCreateVM(vmName, true)
 		Expect(ok).To(BeTrue())
 		Expect(msg).To(Equal(""))
-		_, found := vmTaskErrorCache.Get(getKeyForVMDuplicate(vmName))
+		_, found := memoryCache.Get(getKeyForVMDuplicate(vmName))
 		Expect(found).To(BeFalse())
 
 		setVMDuplicate(vmName)
-		_, found = vmTaskErrorCache.Get(getKeyForVMDuplicate(vmName))
+		_, found = memoryCache.Get(getKeyForVMDuplicate(vmName))
 		Expect(found).To(BeTrue())
 		ok, msg = acquireTicketForCreateVM(vmName, true)
 		Expect(ok).To(BeFalse())
 		Expect(msg).To(Equal("Duplicate virtual machine detected"))
-		vmTaskErrorCache.Delete(getKeyForVMDuplicate(vmName))
+		memoryCache.Delete(getKeyForVMDuplicate(vmName))
 
 		ok, msg = acquireTicketForCreateVM(vmName, false)
 		Expect(ok).To(BeTrue())
@@ -88,7 +88,7 @@ var _ = Describe("VM Operation Limiter", func() {
 
 	It("acquireTicketForUpdatingVM", func() {
 		Expect(acquireTicketForUpdatingVM(vmName)).To(BeTrue())
-		_, found := vmTaskErrorCache.Get(getKeyForVM(vmName))
+		_, found := memoryCache.Get(getKeyForVM(vmName))
 		Expect(found).To(BeTrue())
 		Expect(acquireTicketForUpdatingVM(vmName)).To(BeFalse())
 	})
@@ -103,26 +103,26 @@ var _ = Describe("Placement Group Operation Limiter", func() {
 
 	It("acquireTicketForPlacementGroupOperation", func() {
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeTrue())
-		_, found := vmTaskErrorCache.Get(getKeyForPlacementGroup(groupName))
+		_, found := memoryCache.Get(getKeyForPlacementGroup(groupName))
 		Expect(found).To(BeTrue())
 
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeFalse())
 		releaseTicketForPlacementGroupOperation(groupName)
 
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeTrue())
-		_, found = vmTaskErrorCache.Get(getKeyForPlacementGroup(groupName))
+		_, found = memoryCache.Get(getKeyForPlacementGroup(groupName))
 		Expect(found).To(BeTrue())
 	})
 
 	It("canCreatePlacementGroup", func() {
 		key := getKeyForPlacementGroupDuplicate(groupName)
 
-		_, found := vmTaskErrorCache.Get(key)
+		_, found := memoryCache.Get(key)
 		Expect(found).To(BeFalse())
 		Expect(canCreatePlacementGroup(groupName)).To(BeTrue())
 
 		setPlacementGroupDuplicate(groupName)
-		_, found = vmTaskErrorCache.Get(key)
+		_, found = memoryCache.Get(key)
 		Expect(found).To(BeTrue())
 		Expect(canCreatePlacementGroup(groupName)).To(BeFalse())
 	})
@@ -196,6 +196,6 @@ func resetVMConcurrentCache() {
 	vmConcurrentCache.Flush()
 }
 
-func resetVMTaskErrorCache() {
-	vmTaskErrorCache.Flush()
+func resetMemoryCache() {
+	memoryCache.Flush()
 }

--- a/controllers/vm_limiter_test.go
+++ b/controllers/vm_limiter_test.go
@@ -41,16 +41,16 @@ var _ = Describe("VMLimiter", func() {
 		ok, msg := acquireTicketForCreateVM(vmName, true)
 		Expect(ok).To(BeTrue())
 		Expect(msg).To(Equal(""))
-		_, found := memoryCache.Get(getKeyForVMDuplicate(vmName))
+		_, found := inMemoryCache.Get(getKeyForVMDuplicate(vmName))
 		Expect(found).To(BeFalse())
 
 		setVMDuplicate(vmName)
-		_, found = memoryCache.Get(getKeyForVMDuplicate(vmName))
+		_, found = inMemoryCache.Get(getKeyForVMDuplicate(vmName))
 		Expect(found).To(BeTrue())
 		ok, msg = acquireTicketForCreateVM(vmName, true)
 		Expect(ok).To(BeFalse())
 		Expect(msg).To(Equal("Duplicate virtual machine detected"))
-		memoryCache.Delete(getKeyForVMDuplicate(vmName))
+		inMemoryCache.Delete(getKeyForVMDuplicate(vmName))
 
 		ok, msg = acquireTicketForCreateVM(vmName, false)
 		Expect(ok).To(BeTrue())
@@ -88,7 +88,7 @@ var _ = Describe("VM Operation Limiter", func() {
 
 	It("acquireTicketForUpdatingVM", func() {
 		Expect(acquireTicketForUpdatingVM(vmName)).To(BeTrue())
-		_, found := memoryCache.Get(getKeyForVM(vmName))
+		_, found := inMemoryCache.Get(getKeyForVM(vmName))
 		Expect(found).To(BeTrue())
 		Expect(acquireTicketForUpdatingVM(vmName)).To(BeFalse())
 	})
@@ -103,26 +103,26 @@ var _ = Describe("Placement Group Operation Limiter", func() {
 
 	It("acquireTicketForPlacementGroupOperation", func() {
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeTrue())
-		_, found := memoryCache.Get(getKeyForPlacementGroup(groupName))
+		_, found := inMemoryCache.Get(getKeyForPlacementGroup(groupName))
 		Expect(found).To(BeTrue())
 
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeFalse())
 		releaseTicketForPlacementGroupOperation(groupName)
 
 		Expect(acquireTicketForPlacementGroupOperation(groupName)).To(BeTrue())
-		_, found = memoryCache.Get(getKeyForPlacementGroup(groupName))
+		_, found = inMemoryCache.Get(getKeyForPlacementGroup(groupName))
 		Expect(found).To(BeTrue())
 	})
 
 	It("canCreatePlacementGroup", func() {
 		key := getKeyForPlacementGroupDuplicate(groupName)
 
-		_, found := memoryCache.Get(key)
+		_, found := inMemoryCache.Get(key)
 		Expect(found).To(BeFalse())
 		Expect(canCreatePlacementGroup(groupName)).To(BeTrue())
 
 		setPlacementGroupDuplicate(groupName)
-		_, found = memoryCache.Get(key)
+		_, found = inMemoryCache.Get(key)
 		Expect(found).To(BeTrue())
 		Expect(canCreatePlacementGroup(groupName)).To(BeFalse())
 	})
@@ -197,5 +197,5 @@ func resetVMConcurrentCache() {
 }
 
 func resetMemoryCache() {
-	memoryCache.Flush()
+	inMemoryCache.Flush()
 }

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -159,10 +159,10 @@ func (mr *MockVMServiceMockRecorder) DeleteVMPlacementGroupByID(ctx, id interfac
 }
 
 // DeleteVMPlacementGroupsByNamePrefix mocks base method.
-func (m *MockVMService) DeleteVMPlacementGroupsByNamePrefix(ctx context.Context, placementGroupName string) (int, error) {
+func (m *MockVMService) DeleteVMPlacementGroupsByNamePrefix(ctx context.Context, placementGroupName string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVMPlacementGroupsByNamePrefix", ctx, placementGroupName)
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
## Issue [SKS-2157](http://jira.smartx.com/browse/SKS-2157)

在一个SKS创建的所有工作负载集群包含一百几十个节点的环境中，获取Tower放置组API的调用量会很大（包含 CAPE 和其他的方式的）。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/87e0a3fe-a04f-4b61-91d5-3f4dd5042f8e)

CAPE 每个节点关联了一个放置组，放置组是节点组之间共享的。

当前每个节点 Reconcile 的时候都会通过 Tower API 获取放置组的信息（两次），一次是确认放置组是否存在，一次是确认节点对应的虚拟机是否还在放置组。

CAPE 默认 10-15m 就 resync，这个时候所有的节点都会 Reconcile 一次，也就意味着需要从 Tower 获取两次放置组信息，这样会重复从 Tower 获取放置组信息。


### Change

多个节点是共享放置组的，所以放置组读多写少，考虑使用缓存，减少对 Tower API 的访问。

如果修改了放置组，需要及时删除放置组缓存。并且在删除放置组的时候也应该马上删除放置组缓存，防止马上创建同名放置组的时候使用到过期的缓存。

### Test

[连续八次通过 E2E](https://jenkins.caas.smtx.io/blue/organizations/jenkins/kubesmart/detail/haijian%2Ftest)

需要进一步观察修改前和修改后减少的接口访问量对比。新版代码从 2023-12-05 16:50 开始运行。[监控](https://grafana.tower.smtx.io/explore?panes=%7B%22p9A%22:%7B%22datasource%22:%22Wa0h_GbVk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcloudtower%3D%5C%2210.255.0.4%5C%22,%20pod%3D%5C%22ingress-nginx-controller-tkvs7%5C%22%7D%20%7C%3D%20%5C%22%2Fv2%2Fapi%2Fget-vm-placement-groups%5C%22%20%7C%3D%20%5C%2210.255.128.43%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22Wa0h_GbVk%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%221701878400000%22,%22to%22:%221701964799000%22%7D%7D%7D&schemaVersion=1&orgId=1) 

优化前：
<img width="679" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/4e199ef7-a2d9-440c-909e-935ed788bf42">

优化后：
<img width="737" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/11e58990-8d5c-422a-82f7-d4844b451811">

出现突然访问暴增的原因是 Tower 服务不可用（例如更新、重启等）。Tower 不可用之后，调用 Tower 接口马上就返回 503 了，所以很快，导致 CAPE 不断的退避重试（此时缓存可能无效）。
<img width="1403" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/67ec939c-3a04-4f0d-ae7e-28d7469aab5b">

相关讨论 [slack](https://smartx1.slack.com/archives/C02J9PCQM1S/p1701861265333269)。访问突然暴增的问题可以不在当前 PR 处理。
