### PR TITLE
SKS-2194: Fix labeling virtual machines

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -448,10 +448,8 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx *context.MachineContext) (rec
 	}
 
 	// Reconcile the ElfMachine's Labels using the cluster info
-	if len(vm.Labels) == 0 {
-		if ok, err := r.reconcileLabels(ctx, vm); !ok {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile labels")
-		}
+	if ok, err := r.reconcileLabels(ctx, vm); !ok {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile labels")
 	}
 
 	// Reconcile the ElfMachine's providerID using the VM's UUID.
@@ -1188,10 +1186,26 @@ func (r *ElfMachineReconciler) getBootstrapData(ctx *context.MachineContext) (st
 }
 
 func (r *ElfMachineReconciler) reconcileLabels(ctx *context.MachineContext, vm *models.VM) (bool, error) {
-	creatorLabel, err := ctx.VMService.UpsertLabel(towerresources.GetVMLabelManaged(), "true")
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to upsert label "+towerresources.GetVMLabelManaged())
+	managedLabelKey := towerresources.GetVMLabelManaged()
+	managedLabel := getLabelFromCache(managedLabelKey)
+	if managedLabel == nil {
+		var err error
+		managedLabel, err = ctx.VMService.UpsertLabel(managedLabelKey, "true")
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to upsert label "+towerresources.GetVMLabelManaged())
+		}
+
+		setLabelCache(managedLabel)
 	}
+
+	// If the virtual machine has been labeled with managed label,
+	// it is considered that all labels have been labeled.
+	for i := 0; i < len(vm.Labels); i++ {
+		if *vm.Labels[i].ID == *managedLabel.ID {
+			return true, nil
+		}
+	}
+
 	namespaceLabel, err := ctx.VMService.UpsertLabel(towerresources.GetVMLabelNamespace(), ctx.ElfMachine.Namespace)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to upsert label "+towerresources.GetVMLabelNamespace())
@@ -1209,7 +1223,7 @@ func (r *ElfMachineReconciler) reconcileLabels(ctx *context.MachineContext, vm *
 		}
 	}
 
