### PR TITLE
SKS-2344: Clean unused CloudTower labels created by CAPE every 24h

### DIFF
--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -135,6 +135,9 @@ var _ = Describe("ElfClusterReconciler", func() {
 			}
 			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
 
+			keys := []string{towerresources.GetVMLabelClusterName(), towerresources.GetVMLabelVIP(), towerresources.GetVMLabelNamespace(), towerresources.GetVMLabelManaged()}
+			mockVMService.EXPECT().CleanLabels(keys).Return(nil, nil)
+
 			elfClusterKey := capiutil.ObjectKey(elfCluster)
 			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			_, _ = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfClusterKey})
@@ -280,6 +283,43 @@ var _ = Describe("ElfClusterReconciler", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(logBuffer.String()).To(ContainSubstring(""))
 			Expect(apierrors.IsNotFound(reconciler.Client.Get(reconciler, elfClusterKey, elfCluster))).To(BeTrue())
+		})
+	})
+
+	Context("CleanLabels", func() {
+		BeforeEach(func() {
+			resetMemoryCache()
+		})
+
+		It("should clean labels for Tower", func() {
+			elfCluster.Spec.ControlPlaneEndpoint.Host = "127.0.0.1"
+			elfCluster.Spec.ControlPlaneEndpoint.Port = 6443
+			// ctrlMgrContext := fake.NewControllerManagerContext(cluster, elfCluster)
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+			clusterContext := &context.ClusterContext{
+				ControllerContext: ctrlContext,
+				Cluster:           cluster,
+				ElfCluster:        elfCluster,
+				Logger:            ctrllog.Log,
+				VMService:         mockVMService,
+			}
+
+			unexpectedError := errors.New("unexpected error")
+			keys := []string{towerresources.GetVMLabelClusterName(), towerresources.GetVMLabelVIP(), towerresources.GetVMLabelNamespace(), towerresources.GetVMLabelManaged()}
+			mockVMService.EXPECT().CleanLabels(keys).Return(nil, unexpectedError)
+			reconciler := &ElfClusterReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			reconciler.cleanLabels(clusterContext)
+			Expect(logBuffer.String()).To(ContainSubstring("failed to clean labels for Tower"))
+
+			logBuffer.Reset()
+			mockVMService.EXPECT().CleanLabels(keys).Return(nil, nil)
+			reconciler.cleanLabels(clusterContext)
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Labels of Tower %s are cleaned successfully", elfCluster.Spec.Tower.Server)))
+
+			logBuffer.Reset()
+			reconciler.cleanLabels(clusterContext)
+			Expect(logBuffer.String()).NotTo(ContainSubstring(fmt.Sprintf("Cleaning labels for Tower %s", elfCluster.Spec.Tower.Server)))
 		})
 	})
 })

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -156,8 +156,8 @@ func getKeyForGCLabelTime(tower string) string {
 	return fmt.Sprintf("label:gc:time:%s", tower)
 }
 
