### PR TITLE
SKS-1390: Optimize the creation of virtual machines when insufficient storage detected for ELF cluster

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -110,6 +110,10 @@ const (
 	// waiting for ELF cluster with sufficient memory to create or power on VM.
 	WaitingForELFClusterWithSufficientMemoryReason = "WaitingForELFClusterWithSufficientMemory"
 
+	// WaitingForELFClusterWithSufficientStorageReason (Severity=Info) documents an ElfMachine
+	// waiting for ELF cluster with sufficient storage to create or power on VM.
+	WaitingForELFClusterWithSufficientStorageReason = "WaitingForELFClusterWithSufficientStorage"
+
 	// WaitingForAvailableHostRequiredByPlacementGroupReason (Severity=Info) documents an ElfMachine
 	// waiting for an available host required by placement group to create VM.
 	WaitingForAvailableHostRequiredByPlacementGroupReason = "WaitingForAvailableHostRequiredByPlacementGroup"

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -258,7 +258,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.CloningFailedReason}})
 		})
 
-		It("should create a new VM if none exists", func() {
+		It("should create a new VM if the VM does not exist", func() {
 			resetMemoryCache()
 			vm := fake.NewTowerVM()
 			vm.Name = &elfMachine.Name
@@ -271,7 +271,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 			machineContext.VMService = mockVMService
-			recordIsUnmet(machineContext, clusterInsufficientStorageKey, true)
+			recordOrClearError(machineContext, clusterInsufficientStorageKey, true)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -286,7 +286,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			machineContext = newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
-			recordIsUnmet(machineContext, clusterInsufficientMemoryKey, true)
+			recordOrClearError(machineContext, clusterInsufficientMemoryKey, true)
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
 			Expect(result.RequeueAfter).NotTo(BeZero())
@@ -845,7 +845,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 				machineContext := newMachineContext(ctrlContext, elfCluster, cluster, elfMachine, machine, mockVMService)
 				machineContext.VMService = mockVMService
-				recordIsUnmet(machineContext, clusterInsufficientMemoryKey, true)
+				recordOrClearError(machineContext, clusterInsufficientMemoryKey, true)
 				reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
 				err := reconciler.powerOnVM(machineContext, vm)
 				Expect(err).NotTo(HaveOccurred())

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -258,7 +258,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.CloningFailedReason}})
 		})
 
