### PR TITLE
SKS-3010: Support custom host agent group

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	agentv1 "github.com/smartxworks/host-config-agent-api/api/v1alpha1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	cgscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
@@ -29,6 +30,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/vendor"
 )
 
 // Manager is a CAPE controller manager.
@@ -44,12 +46,13 @@ func New(ctx goctx.Context, opts Options) (Manager, error) {
 	// Ensure the default options are set.
 	opts.defaults()
 
-	_ = cgscheme.AddToScheme(opts.Scheme)
-	_ = clusterv1.AddToScheme(opts.Scheme)
-	_ = infrav1.AddToScheme(opts.Scheme)
-	_ = bootstrapv1.AddToScheme(opts.Scheme)
-	_ = controlplanev1.AddToScheme(opts.Scheme)
-	_ = agentv1.AddToScheme(opts.Scheme)
+	utilruntime.Must(cgscheme.AddToScheme(opts.Scheme))
+	utilruntime.Must(clusterv1.AddToScheme(opts.Scheme))
+	utilruntime.Must(infrav1.AddToScheme(opts.Scheme))
+	utilruntime.Must(bootstrapv1.AddToScheme(opts.Scheme))
+	utilruntime.Must(controlplanev1.AddToScheme(opts.Scheme))
+	vendor.InitHostAgentAPIGroup(&agentv1.GroupVersion, agentv1.SchemeBuilder)
+	utilruntime.Must(agentv1.AddToScheme(opts.Scheme))
 	// +kubebuilder:scaffold:scheme
 
 	// Build the controller manager.

--- a/pkg/vendor/vendor.go
+++ b/pkg/vendor/vendor.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vendor
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+func InitHostAgentAPIGroup(groupVersion *schema.GroupVersion, schemeBuilder *scheme.Builder) {
+	hostAgentAPIGroup := os.Getenv("HOST_CONFIG_AGENT_API_GROUP")
+	if hostAgentAPIGroup != "" {
+		groupVersion.Group = hostAgentAPIGroup
+		schemeBuilder.GroupVersion = *groupVersion
+	}
+}


### PR DESCRIPTION
## Issue SKS-3010

## Change

## Test
1. 没有配置 HOST_CONFIG_AGENT_API_GROUP
agentv1.GroupVersion: kubesmart.smtx.io
agentv1.SchemeBuilder.GroupVersion: kubesmart.smtx.io/v1alpha1

2. HOST_CONFIG_AGENT_API_GROUP=kubesmart.arcfra.io
agentv1.GroupVersion: kubesmart.arcfra.io
agentv1.SchemeBuilder.GroupVersion: kubesmart.arcfra.io/v1alpha1
