### PR TITLE
SKS-4198: Validate network device count in resource status check

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -275,7 +275,8 @@ func (m *ElfMachine) IsResourcesUpToDate() bool {
 	specMemory := *resource.NewQuantity(m.Spec.MemoryMiB*1024*1024, resource.BinarySI)
 	return m.Spec.DiskGiB == m.Status.Resources.Disk &&
 		m.Spec.NumCPUs == m.Status.Resources.CPUCores &&
-		specMemory.Equal(m.Status.Resources.Memory)
+		specMemory.Equal(m.Status.Resources.Memory) &&
+		len(m.Spec.Network.Devices) == len(m.Status.Network)
 }
 
 func (m *ElfMachine) SetVMDisconnectionTimestamp(timestamp *metav1.Time) {

--- a/api/v1beta1/elfmachine_types_test.go
+++ b/api/v1beta1/elfmachine_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestLimitDNSServers(t *testing.T) {
@@ -46,6 +47,157 @@ func TestLimitDNSServers(t *testing.T) {
 			elfMachine.Spec.Network.Devices = tc.devices
 			dnsServers := elfMachine.GetLimitedNameservers(3)
 			g.Expect(dnsServers).To(gomega.Equal(tc.expected))
+		})
+	}
+}
+
+func TestIsResourcesUpToDate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	testCases := []struct {
+		name     string
+		machine  *ElfMachine
+		expected bool
+	}{
+		{
+			name: "all resources match",
+			machine: &ElfMachine{
+				Spec: ElfMachineSpec{
+					NumCPUs:   int32(4),
+					MemoryMiB: int64(8192),
+					DiskGiB:   int32(50),
+					Network: NetworkSpec{
+						Devices: []NetworkDeviceSpec{
+							{NetworkType: NetworkTypeIPV4DHCP},
+							{NetworkType: NetworkTypeIPV4DHCP},
+						},
+					},
+				},
+				Status: ElfMachineStatus{
+					Resources: ResourcesStatus{
+						CPUCores: int32(4),
+						Memory:   *resource.NewQuantity(8192*1024*1024, resource.BinarySI),
+						Disk:     int32(50),
+					},
+					Network: []NetworkStatus{
+						{IPAddrs: []string{"10.0.0.1"}},
+						{IPAddrs: []string{"10.0.0.2"}},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "CPU cores mismatch",
+			machine: &ElfMachine{
+				Spec: ElfMachineSpec{
+					NumCPUs:   int32(4),
+					MemoryMiB: int64(8192),
+					DiskGiB:   int32(50),
+					Network: NetworkSpec{
+						Devices: []NetworkDeviceSpec{
+							{NetworkType: NetworkTypeIPV4DHCP},
+						},
+					},
+				},
+				Status: ElfMachineStatus{
+					Resources: ResourcesStatus{
+						CPUCores: int32(8),
+						Memory:   *resource.NewQuantity(8192*1024*1024, resource.BinarySI),
+						Disk:     int32(50),
+					},
+					Network: []NetworkStatus{
+						{IPAddrs: []string{"10.0.0.1"}},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "memory mismatch",
+			machine: &ElfMachine{
+				Spec: ElfMachineSpec{
+					NumCPUs:   int32(4),
+					MemoryMiB: int64(8192),
+					DiskGiB:   int32(50),
+					Network: NetworkSpec{
+						Devices: []NetworkDeviceSpec{
+							{NetworkType: NetworkTypeIPV4DHCP},
+						},
+					},
+				},
+				Status: ElfMachineStatus{
+					Resources: ResourcesStatus{
+						CPUCores: int32(4),
+						Memory:   *resource.NewQuantity(16384*1024*1024, resource.BinarySI),
+						Disk:     int32(50),
+					},
+					Network: []NetworkStatus{
+						{IPAddrs: []string{"10.0.0.1"}},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "disk mismatch",
+			machine: &ElfMachine{
+				Spec: ElfMachineSpec{
+					NumCPUs:   int32(4),
+					MemoryMiB: int64(8192),
+					DiskGiB:   int32(50),
+					Network: NetworkSpec{
+						Devices: []NetworkDeviceSpec{
+							{NetworkType: NetworkTypeIPV4DHCP},
+						},
+					},
+				},
+				Status: ElfMachineStatus{
+					Resources: ResourcesStatus{
+						CPUCores: int32(4),
+						Memory:   *resource.NewQuantity(8192*1024*1024, resource.BinarySI),
+						Disk:     int32(100),
+					},
+					Network: []NetworkStatus{
+						{IPAddrs: []string{"10.0.0.1"}},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "network devices count mismatch",
+			machine: &ElfMachine{
+				Spec: ElfMachineSpec{
+					NumCPUs:   int32(4),
+					MemoryMiB: int64(8192),
+					DiskGiB:   int32(50),
+					Network: NetworkSpec{
+						Devices: []NetworkDeviceSpec{
+							{NetworkType: NetworkTypeIPV4DHCP},
+							{NetworkType: NetworkTypeIPV4DHCP},
+						},
+					},
+				},
+				Status: ElfMachineStatus{
+					Resources: ResourcesStatus{
+						CPUCores: int32(4),
+						Memory:   *resource.NewQuantity(8192*1024*1024, resource.BinarySI),
+						Disk:     int32(50),
+					},
+					Network: []NetworkStatus{
+						{IPAddrs: []string{"10.0.0.1"}},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.machine.IsResourcesUpToDate()
+			g.Expect(result).To(gomega.Equal(tc.expected))
 		})
 	}
 }


### PR DESCRIPTION
ticket
-
[\[SKS-4198\] ElfMachine 未完成热更新，但 IUM 判断已经成功 - Jira](http://jira.smartx.com/browse/SKS-4198)

change
- IsResourcesUpToDate 方法中增加网卡数量的比较判断，用于在热添加网卡时精确判断热更新流程状态

test
-
优化后，IUM 可以正确等待 elfMachine 热添加网卡结束才标记原地更新结束：
<img width="3298" height="824" alt="image" src="https://github.com/user-attachments/assets/9a270258-5451-48af-bed7-0e9698fd460a" />

<img width="2566" height="266" alt="image" src="https://github.com/user-attachments/assets/1eb190a6-f4fb-49fc-8427-163cf48f62e3" />

<img width="740" height="774" alt="image" src="https://github.com/user-attachments/assets/68f30235-bed2-40fb-a6ad-42eafae067fc" />

<img width="730" height="342" alt="image" src="https://github.com/user-attachments/assets/4393c93e-6523-446a-a61b-00d315723f04" />
