### PR TITLE
SKS-3242: Replace WaitingForAvailableHostWithSufficientMemory with WaitingForELFClusterWithSufficientMemory

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -123,10 +123,6 @@ const (
 	// are automatically re-tried by the controller.
 	SelectingGPUFailedReason = "SelectingGPUFailed"
 
-	// WaitingForAvailableHostWithSufficientMemoryReason (Severity=Info) documents an ElfMachine
-	// waiting for an available host with sufficient memory to create VM.
-	WaitingForAvailableHostWithSufficientMemoryReason = "WaitingForAvailableHostWithSufficientMemory"
-
 	// WaitingForAvailableHostWithEnoughGPUsReason (Severity=Info) documents an ElfMachine
 	// waiting for an available host with enough GPUs to create VM.
 	WaitingForAvailableHostWithEnoughGPUsReason = "WaitingForAvailableHostWithEnoughGPUs"

--- a/controllers/elfmachine_controller_gpu.go
+++ b/controllers/elfmachine_controller_gpu.go
@@ -59,7 +59,7 @@ func (r *ElfMachineReconciler) selectHostAndGPUsForVM(ctx goctx.Context, machine
 			conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.SelectingGPUFailedReason, clusterv1.ConditionSeverityError, reterr.Error())
 		} else if rethost == nil {
 			if availableHosts.Len() == 0 {
-				conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForAvailableHostWithSufficientMemoryReason, clusterv1.ConditionSeverityWarning, "")
+				conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForELFClusterWithSufficientMemoryReason, clusterv1.ConditionSeverityWarning, "")
 				log.V(1).Info("Waiting for enough available hosts")
 			} else {
 				conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForAvailableHostWithEnoughGPUsReason, clusterv1.ConditionSeverityInfo, "")

--- a/controllers/elfmachine_controller_gpu_test.go
+++ b/controllers/elfmachine_controller_gpu_test.go
@@ -289,7 +289,7 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 			ok, err = reconciler.reconcileGPUDevices(ctx, machineContext, vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeFalse())
-			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.WaitingForAvailableHostWithSufficientMemoryReason}})
+			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.WaitingForELFClusterWithSufficientMemoryReason}})
 		})
 
 		It("should remove GPU devices to VM when detect host are not sufficient", func() {


### PR DESCRIPTION
https://github.com/smartxworks/cluster-api-provider-elf/pull/189