### PR TITLE
SKS-3570: Rename vendor to product

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -30,7 +30,7 @@ import (
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
-	"github.com/smartxworks/cluster-api-provider-elf/pkg/vendor"
+	"github.com/smartxworks/cluster-api-provider-elf/pkg/product"
 )
 
 // Manager is a CAPE controller manager.
@@ -51,7 +51,7 @@ func New(ctx goctx.Context, opts Options) (Manager, error) {
 	utilruntime.Must(infrav1.AddToScheme(opts.Scheme))
 	utilruntime.Must(bootstrapv1.AddToScheme(opts.Scheme))
 	utilruntime.Must(controlplanev1.AddToScheme(opts.Scheme))
-	vendor.InitHostAgentAPIGroup(&agentv1.GroupVersion, agentv1.SchemeBuilder)
+	product.InitHostAgentAPIGroup(&agentv1.GroupVersion, agentv1.SchemeBuilder)
 	utilruntime.Must(agentv1.AddToScheme(opts.Scheme))
 	// +kubebuilder:scaffold:scheme
 

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vendor
+package product
 
 import (
 	"os"


### PR DESCRIPTION
CAPE-IP 安装 CAPE 会报错：go: finding module for package [github.com/smartxworks/cluster-api-provider-elf/pkg/vendor](http://github.com/smartxworks/cluster-api-provider-elf/pkg/vendor)
go: [github.com/smartxworks/cluster-api-provider-elf-static-ip](http://github.com/smartxworks/cluster-api-provider-elf-static-ip) imports
        [github.com/smartxworks/cluster-api-provider-elf/pkg/manager](http://github.com/smartxworks/cluster-api-provider-elf/pkg/manager) imports
        [github.com/smartxworks/cluster-api-provider-elf/pkg/vendor](http://github.com/smartxworks/cluster-api-provider-elf/pkg/vendor): module [github.com/smartxworks/cluster-api-provider-elf@latest](http://github.com/smartxworks/cluster-api-provider-elf@latest) found (v1.5.2), but does not contain package [github.com/smartxworks/cluster-api-provider-elf/pkg/vendor](http://github.com/smartxworks/cluster-api-provider-elf/pkg/vendor)

检查发现，/pkg/vendor 目录被忽略了。