### PR TITLE
SKS-2999: Set WaitingForAvailableHostWithSufficientMemoryReason when no sufficient memory hosts

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -118,6 +118,15 @@ const (
 	// waiting for an available host required by placement group to create VM.
 	WaitingForAvailableHostRequiredByPlacementGroupReason = "WaitingForAvailableHostRequiredByPlacementGroup"
 
+	// SelectingGPUFailedReason (Severity=Warning) documents an ElfMachine controller detecting
+	// an error while selecting GPU; those kind of errors are usually transient and failed updating
+	// are automatically re-tried by the controller.
+	SelectingGPUFailedReason = "SelectingGPUFailed"
+
+	// WaitingForAvailableHostWithSufficientMemoryReason (Severity=Info) documents an ElfMachine
+	// waiting for an available host with sufficient memory to create VM.
+	WaitingForAvailableHostWithSufficientMemoryReason = "WaitingForAvailableHostWithSufficientMemory"
+
 	// WaitingForAvailableHostWithEnoughGPUsReason (Severity=Info) documents an ElfMachine
 	// waiting for an available host with enough GPUs to create VM.
 	WaitingForAvailableHostWithEnoughGPUsReason = "WaitingForAvailableHostWithEnoughGPUs"


### PR DESCRIPTION
## Issue
没有足够内存的主机设置的 WaitingForAvailableHostWithEnoughGPUsReason 表达的信息不够清晰

## Change
当没有足够内存的时候的时候设置 WaitingForAvailableHostWithSufficientMemoryReason

## Test
1. GPU 足够但主机内存不足
<img width="397" alt="image" src="https://github.com/user-attachments/assets/eea29c82-2bd5-4860-b8d8-007fdbf445b9">
