### PR TITLE
SKS-2342: Exclude the VMs in shutdown state or in the recycle bin when calculating the number of GPU mounts

### DIFF
--- a/controllers/elfmachine_controller_gpu.go
+++ b/controllers/elfmachine_controller_gpu.go
@@ -94,8 +94,6 @@ func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx *context.MachineContex
 		return nil, nil, err
 	}
 
-	service.CalculateAssignedAndAvailableNumForGPUVMInfos(gpuVMInfos)
-
 	// Filter available GPU devices.
 	gpuVMInfos = gpuVMInfos.FilterAvailableGPUVMInfos()
 
@@ -375,8 +373,6 @@ func (r *ElfMachineReconciler) checkGPUsCanBeUsedForVM(ctx *context.MachineConte
 		if err != nil || len(gpuVMInfos) != len(gpuDeviceIDs) {
 			return false, err
 		}
-
-		service.CalculateAssignedAndAvailableNumForGPUVMInfos(gpuVMInfos)
 
 		setGPUVMInfosCache(gpuVMInfos)
 	}

--- a/controllers/elfmachine_controller_gpu_test.go
+++ b/controllers/elfmachine_controller_gpu_test.go
@@ -136,7 +136,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 
 			logBuffer.Reset()
 			removeGPUVMInfosCache(gpuIDs)
-			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("id"), Name: service.TowerString("vm")}}
+			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("id"), Name: service.TowerString("vm"), Status: models.NewVMStatus(models.VMStatusRUNNING)}}
 			mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(nil, nil)
 			mockVMService.EXPECT().GetGPUDevicesAllocationInfoByIDs([]string{*gpuVMInfo.ID}).Return(gpuVMInfos, nil)
 			hostID, gpus, err = reconciler.selectHostAndGPUsForVM(machineContext, "")
@@ -178,7 +178,8 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			gpuVMInfo1.Vms = []*models.GpuVMDetail{}
 			gpuVMInfo1.Host = &models.NestedHost{ID: host.ID}
 			gpuVMInfo2 := fake.NewTowerVGPUVMInfo(3)
-			gpuVMInfo2.Vms = []*models.GpuVMDetail{{VgpuInstanceOnVMNum: service.TowerInt32(1)}}
+			gpuVMInfo2.AvailableVgpusNum = service.TowerInt32(2)
+			gpuVMInfo2.Vms = []*models.GpuVMDetail{{}}
 			gpuVMInfo2.Host = &models.NestedHost{ID: host.ID}
 			gpuVMInfos := service.NewGPUVMInfos(gpuVMInfo1, gpuVMInfo2)
 			requiredVGPUDevice := infrav1.VGPUDeviceSpec{Type: vGPUType, Count: 3}
@@ -311,7 +312,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			host := fake.NewTowerHost()
 			gpuVMInfo := fake.NewTowerGPUVMInfo()
 			gpuVMInfo.Host = &models.NestedHost{ID: host.ID}
-			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("id"), Name: service.TowerString("vm")}}
+			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("id"), Name: service.TowerString("vm"), Status: models.NewVMStatus(models.VMStatusRUNNING)}}
 			gpuVMInfos := service.NewGPUVMInfos(gpuVMInfo)
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
 			vm.Host = &models.NestedHost{ID: host.ID}
@@ -331,7 +332,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			Expect(logBuffer.String()).To(ContainSubstring("GPU devices of VM are already in use, so remove and reallocate"))
 
 			removeGPUVMInfosCache([]string{*gpuVMInfo.ID})
-			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: vm.ID, Name: vm.Name}}
+			gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: vm.ID, Name: vm.Name, Status: models.NewVMStatus(models.VMStatusRUNNING)}}
 			ok, err = reconciler.reconcileGPUDevices(machineContext, vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
@@ -543,7 +544,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 		Expect(ok).To(BeTrue())
 
 		removeGPUVMInfosCache(gpuIDs)
-		gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("vm1"), Name: service.TowerString("vm1")}}
+		gpuVMInfo.Vms = []*models.GpuVMDetail{{ID: service.TowerString("vm1"), Name: service.TowerString("vm1"), Status: models.NewVMStatus(models.VMStatusRUNNING)}}
 		mockVMService.EXPECT().GetGPUDevicesAllocationInfoByIDs(gpuIDs).Return(service.NewGPUVMInfos(gpuVMInfo), nil)
 		ok, err = reconciler.checkGPUsCanBeUsedForVM(machineContext, gpuIDs)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/service/collections.go
