### PR TITLE
SKS-4235: Toleration labels deletion failed

### DIFF
--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -204,9 +204,7 @@ func (r *ElfClusterReconciler) reconcileDelete(ctx goctx.Context, clusterCtx *co
 			return reconcile.Result{RequeueAfter: config.Cape.DefaultRequeueTimeout}, nil
 		}
 
-		if err := r.reconcileDeleteLabels(ctx, clusterCtx); err != nil {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to delete labels")
-		}
+		r.reconcileDeleteLabels(ctx, clusterCtx)
 	}
 
 	// Cluster is deleted so remove the finalizer.
@@ -235,24 +233,24 @@ func (r *ElfClusterReconciler) reconcileDeleteVMPlacementGroups(ctx goctx.Contex
 	return true, nil
 }
 
-func (r *ElfClusterReconciler) reconcileDeleteLabels(ctx goctx.Context, clusterCtx *context.ClusterContext) error {
+func (r *ElfClusterReconciler) reconcileDeleteLabels(ctx goctx.Context, clusterCtx *context.ClusterContext) {
+	log := ctrl.LoggerFrom(ctx)
+
 	if err := r.reconcileDeleteLabel(ctx, clusterCtx, towerresources.GetVMLabelClusterName(), clusterCtx.ElfCluster.Name, true); err != nil {
-		return err
+		log.Error(err, "failed to delete label", "key", towerresources.GetVMLabelClusterName(), "value", clusterCtx.ElfCluster.Name)
 	}
 
 	if err := r.reconcileDeleteLabel(ctx, clusterCtx, towerresources.GetVMLabelVIP(), clusterCtx.ElfCluster.Spec.ControlPlaneEndpoint.Host, false); err != nil {
-		return err
+		log.Error(err, "failed to delete label", "key", towerresources.GetVMLabelVIP(), "value", clusterCtx.ElfCluster.Spec.ControlPlaneEndpoint.Host)
 	}
 
 	if err := r.reconcileDeleteLabel(ctx, clusterCtx, towerresources.GetVMLabelNamespace(), clusterCtx.ElfCluster.Namespace, true); err != nil {
-		return err
+		log.Error(err, "failed to delete label", "key", towerresources.GetVMLabelNamespace(), "value", clusterCtx.ElfCluster.Namespace)
 	}
 
 	if err := r.reconcileDeleteLabel(ctx, clusterCtx, towerresources.GetVMLabelManaged(), "true", true); err != nil {
-		return err
+		log.Error(err, "failed to delete label", "key", towerresources.GetVMLabelManaged(), "value", "true")
 	}
-
-	return nil
 }
 
 func (r *ElfClusterReconciler) reconcileDeleteLabel(ctx goctx.Context, clusterCtx *context.ClusterContext, key, value string, strict bool) error {


### PR DESCRIPTION
## 容忍标签删除失败

## Changed

删除集群时若标签删除失败仅在日志中报错，不阻塞集群删除。

## Test
部署 tower+er+sks，新建工作负载集群。
<img width="1209" height="290" alt="企业微信截图_df800d1a-8d22-48ec-a0a4-94453de0431c" src="https://github.com/user-attachments/assets/27fd45bf-b430-4ad8-ba99-5e0a22e65f0e" />
创建 er 安全策略，引用工作负载集群虚拟机标签。
<img width="1393" height="361" alt="企业微信截图_cf12a4cd-ded5-44ed-879d-ad1ec3425628" src="https://github.com/user-attachments/assets/ffd475ce-f007-4531-ad40-68eb05a570ef" />
删除工作负载集群，集群删除成功。
<img width="1468" height="292" alt="企业微信截图_fbb48de3-16cb-45c5-9839-07c5d0b22a4f" src="https://github.com/user-attachments/assets/d348c14d-3750-44ef-90a3-c77b58ed6655" />
<img width="1093" height="386" alt="企业微信截图_b449e8eb-8441-4df9-9756-bdc58027dba0" src="https://github.com/user-attachments/assets/640d4971-87c2-4eb1-a77f-2ec17b633026" />
cape-controller-manager pod 日志中报错标签删除失败。
<img width="1402" height="238" alt="企业微信截图_afc3ff82-e8c8-4e29-aef3-93a857f308c6" src="https://github.com/user-attachments/assets/0e51761b-e519-4009-8690-7a7633b9c8c6" />

创建 er 安全策略，引用 sks 管控集群虚拟机标签。
<img width="1479" height="381" alt="企业微信截图_2c8e6f73-2823-4619-b8f6-2205379829e3" src="https://github.com/user-attachments/assets/4e83431b-5d13-47f1-a7fb-a7e2d591e19a" />
卸载 sks 服务，服务卸载成功。
<img width="1584" height="778" alt="企业微信截图_9262ba61-8112-4926-abee-2c4d95514eea" src="https://github.com/user-attachments/assets/075af29f-37e9-4655-9d42-7791157901b2" />
<img width="1148" height="582" alt="企业微信截图_8b4afa5b-e13b-4b3b-ad23-263e6ca8bfdb" src="https://github.com/user-attachments/assets/275706c1-2185-4993-93ab-440f54aa7cbf" />
