### PR TITLE
SKS-3327: Improve root partition expanding commands in preKubeadmCommands

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -104,13 +104,10 @@ spec:
       #! to the system disk through Tower API. These commands will add the new
       #! capacity of the system disk to the root partition.
       #! - |
-      #!   . /etc/os-release
-      #!   rootpath="/dev/mapper/rl-root"
-      #!   if [[ $ID == 'openEuler' ]]; then
-      #!     rootpath="/dev/mapper/openeuler-root"
-      #!   fi
+      #!   rootdevice=$(lsblk -pnro MOUNTPOINT,NAME | awk '$1 ~ /^\/$/ { print $2 }')
+      #!   rootpartition=$(lsblk -pnro MOUNTPOINT,PKNAME | awk '$1 ~ /^\/$/ { print $2 }')
       #! - |
-      #!   result=$(growpart /dev/vda 2)
+      #!   result=$(growpart ${rootpartition%[0-9]*} ${rootpartition##*[a-z]})
       #!   if [[ $? == 0 ]]; then
       #!     echo "$result"
       #!   elif [[ $result == NOCHANGE* ]]; then
@@ -119,9 +116,9 @@ spec:
       #!     echo "$result"
       #!     exit 1
       #!   fi
-      #! - "pvresize /dev/vda2"
+      #! - "pvresize $rootpartition"
       #! - |
-      #!   result=$(lvextend -l+100%FREE -n $rootpath 2>&1)
+      #!   result=$(lvextend -l+100%FREE -n $rootdevice 2>&1)
       #!   if [[ $? == 0 ]]; then
       #!     echo "$result"
       #!   elif [[ $result == *'matches existing size'* ]]; then
@@ -277,13 +274,10 @@ spec:
       #! to the system disk through Tower API. These commands will add the new
       #! capacity of the system disk to the root partition.
       #! - |
-      #!   . /etc/os-release
-      #!   rootpath="/dev/mapper/rl-root"
-      #!   if [[ $ID == 'openEuler' ]]; then
-      #!     rootpath="/dev/mapper/openeuler-root"
-      #!   fi
+      #!   rootdevice=$(lsblk -pnro MOUNTPOINT,NAME | awk '$1 ~ /^\/$/ { print $2 }')
+      #!   rootpartition=$(lsblk -pnro MOUNTPOINT,PKNAME | awk '$1 ~ /^\/$/ { print $2 }')
       #! - |
-      #!   result=$(growpart /dev/vda 2)
+      #!   result=$(growpart ${rootpartition%[0-9]*} ${rootpartition##*[a-z]})
       #!   if [[ $? == 0 ]]; then
       #!     echo "$result"
       #!   elif [[ $result == NOCHANGE* ]]; then
@@ -292,9 +286,9 @@ spec:
       #!     echo "$result"
       #!     exit 1
       #!   fi
-      #! - "pvresize /dev/vda2"
+      #! - "pvresize $rootpartition"
       #! - |
-      #!   result=$(lvextend -l+100%FREE -n $rootpath 2>&1)
+      #!   result=$(lvextend -l+100%FREE -n $rootdevice 2>&1)
       #!   if [[ $? == 0 ]]; then
       #!     echo "$result"
       #!   elif [[ $result == *'matches existing size'* ]]; then


### PR DESCRIPTION
ticket
-
[\[SKS-3327\] 原地更新 - ARM的集群，磁盘扩容，原地更新失败 - Jira](http://jira.smartx.com/browse/SKS-3327)
https://github.com/smartxworks/cluster-api-provider-elf/pull/191 只修改了 playbook，在创建节点时指定大于模板大小的磁盘还需执行 preKubeadmCommands 中的命令。

changes
-
- 优化 templates/cluster-template.yaml 中 preKubeadmCommands 提示的扩容分区命令，适配更多不同的操作系统

test
-
- 手动测试命令：
![image](https://github.com/user-attachments/assets/a973c9b5-d753-4369-842b-de02badcb38a)
- 创建磁盘大于模板的节点成功：
<img width="1762" alt="image" src="https://github.com/user-attachments/assets/a3ec348f-c373-429e-82b8-27a88491fc0f" />

