### PR TITLE
SKS-2387: Requeue ElfMachine when NodeHealthy condition is unknown to ensure the VM can be powered on ASAP

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -112,7 +112,7 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ct
 }
 
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
-func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
 	// Get the ElfMachine resource for this request.
 	var elfMachine infrav1.ElfMachine
 	if err := r.Client.Get(r, req.NamespacedName, &elfMachine); err != nil {
@@ -222,6 +222,22 @@ func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_
 			}
 
 			machineContext.Logger.Error(err, "patch failed", "elfMachine", machineContext.String())
+		}
+
+		// If the node's healthy condition is unknown, the virtual machine may
+		// have been shut down through Tower or directly on the virtual machine.
+		// We need to try to reconcile to ensure that the virtual machine is powered on.
+		if err == nil && result.IsZero() &&
+			machineutil.IsNodeHealthyConditionUnknown(machineContext.Machine) &&
+			!machineutil.IsMachineFailed(machineContext.Machine) &&
+			machineContext.Machine.DeletionTimestamp.IsZero() &&
+			machineContext.ElfMachine.DeletionTimestamp.IsZero() {
+			lastTransitionTime := conditions.GetLastTransitionTime(machineContext.Machine, clusterv1.MachineNodeHealthyCondition)
+			if lastTransitionTime != nil && time.Now().Before(lastTransitionTime.Add(config.VMStatusRequeueDuration)) {
+				result.RequeueAfter = config.DefaultRequeueTimeout
+
+				machineContext.Logger.Info(fmt.Sprintf("The node's healthy condition is unknown, virtual machine may have been shut down, will try to reconcile after %s", result.RequeueAfter), "nodeConditionUnknownTime", lastTransitionTime)
+			}
 		}
 	}()
 

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -229,6 +229,69 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(reconciler.Client.Get(reconciler, elfMachineKey, elfMachine)).To(Succeed())
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForBootstrapDataReason}})
 		})
+
+		It("should requeue when node's healthy condition is unknown", func() {
+			ctrlutil.AddFinalizer(elfMachine, infrav1.MachineFinalizer)
+			ctrlutil.AddFinalizer(machine, infrav1.MachineFinalizer)
+			cluster.Status.InfrastructureReady = false
+
+			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			elfMachineKey := capiutil.ObjectKey(elfMachine)
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			logBuffer.Reset()
+			message := "The node's healthy condition is unknown, virtual machine may have been shut down, will try to reconcile"
+			conditions.MarkUnknown(machine, clusterv1.MachineNodeHealthyCondition, clusterv1.NodeConditionsFailedReason, "test")
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeueTimeout))
+			Expect(logBuffer.String()).To(ContainSubstring(message))
+
+			machine.Status.Conditions[0].LastTransitionTime = metav1.NewTime(time.Now().Add(-config.VMStatusRequeueDuration))
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			conditions.MarkUnknown(machine, clusterv1.MachineNodeHealthyCondition, clusterv1.NodeConditionsFailedReason, "test")
+			machine.Status.FailureMessage = pointer.String("error")
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			conditions.MarkUnknown(machine, clusterv1.MachineNodeHealthyCondition, clusterv1.NodeConditionsFailedReason, "test")
+			machine.Status.FailureMessage = nil
+			machine.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			mockVMService.EXPECT().GetByName(elfMachine.Name).Return(nil, errors.New(service.VMNotFound))
+			machine.DeletionTimestamp = nil
+			elfMachine.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			ctrlutil.AddFinalizer(elfMachine, "no-gc")
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+		})
 	})
 
 	Context("Reconcile ElfMachine VM", func() {

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(result.IsZero()).To(BeTrue())
 
 			logBuffer.Reset()
-			message := "The node's healthy condition is unknown, virtual machine may have been shut down, will try to reconcile"
+			message := "The node's healthy condition is unknown, virtual machine may have been shut down, will reconcile"
 			conditions.MarkUnknown(machine, clusterv1.MachineNodeHealthyCondition, clusterv1.NodeConditionsFailedReason, "test")
 			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
@@ -254,7 +254,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeueTimeout))
 			Expect(logBuffer.String()).To(ContainSubstring(message))
 
-			machine.Status.Conditions[0].LastTransitionTime = metav1.NewTime(time.Now().Add(-config.VMStatusRequeueDuration))
+			machine.Status.Conditions[0].LastTransitionTime = metav1.NewTime(time.Now().Add(-config.VMPowerStatusCheckingDuration))
 			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