-	labelIDs := []string{*namespaceLabel.ID, *clusterNameLabel.ID, *creatorLabel.ID}
+	labelIDs := []string{*namespaceLabel.ID, *clusterNameLabel.ID, *managedLabel.ID}
 	if machineutil.IsControlPlaneMachine(ctx.ElfMachine) {
 		labelIDs = append(labelIDs, *vipLabel.ID)
 	}

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -176,7 +176,7 @@ func getKeyForPGCache(pgName string) string {
 // setPGCache saves the specified placement group to the memory,
 // which can reduce access to the Tower service.
 func setPGCache(pg *models.VMPlacementGroup) {
-	inMemoryCache.Set(getKeyForPGCache(*pg.Name), *pg, gpuCacheDuration)
+	inMemoryCache.Set(getKeyForPGCache(*pg.Name), *pg, pgCacheDuration)
 }
 
 // delPGCaches deletes the specified placement group caches.
@@ -192,6 +192,33 @@ func getPGFromCache(pgName string) *models.VMPlacementGroup {
 	if val, found := inMemoryCache.Get(key); found {
 		if pg, ok := val.(models.VMPlacementGroup); ok {
 			return &pg
+		}
+		// Delete unexpected data.
+		inMemoryCache.Delete(key)
+	}
+
+	return nil
+}
+
+// labelCacheDuration is the lifespan of label cache.
+const labelCacheDuration = 30 * time.Minute
+
+func getKeyForLabelCache(labelKey string) string {
+	return fmt.Sprintf("label:%s:cache", labelKey)
+}
+
+// setLabelCache saves the specified label to the memory,
+// which can reduce access to the Tower service.
+func setLabelCache(label *models.Label) {
+	inMemoryCache.Set(getKeyForLabelCache(*label.Key), *label, labelCacheDuration)
+}
+
+// getLabelFromCache gets the specified label from the memory.
+func getLabelFromCache(labelKey string) *models.Label {
+	key := getKeyForLabelCache(labelKey)
+	if val, found := inMemoryCache.Get(key); found {
+		if label, ok := val.(models.Label); ok {
+			return &label
 		}
 		// Delete unexpected data.
 		inMemoryCache.Delete(key)

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -201,16 +201,21 @@ func getPGFromCache(pgName string) *models.VMPlacementGroup {
 }
 
 // labelCacheDuration is the lifespan of label cache.
-const labelCacheDuration = 30 * time.Minute
+const labelCacheDuration = 10 * time.Minute
 
 func getKeyForLabelCache(labelKey string) string {
 	return fmt.Sprintf("label:%s:cache", labelKey)
 }
 
-// setLabelCache saves the specified label to the memory,
+// setLabelInCache saves the specified label to the memory,
 // which can reduce access to the Tower service.
-func setLabelCache(label *models.Label) {
+func setLabelInCache(label *models.Label) {
 	inMemoryCache.Set(getKeyForLabelCache(*label.Key), *label, labelCacheDuration)
+}
+
+// delLabelCache deletes the specified label cache.
+func delLabelCache(labelKey string) {
+	inMemoryCache.Delete(getKeyForLabelCache(labelKey))
 }
 
 // getLabelFromCache gets the specified label from the memory.

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -186,6 +186,20 @@ var _ = Describe("TowerCache", func() {
 		Expect(getPGFromCache(pgName)).To(BeNil())
 	})
 
+	It("Label Cache", func() {
+		label := &models.Label{
+			ID:    service.TowerString("label-id"),
+			Key:   service.TowerString("label-key"),
+			Value: service.TowerString("label-name"),
+		}
+
+		Expect(getPGFromCache(*label.Key)).To(BeNil())
+		setLabelCache(label)
+		Expect(getLabelFromCache(*label.Key)).To(Equal(label))
+		resetMemoryCache()
+		Expect(getLabelFromCache(*label.Key)).To(BeNil())
+	})
+
 	It("GPU Cache", func() {
 		gpuID := "gpu"
 		gpuVMInfo := models.GpuVMInfo{ID: service.TowerString(gpuID)}

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -194,9 +194,9 @@ var _ = Describe("TowerCache", func() {
 		}
 
 		Expect(getPGFromCache(*label.Key)).To(BeNil())
-		setLabelCache(label)
+		setLabelInCache(label)
 		Expect(getLabelFromCache(*label.Key)).To(Equal(label))
-		resetMemoryCache()
+		delLabelCache(*label.Key)
 		Expect(getLabelFromCache(*label.Key)).To(BeNil())
 	})
 


### PR DESCRIPTION
## Issue [SKS-2194](http://jira.smartx.com/browse/SKS-2194)

https://github.com/smartxworks/cluster-api-provider-elf/pull/162 给虚拟机增加虚拟机后，Tower 会自动给虚拟机添加系统标签导致 CAPE 不能给虚拟机添加预期的标签。

```go
// 已经有了系统标签，导致没有进入 if 执行。
	if len(vm.Labels) == 0 {
		if ok, err := r.reconcileLabels(ctx, vm); !ok {
			return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile labels")
		}
        }

```

## Change
如果虚拟机打上了 managed 标签就认为所有的标签就有了，就可以跳过给虚拟机加标签的逻辑。

考虑每次 Reconcile 都要从 Tower 获取 managed 标签，且 managed 标签除非被人为删除，否则不会变动。为了减少 Tower 接口访问，managed 会缓存 30m。

## Test

创建 1CP + 3Workers 集群，在 ElfCluster 指定 haijian.yang@d8dc20fc-e197-41da-83b6-c903c88663fd。

观察到虚拟机指定了 owner
<img width="565" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/aa384f3f-a37f-49a5-9e3e-9d177c057af4">

虚拟机也打上了预期的标签
<img width="612" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/d8c692b6-cc10-4b1d-a8e4-415d21b777a5">

<img width="612" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/d3bbe73f-42f6-4e03-95c2-50bc4ec386b8">


