### PR TITLE
Update goproxy.cn to proxy.golang.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM golang:1.23.7 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
-ARG goproxy=https://goproxy.cn,direct
+ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
 # Copy the Go Modules manifests


### PR DESCRIPTION
GitHub workflow 中打包镜像，经常报错：
#14 [builder 5/7] RUN go mod download
#14 182.1 go: github.com/onsi/ginkgo/v2@v2.23.0: read "https://goproxy.cn/github.com/onsi/ginkgo/v2/@v/v2.23.0.zip": stream error: stream ID 1381; INTERNAL_ERROR; received from peer
#14 182.1 go: k8s.io/apiextensions-apiserver@v0.30.3: read "https://goproxy.cn/k8s.io/apiextensions-apiserver/@v/v0.30.3.zip": stream error: stream ID 1405; INTERNAL_ERROR; received from peer
#14 182.1 go: k8s.io/apimachinery@v0.30.3: read "https://goproxy.cn/k8s.io/apimachinery/@v/v0.30.3.zip": stream error: stream ID 1407; INTERNAL_ERROR; received from peer