### PR TITLE
SKS-4067: Ensure virtual machines are labeled

### DIFF
--- a/controllers/tower_cache.go
+++ b/controllers/tower_cache.go
@@ -267,38 +267,6 @@ func getPGFromCache(pgName string) *models.VMPlacementGroup {
 	return nil
 }
 
-// labelCacheDuration is the lifespan of label cache.
-const labelCacheDuration = 10 * time.Minute
-
-func getKeyForLabelCache(labelKey string) string {
-	return fmt.Sprintf("label:%s:cache", labelKey)
-}
-
-// setLabelInCache saves the specified label to the memory,
-// which can reduce access to the Tower service.
-func setLabelInCache(label *models.Label) {
-	inMemoryCache.Set(getKeyForLabelCache(*label.Key), *label, labelCacheDuration)
-}
-
-// delLabelCache deletes the specified label cache.
-func delLabelCache(labelKey string) {
-	inMemoryCache.Delete(getKeyForLabelCache(labelKey))
-}
-
-// getLabelFromCache gets the specified label from the memory.
-func getLabelFromCache(labelKey string) *models.Label {
-	key := getKeyForLabelCache(labelKey)
-	if val, found := inMemoryCache.Get(key); found {
-		if label, ok := val.(models.Label); ok {
-			return &label
-		}
-		// Delete unexpected data.
-		inMemoryCache.Delete(key)
-	}
-
-	return nil
-}
-
 /* GPU */
 
 // gpuCacheDuration is the lifespan of gpu cache.

--- a/controllers/tower_cache_test.go
+++ b/controllers/tower_cache_test.go
@@ -205,20 +205,6 @@ var _ = Describe("TowerCache", func() {
 		Expect(getPGFromCache(pgName)).To(BeNil())
 	})
 
-	It("Label Cache", func() {
-		label := &models.Label{
-			ID:    service.TowerString("label-id"),
-			Key:   service.TowerString("label-key"),
-			Value: service.TowerString("label-name"),
-		}
-
-		Expect(getPGFromCache(*label.Key)).To(BeNil())
-		setLabelInCache(label)
-		Expect(getLabelFromCache(*label.Key)).To(Equal(label))
-		delLabelCache(*label.Key)
-		Expect(getLabelFromCache(*label.Key)).To(BeNil())
-	})
-
 	It("GPU Cache", func() {
 		gpuID := "gpu"
 		gpuVMInfo := models.GpuVMInfo{ID: service.TowerString(gpuID)}


### PR DESCRIPTION
## 确保 SKS VM 关联正确标签

## Changed

修改 reconcileLabels 逻辑以自动更新 SKS VM 标签。

## Test

### 删除 sks 集群 controller、worker 节点 sks-managed:true 标签。

<img width="2130" height="663" alt="企业微信截图_17603260889772" src="https://github.com/user-attachments/assets/652363e9-4a87-4d64-8b52-e630194bc758" />
<img width="499" height="296" alt="企业微信截图_17603261505999" src="https://github.com/user-attachments/assets/54e03c74-cd5a-40c6-bdb4-ce2513806352" />
<img width="482" height="260" alt="企业微信截图_17603261739761" src="https://github.com/user-attachments/assets/20fcd415-8b3a-40dd-8e5e-8279da56dd42" />

### 一段时间后被删除标签自动添加。

<img width="609" height="292" alt="企业微信截图_17603268302449" src="https://github.com/user-attachments/assets/dbcbabff-2bec-45f4-83ce-b90074231f4d" />
<img width="614" height="289" alt="企业微信截图_17603268636915" src="https://github.com/user-attachments/assets/ea1e2de4-c2ee-4802-99a6-324cfb6b38f3" />

### cape-controller-manager 日志等级配置为 3 后可看到对应标签关联日志。

<img width="2519" height="84" alt="企业微信截图_17603269216232" src="https://github.com/user-attachments/assets/8df490be-85ea-4ccc-b1f7-e5f698f2c13f" />

### 删除 sks 集群 controller、worker 节点除 sks-managed:true 外其余标签。

<img width="608" height="255" alt="企业微信截图_17603270739067" src="https://github.com/user-attachments/assets/9d80cd1c-fc50-45b9-a0c2-3ae892d074ef" />
<img width="621" height="275" alt="企业微信截图_17603270914410" src="https://github.com/user-attachments/assets/73fcae40-5606-49e3-bde5-daf914d54c70" />

### 一段时间后被删除标签自动添加。

<img width="617" height="291" alt="企业微信截图_17603278758888" src="https://github.com/user-attachments/assets/e9a59c7d-2ff1-4d64-8002-82e3b413fe79" />
<img width="623" height="293" alt="企业微信截图_17603279009714" src="https://github.com/user-attachments/assets/e9ff61a7-efc2-48bd-9d3f-598e2dd85bb2" />

### cape-controller-manager 日志等级配置为 3 后可看到对应标签关联日志。

<img width="2515" height="83" alt="企业微信截图_17603293656453" src="https://github.com/user-attachments/assets/ae5804a6-d808-420a-b17f-6be7af5d4387" />
