### PR TITLE
SKS-2437: Bump kube-vip to v0.7.1

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -97,6 +97,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      - /etc/kube-vip-prepare.sh
     useExperimentalRetryJoin: true
     files:
     - content: |
@@ -111,25 +112,41 @@ spec:
           - args:
             - manager
             env:
-            - name: cp_enable
+            - name: vip_arp
               value: "true"
-            - name: vip_interface
-              value: ${VIP_NETWORK_INTERFACE:="ens4"}
-            - name: address
-              value: ${CONTROL_PLANE_ENDPOINT_IP}
             - name: port
               value: "6443"
-            - name: vip_arp
+            - name: vip_interface
+              value: ${VIP_NETWORK_INTERFACE:="ens4"}
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: svc_enable
+              value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: svc_election
               value: "true"
             - name: vip_leaderelection
               value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
             - name: vip_leaseduration
               value: "5"
             - name: vip_renewdeadline
               value: "3"
             - name: vip_retryperiod
               value: "1"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.12
+            - name: address
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
+            - name: prometheus_server
+              value: :2112
+            image: ghcr.io/kube-vip/kube-vip:v0.7.1
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -152,7 +169,6 @@ spec:
           volumes:
           - hostPath:
               path: /etc/kubernetes/admin.conf
-              type: FileOrCreate
             name: kubeconfig
           - hostPath:
               path: /etc/localtime
@@ -161,6 +177,53 @@ spec:
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
+    - content: |
+        #!/bin/bash
+
+        # Copyright 2020 The Kubernetes Authors.
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+
+        set -e
+
+        # Configure the workaround required for kubeadm init with kube-vip:
+        # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+        # Nothing to do for kubernetes < v1.29
+        KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+        if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+          exit 0
+        fi
+
+        IS_KUBEADM_INIT="false"
+
+        # cloud-init kubeadm init
+        if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        # ignition kubeadm init
+        if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+          IS_KUBEADM_INIT="true"
+        fi
+
+        if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+            /etc/kubernetes/manifests/kube-vip.yaml
+        fi
+      owner: root:root
+      path: /etc/kube-vip-prepare.sh
+      permissions: "0700"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
## Issue

## Change

### [v0.7.1](https://github.com/kube-vip/kube-vip/releases/tag/v0.7.1) 已知问题
- https://github.com/kube-vip/kube-vip/issues/684 解决方法：[CAPV ](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/templates/cluster-template.yaml#L184)。已经按照 Issue 描述的方法处理。
- https://github.com/kube-vip/kube-vip/issues/692 Kubernetes v1.29 不支持 v0.7.1 使用的 hostAliases。经过验证，这个不影响 CAPE 的使用。

