### PR TITLE
SKS-3173: Use cape-controller-manager ServiceAccount & fix elfMachineTemplate permissions

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 # subjects if changing service account names.
 - role.yaml
 - role_binding.yaml
+- service_account.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -129,3 +129,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - elfmachinetemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -64,6 +64,7 @@ const failedToUpsertLabelMsg = "failed to upsert label"
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/finalizers,verbs=update
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachinetemplates,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments;machinedeployments/status,verbs=get;list;watch


### PR DESCRIPTION
ticket
-
[\[SKS-3173\] \[CAPE\] cape-controller 和 cape-ip-controller 混用了 RBAC 权限 - Jira](http://jira.smartx.com/browse/SKS-3173)
cape-controller 和 cape-ip-controller 都是用 default sa，导致它们的 RBAC 混用了。

changed
-
- 使用 cape-controller-manager ServiceAccount 
- 添加 elfmachinetemplate 权限

test
-
生成的 manifests:
![image](https://github.com/user-attachments/assets/b17e4e10-4684-4b9c-8a59-656feba4bd94)
![image](https://github.com/user-attachments/assets/cad77ec1-312f-4ae4-a3bc-2cd523b3e2a8)
![image](https://github.com/user-attachments/assets/7c9e10d1-f245-400f-9f05-09bca5218c30)
在未添加 elfmachinetemplate 时修改 elfmachine，webhook 会报错无权限：
![image](https://github.com/user-attachments/assets/12e58d07-8d8e-451e-ae4e-86d26c6e2e61)
添加 elfmachinetemplate 后再修改，正确报错：
![image](https://github.com/user-attachments/assets/119e6a2c-5e3d-461e-9fc3-c5593d590cb8)
