### PR TITLE
improve expand_root_partition.yaml

### DIFF
--- a/pkg/hostagent/tasks/expand_root_partition.yaml
+++ b/pkg/hostagent/tasks/expand_root_partition.yaml
@@ -2,36 +2,47 @@
 - name: Expand root partition
   hosts: all
   become: true
-  gather_facts: false
+  gather_facts: true
   tasks:
-  - name: Get root path
+  - name: Set root device
+    ansible.builtin.set_fact:
+      rootdevice: >-
+        {{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}
+
+  - name: Set root partition
+    ansible.builtin.set_fact:
+      rootpartition: >-
+        {{ ansible_devices 
+           | dict2items 
+           | map(attribute='value.partitions') 
+           | map('dict2items') 
+           | flatten(1) 
+           | selectattr('value.holders', 'defined') 
+           | selectattr('value.holders', 'contains', rootdevice.split('/')[-1]) 
+           | map(attribute='key') 
+           | first }}
+
+  - name: Grow partition
     shell: |
-      . /etc/os-release
-      rootpath="/dev/mapper/rl-root"
-      if [[ $ID == 'openEuler' ]]; then
-        rootpath="/dev/mapper/openeuler-root"
-      fi
-      echo $rootpath
-    register: rootpath
-  - name: Grow vda2
-    shell: |
-      result=$(growpart /dev/vda 2)
-      if [[ $? == 0 ]]; then
+      result=$(growpart /dev/{{ rootpartition | regex_replace('[0-9]+$', '') }} {{ rootpartition | regex_search('[0-9]+$') }})
+      if [ $? -eq 0 ]; then
         echo "$result"
-      elif [[ $result == NOCHANGE* ]]; then
+      elif echo "$result" | grep -q '^NOCHANGE'; then
         echo "$result"
       else
         echo "$result"
         exit 1
       fi
-  - name: Resize vda2
-    shell: pvresize /dev/vda2
+
+  - name: Resize partition
+    shell: pvresize /dev/{{ rootpartition }}
+
   - name: Extend root
     shell: |
-      result=$(lvextend -r -l+100%FREE -n {{ rootpath.stdout }} 2>&1)
-      if [[ $? == 0 ]]; then
+      result=$(lvextend -r -l+100%FREE -n {{ rootdevice }} 2>&1)
+      if [ $? -eq 0 ]; then
         echo "$result"
-      elif [[ $result == *'matches existing size'* ]]; then
+      elif echo "$result" | grep -q 'matches existing size'; then
         echo "$result"
       else
         echo "$result"


### PR DESCRIPTION
ticket
-
[\[SKS-3327\] 原地更新 - ARM的集群，磁盘扩容，原地更新失败 - Jira](http://jira.smartx.com/browse/SKS-3327)
根因： openEuler 的根目录分区是 vda3，playbook 中写死了 vda2 导致失败：
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4d953689-5054-4895-8404-c3f42a88d708" />

changes
-
- 优化 expand_root_partition.yaml
  - 从 ansible facts 中提取根目录的挂载设备和分区
  - 调整 shell 语法，兼容 sh 

test
-
- rocky 集群磁盘热扩容成功
![image](https://github.com/user-attachments/assets/9e2e15aa-3e66-4c95-867a-af9a001ae8e6)

- openEuler 磁盘热扩容成功
![image](https://github.com/user-attachments/assets/5c9f17c4-c8f4-4739-b4cb-d83b185cdbb0)

- 手动在 Kylin 系统中测试 playbook 扩容成功
- 手动在 ubuntu 系统中测试 playbook 扩容成功