[v0.7.1](https://github.com/kube-vip/kube-vip/releases/tag/v0.7.1)
- Added common endpoint provider interface and fixed route deletion iss… by @p-strusiewiczsurmacki-mobica in https://github.com/kube-vip/kube-vip/pull/761
- Bump golang from 1.21.6-alpine3.18 to 1.22.0-alpine3.18 by https://github.com/dependabot in https://github.com/kube-vip/kube-vip/pull/760
-Fix IPVS service error: netlink receive invalid argument by @lou-lan in https://github.com/kube-vip/kube-vip/pull/765
- Added possibility to remove redundant routes by @p-strusiewiczsurmacki-mobica in https://github.com/kube-vip/kube-vip/pull/763
- Bump sigs.k8s.io/kind from 0.20.0 to 0.22.0 by https://github.com/dependabot in https://github.com/kube-vip/kube-vip/pull/764
- Bump golang.org/x/sys from 0.16.0 to 0.17.0 by https://github.com/dependabot in https://github.com/kube-vip/kube-vip/pull/759
- Bump go.etcd.io/etcd/api/v3 from 3.5.11 to 3.5.12 by https://github.com/dependabot in https://github.com/kube-vip/kube-vip/pull/757
- fixes a bug that wouldn't return CIDRs for egress by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/768

[v0.7.0](https://github.com/kube-vip/kube-vip/releases/tag/v0.7.0)
- Dualstack support for Loadbalancer Services by @flawedmatrix in https://github.com/kube-vip/kube-vip/pull/687
- Add config options for BGP timers by @marc-cerebras in https://github.com/kube-vip/kube-vip/pull/695
- Updates to the client to auto-detect by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/699
- fixes to the new ipvs import by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/710
- Allows a configurable path to the kubernetes config by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/713
- fix https://github.com/kube-vip/kube-vip/issues/723 and allow short hostnames as well by @Cellebyte in https://github.com/kube-vip/kube-vip/pull/724
- Non-leader-election for routing table mode by @p-strusiewiczsurmacki-mobica in https://github.com/kube-vip/kube-vip/pull/720
- Added cli-options for bgp holdtime and keepalive by @Cellebyte in https://github.com/kube-vip/kube-vip/pull/730
- Minimal implementation of DualStack Services support by @p-strusiewiczsurmacki-mobica in https://github.com/kube-vip/kube-vip/pull/722
- No-leader-election mode for BGP and fixes for routing table mode by @p-strusiewiczsurmacki-mobica in https://github.com/kube-vip/kube-vip/pull/740
- fix: Using log instead of fmt.print by @ii2day in https://github.com/kube-vip/kube-vip/pull/746
- fix: print manifests to stdout by @Wielewout in https://github.com/kube-vip/kube-vip/pull/750

[v0.6.4](https://github.com/kube-vip/kube-vip/releases/tag/v0.6.4)
- Add leader election using etcd as a backend by @g-gaston in https://github.com/kube-vip/kube-vip/pull/626
- Add annotation to specify DHCP lease hostname by @shkuviak in https://github.com/kube-vip/kube-vip/pull/664
- Cleanup by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/669
- Add environment variable for routing table type by @timosluis in https://github.com/kube-vip/kube-vip/pull/606
- Added create rbac settings section for kind deployment by @hellt in https://github.com/kube-vip/kube-vip/pull/607
- Fixes to linting for routing table by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/670

[v0.6.3](https://github.com/kube-vip/kube-vip/releases/tag/v0.6.3)
- ARP: Add node labeling for ARP mode DaemonSet deployment. by @mjtrangoni in https://github.com/kube-vip/kube-vip/pull/617
- prometheus: Handle root path by @mjtrangoni in https://github.com/kube-vip/kube-vip/pull/613
- chore: Spelling fixes by @mjtrangoni in https://github.com/kube-vip/kube-vip/pull/612
- This bumps the base images for vulnerabilities by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/619
- Adds logic and debugging around fqdn endpoints by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/621
- Allow svc lock name to be configurable in arp mode. by @Willena in https://github.com/kube-vip/kube-vip/pull/622
- Enable unit and e2e tests in CI by @g-gaston in https://github.com/kube-vip/kube-vip/pull/624
- Call fatal when interface fails by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/623

[v0.6.2](https://github.com/kube-vip/kube-vip/releases/tag/v0.6.2)
- Fixes to ginko by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/593
- Some BIG OLDE e2e tests! by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/596
- This makes sure we check if a services is active by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/597
- Updating version in makefile by @jkossis in https://github.com/kube-vip/kube-vip/pull/595
- Increase client QPS to reduce clientside k8api throttling by @megakid in https://github.com/kube-vip/kube-vip/pull/575
- Fix to main by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/598
- action fix by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/599
- Fix dos through checking for remaining services before releasing ip. … by @usiegl00 in https://github.com/kube-vip/kube-vip/pull/601

[v0.6.1](https://github.com/kube-vip/kube-vip/releases/tag/v0.6.1)
- Add BGP password support for Equinix Metal by @enkelprifti98 in https://github.com/kube-vip/kube-vip/pull/565
- Add support for multiple BGP peers when using Equinix Metal annotations by @enkelprifti98 in https://github.com/kube-vip/kube-vip/pull/567
- adding iptables-wrappers script to entrypoint by @dockerpac in https://github.com/kube-vip/kube-vip/pull/502
- Revert "adding iptables-wrappers script to entrypoint" by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/569
- Check activeServiceLoadBalancerCancel is nil or not before calling it by @lubronzhan in https://github.com/kube-vip/kube-vip/pull/571
- Use configurable LeaseName instead of hardcoded by @timosluis in https://github.com/kube-vip/kube-vip/pull/573
- enable leaderelection for bgp in CP mode by @marc-cerebras in https://github.com/kube-vip/kube-vip/pull/578
- Fix makefile default target by @runsisi in https://github.com/kube-vip/kube-vip/pull/579
- Bump google.golang.org/grpc from 1.51.0 to 1.53.0 by https://github.com/dependabot in https://github.com/kube-vip/kube-vip/pull/583
- Allow specifying annotations for created Lease resources by @timosluis in https://github.com/kube-vip/kube-vip/pull/585
- Update the DHCP workflows by @rikatz in https://github.com/kube-vip/kube-vip/pull/587
- Update go dependencies by @mrueg in https://github.com/kube-vip/kube-vip/pull/576
- Fixes to e2e tests and re-enabling by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/592

[v0.6.0](https://github.com/kube-vip/kube-vip/releases/tag/v0.6.0)
- Add support for lbClassName by @W1zzardTPU in https://github.com/kube-vip/kube-vip/pull/546
- Use correct address family for ipvs destinations by @sykesm in https://github.com/kube-vip/kube-vip/pull/554
- fix LB annotations by @tuxtof in https://github.com/kube-vip/kube-vip/pull/553
- Ignore different family on IPVS delete by @sykesm in https://github.com/kube-vip/kube-vip/pull/555
- This ensures rule cleaning only happens in a NS by @thebsdbox in https://github.com/kube-vip/kube-vip/pull/558
- [feat] Add bgp metrics (bgp_session_info) by @DrBu7cher in https://github.com/kube-vip/kube-vip/pull/561
- Set iptables rules to restrict user access to ports other than the load balancer service port through the VIP by @yaocw2020 in https://github.com/kube-vip/kube-vip/pull/560
- Remove pkg/service and address items flagged by linting by @sykesm in https://github.com/kube-vip/kube-vip/pull/557
- Add annotation kube-vip.io/ignore-service-security by @yaocw2020 in https://github.com/kube-vip/kube-vip/pull/562


## Test

k8s v1.29
<img width="889" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/959f9051-3647-4511-9968-231d40290bd9">

k8s < v1.29
<img width="1151" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf/assets/19967151/6791adac-5c5b-4eda-ab8d-bfb7aff7011b">
