### PR TITLE
SKS-3181: Should hook elfMachine UPDATE verbs in mutation webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -20,6 +20,7 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - elfmachines
   sideEffects: None

--- a/webhooks/elfmachine_webhook_mutation.go
+++ b/webhooks/elfmachine_webhook_mutation.go
@@ -45,7 +45,7 @@ func (m *ElfMachineMutation) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 //+kubebuilder:object:generate=false
-//+kubebuilder:webhook:verbs=create,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-elfmachine,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=elfmachines,versions=v1beta1,name=mutation.elfmachine.infrastructure.x-k8s.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-elfmachine,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=elfmachines,versions=v1beta1,name=mutation.elfmachine.infrastructure.x-k8s.io,admissionReviewVersions=v1
 
 type ElfMachineMutation struct {
 	client.Client

--- a/webhooks/elfmachine_webhook_mutation.go
+++ b/webhooks/elfmachine_webhook_mutation.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	annotationsutil "github.com/smartxworks/cluster-api-provider-elf/pkg/util/annotations"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/version"
 )
 
@@ -64,7 +65,22 @@ func (m *ElfMachineMutation) Handle(ctx goctx.Context, request admission.Request
 	}
 
 	if elfMachine.Spec.NumCoresPerSocket <= 0 {
-		elfMachine.Spec.NumCoresPerSocket = elfMachine.Spec.NumCPUs
+		// Prefer to set the value to be the same as elfMachineTemplate
+		elfMachineTemplateName := annotationsutil.GetTemplateClonedFromName(&elfMachine)
+		if elfMachineTemplateName != "" {
+			var elfMachineTemplate infrav1.ElfMachineTemplate
+			if err := m.Get(ctx, client.ObjectKey{
+				Namespace: elfMachine.Namespace,
+				Name:      annotationsutil.GetTemplateClonedFromName(&elfMachine),
+			}, &elfMachineTemplate); err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			elfMachine.Spec.NumCoresPerSocket = elfMachineTemplate.Spec.Template.Spec.NumCoresPerSocket
+		}
+		// If elfMachineTemplate also has no value, set it to be the same as NumCPUs
+		if elfMachine.Spec.NumCoresPerSocket <= 0 {
+			elfMachine.Spec.NumCoresPerSocket = elfMachine.Spec.NumCPUs
+		}
 	}
 
 	if marshaledElfMachine, err := json.Marshal(elfMachine); err != nil {

--- a/webhooks/elfmachine_webhook_validation.go
+++ b/webhooks/elfmachine_webhook_validation.go
@@ -94,7 +94,8 @@ func (v *ElfMachineValidator) ValidateUpdate(ctx goctx.Context, oldObj, newObj r
 		if elfMachine.Spec.NumCPUs != elfMachineTemplate.Spec.Template.Spec.NumCPUs {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "numCPUs"), elfMachine.Spec.NumCPUs, fmt.Sprintf(canOnlyModifiedThroughElfMachineTemplate, elfMachineTemplateName)))
 		}
-		if elfMachine.Spec.NumCoresPerSocket != elfMachineTemplate.Spec.Template.Spec.NumCoresPerSocket {
+		if elfMachine.Spec.NumCoresPerSocket != 0 && elfMachineTemplate.Spec.Template.Spec.NumCoresPerSocket != 0 &&
+			elfMachine.Spec.NumCoresPerSocket != elfMachineTemplate.Spec.Template.Spec.NumCoresPerSocket {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "numCoresPerSocket"), elfMachine.Spec.NumCoresPerSocket, fmt.Sprintf(canOnlyModifiedThroughElfMachineTemplate, elfMachineTemplateName)))
 		}
 		if elfMachine.Spec.MemoryMiB != elfMachineTemplate.Spec.Template.Spec.MemoryMiB {


### PR DESCRIPTION
问题
-
[\[SKS-3181\] \[CAPE\] elfMachine 的 mutation webhook 没有处理 UPDATE - Jira](http://jira.smartx.com/browse/SKS-3181)
elfMachine 的 mutation webhook 没有拦截 UPDATE 事件。
在部分场景下（升级 SKS），elfMachine 需要在 UPDATE 中设置默认值。

修改
-
- 给 elfMachine 的 mutation webhook 增加 UPDATE verbs
- 完善 elfMachine 的 webhook

测试
-
环境中的 webhook 正确更新:
<img width="294" alt="image" src="https://github.com/user-attachments/assets/64befc3a-b38a-45fd-bb8c-27e543ebf707">