-// acquireTicketForGCTowerLabels returns whether label gc operation can be performed.
-func acquireTicketForGCTowerLabels(tower string) bool {
+// acquireLockForGCTowerLabels returns whether label gc operation can be performed.
+func acquireLockForGCTowerLabels(tower string) bool {
 	labelOperationLock.Lock()
 	defer labelOperationLock.Unlock()
 
@@ -183,8 +183,8 @@ func acquireTicketForGCTowerLabels(tower string) bool {
 	return true
 }
 
-// releaseTicketForForGCTowerLabels releases the Tower whose labels are being cleared.
-func releaseTicketForForGCTowerLabels(tower string) {
+// releaseLockForForGCTowerLabels releases the Tower whose labels are being cleared.
+func releaseLockForForGCTowerLabels(tower string) {
 	labelOperationLock.Lock()
 	defer labelOperationLock.Unlock()
 

--- a/controllers/vm_limiter.go
+++ b/controllers/vm_limiter.go
@@ -144,6 +144,61 @@ func getKeyForVMDuplicate(name string) string {
 	return fmt.Sprintf("vm:duplicate:%s", name)
 }
 
+/* Label */
+
+var labelOperationLock sync.Mutex
+
+func getKeyForGCLabel(tower string) string {
+	return fmt.Sprintf("label:gc:%s", tower)
+}
+
+func getKeyForGCLabelTime(tower string) string {
+	return fmt.Sprintf("label:gc:time:%s", tower)
+}
+
+// acquireTicketForGCTowerLabels returns whether label gc operation can be performed.
+func acquireTicketForGCTowerLabels(tower string) bool {
+	labelOperationLock.Lock()
+	defer labelOperationLock.Unlock()
+
+	if _, found := inMemoryCache.Get(getKeyForGCLabel(tower)); found {
+		return false
+	}
+
+	key := getKeyForGCLabelTime(tower)
+	if val, found := inMemoryCache.Get(key); found {
+		lastGCTime, ok := val.(time.Time)
+		if ok {
+			if time.Now().Before(lastGCTime.Add(24 * time.Hour)) {
+				return false
+			}
+		} else {
+			// Delete unexpected data.
+			inMemoryCache.Delete(key)
+		}
+	}
+
+	inMemoryCache.Set(getKeyForGCLabel(tower), nil, cache.NoExpiration)
+
+	return true
+}
+
+// releaseTicketForForGCTowerLabels releases the Tower whose labels are being cleared.
+func releaseTicketForForGCTowerLabels(tower string) {
+	labelOperationLock.Lock()
+	defer labelOperationLock.Unlock()
+
+	inMemoryCache.Delete(getKeyForGCLabel(tower))
+}
+
+// recordGCTimeForTowerLabels records the last GC label time of the specified Tower.
+func recordGCTimeForTowerLabels(tower string) {
+	labelOperationLock.Lock()
+	defer labelOperationLock.Unlock()
+
+	inMemoryCache.Set(getKeyForGCLabelTime(tower), time.Now(), cache.NoExpiration)
+}
+
 /* GPU */
 
 type lockedGPUDevice struct {

--- a/pkg/service/mock_services/vm_mock.go
+++ b/pkg/service/mock_services/vm_mock.go
@@ -83,6 +83,21 @@ func (mr *MockVMServiceMockRecorder) AddVMsToPlacementGroup(placementGroup, vmID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVMsToPlacementGroup", reflect.TypeOf((*MockVMService)(nil).AddVMsToPlacementGroup), placementGroup, vmIDs)
 }
 
+// CleanLabels mocks base method.
+func (m *MockVMService) CleanLabels(keys []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanLabels", keys)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanLabels indicates an expected call of CleanLabels.
+func (mr *MockVMServiceMockRecorder) CleanLabels(keys interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanLabels", reflect.TypeOf((*MockVMService)(nil).CleanLabels), keys)
+}
+
 // Clone mocks base method.
 func (m *MockVMService) Clone(elfCluster *v1beta1.ElfCluster, elfMachine *v1beta1.ElfMachine, bootstrapData, host string, machineGPUDevices []*service.GPUDeviceInfo) (*models.WithTaskVM, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Issue [SKS-2344](http://jira.smartx.com/browse/SKS-2344)

当前 Tower 每个标签都有一个虚拟机引用计数，这个计数是异步同步近实时更新的。
例如删除一个标签关联的虚拟机之后，标签的计数更新时间可能在 1 秒内，也可能几秒之后。

当前 CAPE 删除 ClusterNameLabel 和 NamespaceLabel 的时候会判断标签的虚拟机引用计数是否大于等于 0，
只有引用计数大于等于 0 的时候才会删除该标签。

因此，CAPE 在删除 ClusterNameLabel 和 NamespaceLabel 的时候会存在遗删的可能。

### Change

定期清理（每天一次）没有被使用的 Tower 标签。

为了避免误删在使用的标签，清理标签的时候增加只能清理一天前创建的限制。

### Test

程序运行之前，Tower 有很多一天前创建的标签
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/9d20a430-2fc1-4da7-aeb9-90a65d21d69c)

程序运行之后，新建一个集群，观察到只剩下当前集群使用的标签
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/b1b0aeb2-2f50-4ece-a83e-862b64955eb3)