+++ b/pkg/service/collections.go
@@ -267,11 +267,6 @@ func GPUVMInfoFilterAnd(filters ...GPUVMInfoFilterFunc) GPUVMInfoFilterFunc {
 // which can allocatable for virtual machines.
 func (s GPUVMInfos) FilterAvailableGPUVMInfos() GPUVMInfos {
 	return s.Filter(func(gpuVMInfo *models.GpuVMInfo) bool {
-		if (*gpuVMInfo.UserUsage == models.GpuDeviceUsagePASSTHROUGH && len(gpuVMInfo.Vms) > 0) ||
-			(*gpuVMInfo.UserUsage == models.GpuDeviceUsageVGPU && *gpuVMInfo.AvailableVgpusNum <= 0) {
-			return false
-		}
-
-		return true
+		return GetAvailableCountFromGPUVMInfo(gpuVMInfo) > 0
 	})
 }

--- a/pkg/service/collections_test.go
+++ b/pkg/service/collections_test.go
@@ -115,7 +115,9 @@ func TestGPUVMInfoCollection(t *testing.T) {
 
 		gpuVMInfo1.UserUsage = models.NewGpuDeviceUsage(models.GpuDeviceUsagePASSTHROUGH)
 		g.Expect(NewGPUVMInfos(gpuVMInfo1).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(1))
-		gpuVMInfo1.Vms = []*models.GpuVMDetail{{}}
+		gpuVMInfo1.Vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusSTOPPED)}}
+		g.Expect(NewGPUVMInfos(gpuVMInfo1).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(1))
+		gpuVMInfo1.Vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusRUNNING)}}
 		g.Expect(NewGPUVMInfos(gpuVMInfo1).FilterAvailableGPUVMInfos().Len()).To(gomega.Equal(0))
 
 		gpuVMInfo2.UserUsage = models.NewGpuDeviceUsage(models.GpuDeviceUsageVGPU)

--- a/pkg/service/util_test.go
+++ b/pkg/service/util_test.go
@@ -142,33 +142,33 @@ func TestGetAvailableCountFromGPUVMInfo(t *testing.T) {
 	})
 }
 
-func TestFilterActualAllocatedVMsForGPU(t *testing.T) {
+func TestGetVMsOccupyingGPU(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	t.Run("should filter actual allocated vms", func(t *testing.T) {
 		vms := []*models.GpuVMDetail{}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.BeEmpty())
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.BeEmpty())
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusSTOPPED)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.BeEmpty())
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.BeEmpty())
 
 		vms = []*models.GpuVMDetail{{InRecycleBin: TowerBool(true)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.BeEmpty())
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.BeEmpty())
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusRUNNING)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.Equal(vms))
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.Equal(vms))
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusSUSPENDED)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.Equal(vms))
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.Equal(vms))
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusUNKNOWN)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.Equal(vms))
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.Equal(vms))
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusDELETED)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.Equal(vms))
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.Equal(vms))
 
 		vms = []*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusSTOPPED)}, {Status: models.NewVMStatus(models.VMStatusRUNNING)}}
-		g.Expect(filterActualAllocatedVMsForGPU(vms)).To(gomega.Equal([]*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusRUNNING)}}))
+		g.Expect(getVMsOccupyingGPU(vms)).To(gomega.Equal([]*models.GpuVMDetail{{Status: models.NewVMStatus(models.VMStatusRUNNING)}}))
 	})
 }
 


### PR DESCRIPTION
## Issue 

[SKS-2342](http://jira.smartx.com/browse/SKS-2342) GPU/vGPU - 计算挂载虚拟机时没有过滤回收站和关机状态的虚拟机

### Change

GPU 在计算挂载虚拟机时过滤回收站和关机状态的虚拟机。
而 vGPU 直接使用 AvailableVgpusNum 即可（回收站和关机状态的虚拟机都不会统计）。

#### GPU/vGPU 可用性判断

判断 GPUs  是否可用，每个 GPU 要满足以下要求（参考代码 HasGPUsCanNotBeUsedForVM）：
✅GPU 没有挂载任何虚拟机（不包括在回收站和关机状态） 
✅GPU 只挂载了一个虚拟机（不包括在回收站和关机状态），且是当前虚拟机
❌其他情况不可用

判断 vGPUs 是否可用（参考代码 HasGPUsCanNotBeUsedForVM）：
✅所有的 vGPUs 可分配数量满足虚拟机的需求
❌其他情况不可用

### Test
#### GPU
1.1 创建一个关机状态的虚拟机，并挂载了 T4。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/f02744f0-bbfe-4f37-889c-c8ad854ef88f)
1.2 创建 1CP + 1Worker（挂载 1T4） 集群，观察到 Worker 仍然可以挂载上述关机状态虚拟机挂载的 T4
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/22b2d46e-9779-4357-8cda-e2c9993dbf72)

2.1 创建一个关机状态的虚拟机，并挂载了 T4，然后放入回收站。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/d3c23421-d19c-405d-b046-7d798a47205d)

2.2 创建 1CP + 1Worker（挂载 1T4） 集群，观察到 Worker 仍然可以挂载上述在回收站虚拟机挂载的 T4
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/5ed8b0f3-c11a-44d7-9553-fd383a5b7c13)


#### vGPU
1.1 创建一个关机状态的虚拟机，并挂载了一个 GRID T4-4C。
1.2 创建 1CP + 1Worker（挂载一个 GRID T4-4C） 集群，观察到 Worker 仍然可以挂载上述关机状态虚拟机挂载的 GRID T4-4C
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/d30e4e43-e4c2-4592-8632-dfa438db6c65)


2.1 创建一个关机状态的虚拟机，挂载了一个 GRID T4-4C，并放入回收站。
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/76281ce0-b270-40bf-afa9-1757500faa8e)

2.2 创建 1CP + 1Worker（挂载一个 GRID T4-4C） 集群，观察到 Worker 仍然可以挂载上述在回收站虚拟机挂载的 GRID T4-4C
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/11d5b03e-c3a5-4fb4-8a6f-05e14c66ef05)

