### PR TITLE
SKS-2344: Fix cleaning unused CloudTower labels created by CAPE every 24h

### DIFF
--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -794,6 +794,7 @@ func (svr *TowerVMService) CleanLabels(keys []string) ([]string, error) {
 		Where: &models.LabelWhereInput{
 			KeyIn:        keys,
 			CreatedAtLte: TowerString(time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)),
+			TotalNum:     TowerInt32(0),
 		},
 	}
 


### PR DESCRIPTION
### Issue
问题：集群节点虚拟机标签丢失。

定位：定时清理标签没有加上 TotalNum = 0 的限制。

### Change
定时清理补上 TotalNum = 0 的限制。

### Test