-		It("should create a new VM if the VM does not exist", func() {
+		It("should create a new VM if not exists", func() {
 			resetMemoryCache()
 			vm := fake.NewTowerVM()
 			vm.Name = &elfMachine.Name

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -50,7 +50,8 @@ type clusterResource struct {
 //
 // Includes these scenarios:
 // 1. ELF cluster has insufficient memory.
-// 2. Placement group not satisfy policy.
+// 2. ELF cluster has insufficient storage.
+// 3. Placement group not satisfy policy.
 func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, error) {
 	lock.Lock()
 	defer lock.Unlock()
@@ -59,6 +60,10 @@ func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, er
 		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForELFClusterWithSufficientMemoryReason, clusterv1.ConditionSeverityInfo, "")
 
 		return true, fmt.Sprintf("Insufficient memory detected for the ELF cluster %s", ctx.ElfCluster.Spec.Cluster), nil
+	} else if resource := getClusterResource(getKeyForInsufficientStorageError(ctx.ElfCluster.Spec.Cluster)); resource != nil {
+		conditions.MarkFalse(ctx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForELFClusterWithSufficientStorageReason, clusterv1.ConditionSeverityInfo, "")
+
+		return true, fmt.Sprintf("Insufficient storage detected for the ELF cluster %s", ctx.ElfCluster.Spec.Cluster), nil
 	}
 
 	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
@@ -79,6 +84,16 @@ func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, er
 func recordElfClusterMemoryInsufficient(ctx *context.MachineContext, isInsufficient bool) {
 	key := getKeyForInsufficientMemoryError(ctx.ElfCluster.Spec.Cluster)
 	if isInsufficient {
+		inMemoryCache.Set(key, newClusterResource(), resourceDuration)
+	} else {
+		inMemoryCache.Delete(key)
+	}
+}
+
+// recordElfClusterStorageInsufficient records whether the storage is insufficient.
+func recordElfClusterStorageInsufficient(ctx *context.MachineContext, isError bool) {
+	key := getKeyForInsufficientStorageError(ctx.ElfCluster.Spec.Cluster)
+	if isError {
 		inMemoryCache.Set(key, newClusterResource(), resourceDuration)
 	} else {
 		inMemoryCache.Delete(key)
@@ -116,7 +131,9 @@ func canRetryVMOperation(ctx *context.MachineContext) (bool, error) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	if ok := canRetry(getKeyForInsufficientMemoryError(ctx.ElfCluster.Spec.Cluster)); ok {
+	if ok := canRetry(getKeyForInsufficientStorageError(ctx.ElfCluster.Spec.Cluster)); ok {
+		return true, nil
+	} else if ok := canRetry(getKeyForInsufficientMemoryError(ctx.ElfCluster.Spec.Cluster)); ok {
 		return true, nil
 	}
 
@@ -156,6 +173,10 @@ func getClusterResource(key string) *clusterResource {
 	}
 
 	return nil
+}
+
+func getKeyForInsufficientStorageError(clusterID string) string {
+	return fmt.Sprintf("insufficient:storage:%s", clusterID)
 }
 
 func getKeyForInsufficientMemoryError(clusterID string) string {

--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -51,7 +51,7 @@ type clusterResource struct {
 // Includes these scenarios:
 // 1. ELF cluster has insufficient memory.
 // 2. ELF cluster has insufficient storage.
-// 3. Placement group not satisfy policy.
+// 3. Cannot satisfy the PlacementGroup policy.
 func isELFScheduleVMErrorRecorded(ctx *context.MachineContext) (bool, string, error) {
 	lock.Lock()
 	defer lock.Unlock()

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -34,8 +34,10 @@ import (
 )
 
 const (
-	clusterKey        = "clusterID"
-	placementGroupKey = "getPlacementGroupName"
+	clusterKey                    = "clusterID"
+	clusterInsufficientMemoryKey  = "clusterInsufficientMemory"
+	clusterInsufficientStorageKey = "clusterInsufficientStorage"
+	placementGroupKey             = "getPlacementGroupName"
 )
 
 var _ = Describe("TowerCache", func() {
@@ -44,7 +46,7 @@ var _ = Describe("TowerCache", func() {
 	})
 
 	It("should set memoryInsufficient/policyNotSatisfied", func() {
-		for _, name := range []string{clusterKey, placementGroupKey} {
+		for _, name := range []string{clusterInsufficientMemoryKey, clusterInsufficientStorageKey, placementGroupKey} {
 			resetMemoryCache()
 			elfCluster, cluster, elfMachine, machine, secret := fake.NewClusterAndMachineObjects()
 			elfCluster.Spec.Cluster = name
@@ -98,7 +100,7 @@ var _ = Describe("TowerCache", func() {
 	})
 
 	It("should return whether need to detect", func() {
-		for _, name := range []string{clusterKey, placementGroupKey} {
+		for _, name := range []string{clusterInsufficientMemoryKey, clusterInsufficientStorageKey, placementGroupKey} {
 			resetMemoryCache()
 			elfCluster, cluster, elfMachine, machine, secret := fake.NewClusterAndMachineObjects()
 			elfCluster.Spec.Cluster = name
@@ -154,12 +156,22 @@ var _ = Describe("TowerCache", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		expectConditions(elfMachine, []conditionAssertion{})
 
-		recordIsUnmet(machineContext, clusterKey, true)
+		elfCluster.Spec.Cluster = clusterInsufficientMemoryKey
+		recordIsUnmet(machineContext, clusterInsufficientMemoryKey, true)
 		ok, msg, err = isELFScheduleVMErrorRecorded(machineContext)
 		Expect(ok).To(BeTrue())
 		Expect(msg).To(ContainSubstring("Insufficient memory detected for the ELF cluster"))
 		Expect(err).ShouldNot(HaveOccurred())
 		expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForELFClusterWithSufficientMemoryReason}})
+
+		resetMemoryCache()
+		elfCluster.Spec.Cluster = clusterInsufficientStorageKey
+		recordIsUnmet(machineContext, clusterInsufficientStorageKey, true)
+		ok, msg, err = isELFScheduleVMErrorRecorded(machineContext)
+		Expect(ok).To(BeTrue())
+		Expect(msg).To(ContainSubstring("Insufficient storage detected for the ELF cluster clusterInsufficientStorage"))
+		Expect(err).ShouldNot(HaveOccurred())
+		expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForELFClusterWithSufficientStorageReason}})
 
 		resetMemoryCache()
 		recordIsUnmet(machineContext, placementGroupKey, true)
@@ -220,8 +232,10 @@ func removeGPUVMInfosCache(gpuIDs []string) {
 }
 
 func getKey(ctx *context.MachineContext, name string) string {
-	if name == clusterKey {
+	if name == clusterInsufficientMemoryKey {
 		return getKeyForInsufficientMemoryError(name)
+	} else if name == clusterInsufficientStorageKey {
+		return getKeyForInsufficientStorageError(name)
 	}
 
 	placementGroupName, err := towerresources.GetVMPlacementGroupName(ctx, ctx.Client, ctx.Machine, ctx.Cluster)
@@ -231,8 +245,11 @@ func getKey(ctx *context.MachineContext, name string) string {
 }
 
 func recordIsUnmet(ctx *context.MachineContext, key string, isUnmet bool) {
-	if strings.Contains(key, clusterKey) {
+	if strings.Contains(key, clusterInsufficientMemoryKey) {
 		recordElfClusterMemoryInsufficient(ctx, isUnmet)
+		return
+	} else if strings.Contains(key, clusterInsufficientStorageKey) {
+		recordElfClusterStorageInsufficient(ctx, isUnmet)
 		return
 	}
 

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -37,6 +37,7 @@ const (
 	LabelAddFailed            = "LABEL_ADD_FAILED"
 	CloudInitError            = "VM_CLOUD_INIT_CONFIG_ERROR"
 	MemoryInsufficientError   = "HostAvailableMemoryFilter"
+	StorageInsufficientError  = "EAllocSpace"
 	PlacementGroupError       = "PlacementGroupFilter" // SMTX OS <= 5.0.4
 	PlacementGroupMustError   = "PlacementGroupMustFilter"
 	PlacementGroupPriorError  = "PlacementGroupPriorFilter"
@@ -109,6 +110,10 @@ func ParseGPUAssignFailed(message string) string {
 	}
 
 	return message[index:]
+}
+
+func IsStorageInsufficientError(message string) bool {
+	return strings.Contains(message, StorageInsufficientError)
 }
 
 func IsMemoryInsufficientError(message string) bool {


### PR DESCRIPTION
## Issue [SKS-1390](http://jira.smartx.com/browse/SKS-1390)

集群存储不足时，创建节点 VM 任务不断重试，创建出多个重复的同名 volume。

## Change
* 创建虚拟机的时候如果检测到存储不足，延迟五分钟允许重试。参考之前内存不足的处理：https://github.com/smartxworks/cluster-api-provider-elf/pull/79
* reconcileVMFailedTask 拆成两个 Switch 处理，第一个 Switch 根据任务类型处理，第二个 Switch 根据错误的类型处理（不同类型测任务可能产生同样的错误）。

SMTX OS 6.0 未复现多个重复的同名 volume，因此不需处理。

## Test
1. 把集群的存储资源机会消耗完
<img width="354" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/7a1e752f-bc51-45dd-9e03-e1b3869ff73a">

2. 创建任意数量节点的集群，观察到存储不足导致节点无法创建，并每隔五分钟后允许重试
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/b2116e98-d608-4bed-a849-07f9e15fdf64)