@@ -285,6 +285,16 @@ var _ = Describe("ElfMachineReconciler", func() {
 			machine.DeletionTimestamp = nil
 			elfMachine.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
 			ctrlutil.AddFinalizer(elfMachine, "no-gc")
+			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
+			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}
+			result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			machine.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+			ctrlutil.AddFinalizer(machine, "no-gc")
+			elfMachine.DeletionTimestamp = nil
 			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, secret, md)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext, NewVMService: mockNewVMService}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ var (
 	// WaitTaskTimeoutForPlacementGroupOperation is the timeout for waiting for placement group creating/updating/deleting task to complete.
 	WaitTaskTimeoutForPlacementGroupOperation = 10 * time.Second
 
-	// VMStatusRequeueDuration is the time duration for make sure the virtual machine is powered on,
-	// starting from when the machine's node healthy condition is unknown.
-	VMStatusRequeueDuration = 1 * time.Minute
+	// VMPowerStatusCheckingDuration is the time duration for cheking if the VM is powered off
+	// after the Machine's NodeHealthy condition status is set to Unknown.
+	VMPowerStatusCheckingDuration = 2 * time.Minute
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,4 +33,8 @@ var (
 
 	// WaitTaskTimeoutForPlacementGroupOperation is the timeout for waiting for placement group creating/updating/deleting task to complete.
 	WaitTaskTimeoutForPlacementGroupOperation = 10 * time.Second
+
+	// VMStatusRequeueDuration is the time duration for make sure the virtual machine is powered on,
+	// starting from when the machine's node healthy condition is unknown.
+	VMStatusRequeueDuration = 1 * time.Minute
 )

--- a/pkg/util/machine/machine.go
+++ b/pkg/util/machine/machine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
@@ -112,6 +113,20 @@ func GetNodeGroupName(machine *clusterv1.Machine) string {
 	clusterName := labelsutil.GetClusterNameLabelLabel(machine)
 
 	return strings.ReplaceAll(nodeGroupName, fmt.Sprintf("%s-", clusterName), "")
+}
+
+// IsNodeHealthyConditionUnknown returns whether the node's healthy condition is unknown.
+func IsNodeHealthyConditionUnknown(machine *clusterv1.Machine) bool {
+	if conditions.IsUnknown(machine, clusterv1.MachineNodeHealthyCondition) &&
+		conditions.GetReason(machine, clusterv1.MachineNodeHealthyCondition) == clusterv1.NodeConditionsFailedReason {
+		return true
+	}
+
+	return false
+}
+
+func IsMachineFailed(machine *clusterv1.Machine) bool {
+	return machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil
 }
 
 func ConvertProviderIDToUUID(providerID *string) string {


### PR DESCRIPTION
## Issue
[SKS-2387](http://jira.smartx.com/browse/SKS-2387) 在虚拟机操作系统中执行 shutdown 命令关机后 CAPE 没有及时开机，需要等默认的 10m 分钟 resync。

## Change
Tower -> ELF -> VM

当前 Tower 不支持 Watch 虚拟机的状态，所以我们不能实时感知虚拟机被关机了。

Tower 每隔 20s 从 ELF  定时同步虚拟机，一般情况下 30s 左右完成。

CAPI Machine 控制器会实时感知节点的变化。观察到如果虚拟机关机了，那么 Machine 会设置 NodeHealthy 为 Unknown（[相关代码](https://github.com/kubernetes-sigs/cluster-api/blob/caa378c55af88599903f3c0e48799fd697e36049/internal/controllers/machine/machine_controller_noderef.go#L152)）
```yaml
lastTransitionTime: "2024-01-19T08:47:56Z"
    message: 'Node condition MemoryPressure is Unknown. Node condition DiskPressure
      is Unknown. Node condition PIDPressure is Unknown. Node condition Ready is Unknown. '
    reason: NodeConditionsFailed
    status: Unknown
    type: NodeHealthy
```

因此可以 CAPE  可以通过检测 Machine 是否设置了 NodeHealthy 为 Unknown，如果是，表示虚拟机可能被关机了。但  NodeHealthy 为 Unknown 不一定就是虚拟机关机了（可能是虚拟机故障或网络故障等）。考虑到 Tower 大约 30s 会从 ELF 同步虚拟机信息，也就是关闭虚拟机后，Tower 大约 30s 才能感知到虚拟机被关机了。因此，如果检测到 NodeHealthy 为 Unknown，在一分钟内 requeue ElfMachine，利用 ElfMachine 控制器检测 Tower 虚拟机的状态，如果虚拟机真的被关闭了，会尝试启动虚拟机。


### 局限
* 集群不可访问的情况，CAPI 就不能设置获取到节点的信息，也就不会设置 NodeHealthy 为 Unknown。

## Test
1. 创建任意节点数量的集群
2. 随机选择一个节点的虚拟机通过 shutdown 关机
3. 观察到被关闭的虚拟机在 30s 左右被启动

3.1 ELF Machine 先被设置了 NodeHealthy 为 Unknown，Tower 后同步关机信息
<img width="1127" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/8b84c181-403c-4e28-9681-8e085b9eb6a8">
3.2 Tower 先同步关机信息， ELF Machine 后被设置了 NodeHealthy 为 Unknown
![image](https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/76b146df-717d-4e7e-819c-f55b0bc64223)


