### PR TITLE
SKS-4644: Support hostNamePrefix

### DIFF
--- a/api/v1beta1/elfmachine_types.go
+++ b/api/v1beta1/elfmachine_types.go
@@ -59,6 +59,13 @@ type ElfMachineSpec struct {
 	// FailureDomains is a list of failure domain objects.
 	FailureDomains []CloudFailureDomain `json:"failureDomains,omitempty"`
 
+	// HostNamePrefix is the prefix of the hostname for nodes in this machine.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=57
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$`
+	// +optional
+	HostNamePrefix string `json:"hostNamePrefix,omitempty"`
+
 	// Template is the name or ID of the template used to clone new machines.
 	Template string `json:"template"`
 
@@ -68,7 +75,7 @@ type ElfMachineSpec struct {
 	// +optional
 	OSType string `json:"osType,omitempty"`
 
-	// Network is the network configuration for this machin's VM.
+	// Network is the network configuration for this machine's VM.
 	// +optional
 	Network NetworkSpec `json:"network,omitempty"`
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -325,4 +325,11 @@ type CloudFailureDomain struct {
 	// Network is the network configuration.
 	// +optional
 	Network NetworkSpec `json:"network,omitempty"`
+
+	// HostNamePrefix is the prefix of the hostname for nodes in this failure domain.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=57
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$`
+	// +optional
+	HostNamePrefix string `json:"hostNamePrefix,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachines.yaml
@@ -94,6 +94,13 @@ spec:
                       description: computeCluster as the failure domain
                       minLength: 1
                       type: string
+                    hostNamePrefix:
+                      description: HostNamePrefix is the prefix of the hostname for
+                        nodes in this failure domain.
+                      maxLength: 57
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$
+                      type: string
                     network:
                       description: Network is the network configuration.
                       properties:
@@ -249,11 +256,18 @@ spec:
                   Required when cloneMode is FullClone.
                   Defaults to AUTO_SCHEDULE.
                 type: string
+              hostNamePrefix:
+                description: HostNamePrefix is the prefix of the hostname for nodes
+                  in this machine.
+                maxLength: 57
+                minLength: 1
+                pattern: ^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$
+                type: string
               memoryMiB:
                 format: int64
                 type: integer
               network:
-                description: Network is the network configuration for this machin's
+                description: Network is the network configuration for this machine's
                   VM.
                 properties:
                   devices:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elfmachinetemplates.yaml
@@ -70,6 +70,13 @@ spec:
                               description: computeCluster as the failure domain
                               minLength: 1
                               type: string
+                            hostNamePrefix:
+                              description: HostNamePrefix is the prefix of the hostname
+                                for nodes in this failure domain.
+                              maxLength: 57
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$
+                              type: string
                             network:
                               description: Network is the network configuration.
                               properties:
@@ -228,12 +235,19 @@ spec:
                           Required when cloneMode is FullClone.
                           Defaults to AUTO_SCHEDULE.
                         type: string
+                      hostNamePrefix:
+                        description: HostNamePrefix is the prefix of the hostname
+                          for nodes in this machine.
+                        maxLength: 57
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[-A-Za-z0-9]*[A-Za-z0-9])?)*$
+                        type: string
                       memoryMiB:
                         format: int64
                         type: integer
                       network:
                         description: Network is the network configuration for this
-                          machin's VM.
+                          machine's VM.
                         properties:
                           devices:
                             description: Devices is the list of network devices used

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1636,6 +1636,8 @@ func (r *ElfMachineReconciler) reconcileFailureDomain(ctx goctx.Context, machine
 	return true
 }
 
+// getNode gets the K8s Node corresponding to the VM by providerID.
+// ref: https://github.com/kubernetes-sigs/cluster-api/blob/7043215020b378a110ecd2c10782a5ca58d5456b/internal/controllers/machine/machine_controller_noderef.go#L218-L245.
 func (r *ElfMachineReconciler) getNode(ctx goctx.Context, c client.Reader, providerID string) (*corev1.Node, error) {
 	nodeList := corev1.NodeList{}
 	if err := c.List(ctx, &nodeList, client.MatchingFields{index.NodeProviderIDField: providerID}); err != nil {

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/api/v1beta1/index"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -62,6 +64,8 @@ import (
 
 const failedToUpsertLabelMsg = "failed to upsert label"
 
+var ErrNodeNotFound = errors.New("cannot find node with matching ProviderID")
+
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/finalizers,verbs=update
@@ -76,11 +80,12 @@ const failedToUpsertLabelMsg = "failed to upsert label"
 type ElfMachineReconciler struct {
 	*context.ControllerManagerContext
 	NewVMService service.NewVMServiceFunc
+	ClusterCache clustercache.ClusterCache
 }
 
 // AddMachineControllerToManager adds the machine controller to the provided
 // manager.
-func AddMachineControllerToManager(ctx goctx.Context, ctrlMgrCtx *context.ControllerManagerContext, mgr ctrlmgr.Manager, options controller.Options) error {
+func AddMachineControllerToManager(ctx goctx.Context, ctrlMgrCtx *context.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache, options controller.Options) error {
 	var (
 		controlledType     = &infrav1.ElfMachine{}
 		controlledTypeName = reflect.TypeOf(controlledType).Elem().Name()
@@ -90,6 +95,7 @@ func AddMachineControllerToManager(ctx goctx.Context, ctrlMgrCtx *context.Contro
 	reconciler := &ElfMachineReconciler{
 		ControllerManagerContext: ctrlMgrCtx,
 		NewVMService:             service.NewVMService,
+		ClusterCache:             clusterCache,
 	}
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "elfmachine")
 
@@ -298,7 +304,7 @@ func (r *ElfMachineReconciler) reconcileDeleteVM(ctx goctx.Context, machineCtx *
 	}
 
 	// Before destroying VM, attempt to delete kubernetes node.
-	err = r.deleteNode(ctx, machineCtx, machineCtx.ElfMachine.Name)
+	err = r.deleteNode(ctx, machineCtx)
 	if err != nil {
 		return err
 	}
@@ -492,14 +498,8 @@ func (r *ElfMachineReconciler) reconcileNormal(ctx goctx.Context, machineCtx *co
 	machineCtx.ElfMachine.Status.Ready = true
 	conditions.MarkTrue(machineCtx.ElfMachine, infrav1.VMProvisionedCondition)
 
-	if ok, err := r.reconcileNode(ctx, machineCtx, vm); !ok {
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		log.Info("Node providerID is not reconciled")
-
-		return reconcile.Result{RequeueAfter: config.Cape.DefaultRequeueTimeout}, nil
+	if err := r.reconcileNode(ctx, machineCtx, vm); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	if result, err := r.deleteDuplicateVMs(ctx, machineCtx); err != nil || !result.IsZero() {
@@ -531,7 +531,9 @@ func (r *ElfMachineReconciler) reconcileVM(ctx goctx.Context, machineCtx *contex
 			conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.CloningReason, clusterv1.ConditionSeverityInfo, "")
 		}
 
-		bootstrapData, err := r.getBootstrapData(ctx, machineCtx)
+		hostName := machineCtx.GenerateHostname()
+
+		bootstrapData, err := r.getBootstrapData(ctx, machineCtx, hostName)
 		if err != nil {
 			conditions.MarkFalse(machineCtx.ElfMachine, infrav1.VMProvisionedCondition, infrav1.CloningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 
@@ -576,12 +578,13 @@ func (r *ElfMachineReconciler) reconcileVM(ctx goctx.Context, machineCtx *contex
 			}
 		}
 
-		log.Info("Create VM for ElfMachine")
+		log.Info("Create VM for ElfMachine", "hostName", hostName)
 		vmInfo := &service.CloneVMInfo{
 			Cluster:    machineCtx.GetElfClusterID(),
 			Host:       service.GetTowerString(hostID),
 			CloudInit:  bootstrapData,
 			GPUDevices: gpuDeviceInfos,
+			HostName:   hostName,
 		}
 		withTaskVM, err := machineCtx.VMService.Clone(machineCtx.ElfCluster, machineCtx.ElfMachine, vmInfo)
 		if err != nil {
@@ -1088,7 +1091,7 @@ func (r *ElfMachineReconciler) reconcileHostAndZone(ctx goctx.Context, machineCt
 
 	if vm.Cluster != nil {
 		clusterStatus := infrav1.ComputeClusterStatus{
-			ClusterID: service.GetTowerString(vm.Cluster.Name),
+			ClusterID: service.GetTowerString(vm.Cluster.ID),
 			Name:      service.GetTowerString(vm.Cluster.Name),
 		}
 		if !clusterStatus.Equal(&machineCtx.ElfMachine.Status.ComputeCluster) {
@@ -1152,12 +1155,12 @@ func (r *ElfMachineReconciler) reconcileProviderID(ctx goctx.Context, machineCtx
 }
 
 // reconcileNode sets providerID and host server labels for node.
-func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *context.MachineContext, vm *models.VM) (bool, error) {
+func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *context.MachineContext, vm *models.VM) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 	if providerID == "" {
-		return false, errors.Errorf("invalid VM UUID %s from %s %s/%s for %s",
+		return errors.Errorf("invalid VM UUID %s from %s %s/%s for %s",
 			*vm.LocalID,
 			machineCtx.ElfCluster.GroupVersionKind(),
 			machineCtx.ElfCluster.GetNamespace(),
@@ -1165,14 +1168,14 @@ func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *cont
 			ctx)
 	}
 
-	kubeClient, err := util.NewKubeClient(ctx, r.Client, machineCtx.Cluster)
+	remoteClient, err := r.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(machineCtx.Cluster))
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
+		return errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
 	}
 
-	node, err := kubeClient.CoreV1().Nodes().Get(ctx, machineCtx.ElfMachine.Name, metav1.GetOptions{})
+	node, err := r.getNode(ctx, remoteClient, providerID)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get node %s for setting providerID and labels", machineCtx.ElfMachine.Name)
+		return errors.Wrapf(err, "failed to get node by providerID %s", providerID)
 	}
 
 	keys := []string{
@@ -1243,8 +1246,8 @@ func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *cont
 		expectedLabels[labelsutil.ClusterAutoscalerCAPIGPULabel] = nil
 	}
 
-	if node.Spec.ProviderID != "" && reflect.DeepEqual(actualLabels, expectedLabels) {
-		return true, nil
+	if reflect.DeepEqual(actualLabels, expectedLabels) {
+		return nil
 	}
 
 	payloads := map[string]interface{}{
@@ -1252,26 +1255,20 @@ func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *cont
 			"labels": expectedLabels,
 		},
 	}
-	// providerID cannot be modified after setting a valid value.
-	if node.Spec.ProviderID == "" {
-		payloads["spec"] = map[string]interface{}{
-			"providerID": providerID,
-		}
-	}
 
 	payloadBytes, err := json.Marshal(payloads)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	_, err = kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, apitypes.MergePatchType, payloadBytes, metav1.PatchOptions{})
+	err = remoteClient.Patch(ctx, node, client.RawPatch(apitypes.MergePatchType, payloadBytes))
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	log.Info("Setting node providerID and labels succeeded", "providerID", providerID, "labels", expectedLabels)
+	log.Info("Setting node labels succeeded", "labels", expectedLabels)
 
-	return true, nil
+	return nil
 }
 
 // Ensure all the VM's NICs that need IP have obtained IP addresses and VM network ready, otherwise requeue.
@@ -1329,7 +1326,7 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx goctx.Context, machineCtx *c
 
 	if len(ipToMachineAddressMap) < len(networkDevicesWithIP) {
 		// Try to get VM NIC IP address from the K8s Node.
-		nodeIP, err := r.getK8sNodeIP(ctx, machineCtx, machineCtx.ElfMachine.Name)
+		nodeIP, err := r.getK8sNodeIP(ctx, machineCtx)
 		if err == nil && nodeIP != "" {
 			ipToMachineAddressMap[nodeIP] = clusterv1.MachineAddress{
 				Address: nodeIP,
@@ -1364,7 +1361,7 @@ func (r *ElfMachineReconciler) reconcileNetwork(ctx goctx.Context, machineCtx *c
 	return true, nil
 }
 
-func (r *ElfMachineReconciler) getBootstrapData(ctx goctx.Context, machineCtx *context.MachineContext) (string, error) {
+func (r *ElfMachineReconciler) getBootstrapData(ctx goctx.Context, machineCtx *context.MachineContext, hostName string) (string, error) {
 	secret := &corev1.Secret{}
 	secretKey := apitypes.NamespacedName{
 		Namespace: machineCtx.Machine.Namespace,
@@ -1380,7 +1377,7 @@ func (r *ElfMachineReconciler) getBootstrapData(ctx goctx.Context, machineCtx *c
 		return "", errors.New("error retrieving bootstrap data: secret value key is missing")
 	}
 
-	return string(value), nil
+	return patchCloudInitBootstrapData(ctx, string(value), cloudInitMutationContext{hostName: hostName})
 }
 
 func (r *ElfMachineReconciler) reconcileLabels(ctx goctx.Context, machineCtx *context.MachineContext, vm *models.VM) (bool, error) {
@@ -1441,7 +1438,7 @@ func (r *ElfMachineReconciler) isWaitingForStaticIPAllocation(machineCtx *contex
 // This is necessary since CAPI does not set the nodeRef field on the owner Machine object
 // until the node moves to Ready state. Hence, on Machine deletion it is unable to delete
 // the kubernetes node corresponding to the VM.
-func (r *ElfMachineReconciler) deleteNode(ctx goctx.Context, machineCtx *context.MachineContext, nodeName string) error {
+func (r *ElfMachineReconciler) deleteNode(ctx goctx.Context, machineCtx *context.MachineContext) error {
 	// When the cluster needs to be deleted, there is no need to delete the k8s node.
 	if machineCtx.Cluster.DeletionTimestamp != nil {
 		return nil
@@ -1452,39 +1449,47 @@ func (r *ElfMachineReconciler) deleteNode(ctx goctx.Context, machineCtx *context
 		return nil
 	}
 
-	kubeClient, err := util.NewKubeClient(ctx, r.Client, machineCtx.Cluster)
+	remoteClient, err := r.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(machineCtx.Cluster))
 	if err != nil {
 		return errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
 	}
 
+	node, err := r.getNode(ctx, remoteClient, *machineCtx.ElfMachine.Spec.ProviderID)
+	if err != nil {
+		if err == ErrNodeNotFound {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to get node by providerID %s", *machineCtx.ElfMachine.Spec.ProviderID)
+	}
+
 	// Attempt to delete the corresponding node.
-	err = kubeClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	err = remoteClient.Delete(ctx, node)
 	// k8s node is already deleted.
 	if err != nil && apierrors.IsNotFound(err) {
 		return nil
 	}
 
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete K8s node %s for Cluster %s/", nodeName, klog.KObj(machineCtx.Cluster))
+		return errors.Wrapf(err, "failed to delete K8s node %s for Cluster %s/", node.Name, klog.KObj(machineCtx.Cluster))
 	}
 
 	return nil
 }
 
 // getK8sNodeIP get the default network IP of K8s Node.
-func (r *ElfMachineReconciler) getK8sNodeIP(ctx goctx.Context, machineCtx *context.MachineContext, nodeName string) (string, error) {
-	kubeClient, err := util.NewKubeClient(ctx, r.Client, machineCtx.Cluster)
+func (r *ElfMachineReconciler) getK8sNodeIP(ctx goctx.Context, machineCtx *context.MachineContext) (string, error) {
+	if machineCtx.ElfMachine.Spec.ProviderID == nil {
+		return "", nil
+	}
+
+	remoteClient, err := r.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(machineCtx.Cluster))
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
 	}
 
-	k8sNode, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		return "", nil
-	}
-
+	k8sNode, err := r.getNode(ctx, remoteClient, *machineCtx.ElfMachine.Spec.ProviderID)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get K8s Node %s for Cluster %s", nodeName, klog.KObj(machineCtx.Cluster))
+		return "", errors.Wrapf(err, "failed to get node by providerID %s", *machineCtx.ElfMachine.Spec.ProviderID)
 	}
 
 	if len(k8sNode.Status.Addresses) == 0 {
@@ -1629,4 +1634,32 @@ func (r *ElfMachineReconciler) reconcileFailureDomain(ctx goctx.Context, machine
 	}
 
 	return true
+}
+
+func (r *ElfMachineReconciler) getNode(ctx goctx.Context, c client.Reader, providerID string) (*corev1.Node, error) {
+	nodeList := corev1.NodeList{}
+	if err := c.List(ctx, &nodeList, client.MatchingFields{index.NodeProviderIDField: providerID}); err != nil {
+		return nil, err
+	}
+	if len(nodeList.Items) == 0 {
+		// If for whatever reason the index isn't registered or available, we fallback to loop over the whole list.
+		nl := corev1.NodeList{}
+		if err := c.List(ctx, &nl); err != nil {
+			return nil, err
+		}
+
+		for _, node := range nl.Items {
+			if providerID == node.Spec.ProviderID {
+				return &node, nil
+			}
+		}
+
+		return nil, ErrNodeNotFound
+	}
+
+	if len(nodeList.Items) != 1 {
+		return nil, fmt.Errorf("unexpectedly found more than one Node matching the providerID %s", providerID)
+	}
+
+	return &nodeList.Items[0], nil
 }

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1154,7 +1154,7 @@ func (r *ElfMachineReconciler) reconcileProviderID(ctx goctx.Context, machineCtx
 	return nil
 }
 
-// reconcileNode sets providerID and host server labels for node.
+// reconcileNode sets labels on the corresponding K8s Node according to the VM information.
 func (r *ElfMachineReconciler) reconcileNode(ctx goctx.Context, machineCtx *context.MachineContext, vm *models.VM) error {
 	log := ctrl.LoggerFrom(ctx)
 

--- a/controllers/elfmachine_controller_cloudinit.go
+++ b/controllers/elfmachine_controller_cloudinit.go
@@ -1,0 +1,426 @@
+package controllers
+
+import (
+	"bytes"
+	goctx "context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	kubeadmAPIVersionV1Beta3 = "kubeadm.k8s.io/v1beta3"
+	kubeadmAPIVersionV1Beta4 = "kubeadm.k8s.io/v1beta4"
+	kubeadmProviderIDValue   = "elf://{{ ds.meta_data.instance_id }}"
+)
+
+type cloudInitMutationContext struct {
+	hostName string
+}
+
+type cloudInitMutator func(root *yaml.Node, mutationCtx cloudInitMutationContext) (bool, error)
+
+var cloudInitMutators = []cloudInitMutator{
+	ensureHostnameCommandsInRunCmd,
+	ensureKubeadmConfigInWriteFiles,
+}
+
+func patchCloudInitBootstrapData(ctx goctx.Context, bootstrapData string, mutationCtx cloudInitMutationContext) (data string, err error) {
+	changed := false
+
+	defer func() {
+		if err == nil && changed {
+			log := ctrl.LoggerFrom(ctx)
+			log.V(3).Info("patched cloud-init bootstrap data", "hostname", mutationCtx.hostName)
+		}
+	}()
+	header, body := splitCloudConfigHeader(bootstrapData)
+
+	root, ok := parseYAMLMapping(body)
+	if !ok {
+		// Keep passthrough behavior for bootstrap formats we do not explicitly support.
+		return bootstrapData, nil
+	}
+
+	for _, mutator := range cloudInitMutators {
+		updated, err := mutator(root, mutationCtx)
+		if err != nil {
+			return "", err
+		}
+		if updated {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return bootstrapData, nil
+	}
+
+	marshaled, err := yaml.Marshal(root)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal bootstrap data after mutating cloud-init")
+	}
+
+	if header == "" {
+		return string(marshaled), nil
+	}
+
+	return header + "\n" + string(marshaled), nil
+}
+
+func ensureHostnameCommandsInRunCmd(root *yaml.Node, mutationCtx cloudInitMutationContext) (bool, error) {
+	if mutationCtx.hostName == "" {
+		return false, nil
+	}
+
+	runcmd := findYAMLMapValue(root, "runcmd")
+	desiredCommands := []string{
+		`echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts`,
+		`echo "127.0.0.1   localhost" >>/etc/hosts`,
+		fmt.Sprintf(`echo "127.0.0.1   %s" >>/etc/hosts`, mutationCtx.hostName),
+	}
+	runcmd.Content = append(newScalarNodes(desiredCommands), runcmd.Content...)
+
+	return true, nil
+}
+
+func ensureKubeadmConfigInWriteFiles(root *yaml.Node, mutationCtx cloudInitMutationContext) (bool, error) {
+	writeFiles := findYAMLMapValue(root, "write_files")
+	if writeFiles == nil || writeFiles.Kind != yaml.SequenceNode {
+		return false, nil
+	}
+
+	changed := false
+	for _, item := range writeFiles.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+
+		path := findYAMLMapValue(item, "path")
+		content := findYAMLMapValue(item, "content")
+		if path == nil || content == nil || !isKubeadmConfigWriteFile(path.Value) {
+			continue
+		}
+
+		updated, err := ensureKubeadmConfigContent(content, mutationCtx.hostName)
+		if err != nil {
+			return false, err
+		}
+		if updated {
+			changed = true
+		}
+	}
+
+	return changed, nil
+}
+
+func ensureKubeadmConfigContent(content *yaml.Node, hostname string) (bool, error) {
+	if content.Kind != yaml.ScalarNode || (content.Tag != "" && content.Tag != "!!str") {
+		return false, nil
+	}
+
+	header, body := splitYAMLDocumentHeader(content.Value)
+	documents, ok := parseYAMLDocuments(body)
+	if !ok {
+		return false, nil
+	}
+
+	if !ensureKubeadmNodeRegistrationDocuments(documents, hostname) {
+		return false, nil
+	}
+
+	marshaled, err := marshalYAMLDocuments(documents, header)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to marshal kubeadm config after ensuring provider-id")
+	}
+
+	content.Tag = "!!str"
+	content.Value = marshaled
+
+	return true, nil
+}
+
+func ensureKubeadmNodeRegistrationDocuments(documents []*yaml.Node, hostname string) bool {
+	changed := false
+	for _, document := range documents {
+		if !isKubeadmNodeRegistrationDocument(document) {
+			continue
+		}
+
+		if ensureKubeadmNodeRegistration(document, hostname) {
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func isKubeadmNodeRegistrationDocument(root *yaml.Node) bool {
+	switch getYAMLMapString(root, "kind") {
+	case "InitConfiguration", "JoinConfiguration":
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureKubeadmNodeRegistration(root *yaml.Node, hostname string) bool {
+	changed := false
+	nodeRegistration, _ := ensureYAMLMappingValue(root, "nodeRegistration")
+	if ensureKubeletProviderID(root, nodeRegistration) {
+		changed = true
+	}
+
+	return changed
+}
+
+func ensureKubeletProviderID(root, nodeRegistration *yaml.Node) bool {
+	kubeletExtraArgs := findYAMLMapValue(nodeRegistration, "kubeletExtraArgs")
+	if kubeletExtraArgs == nil {
+		switch getYAMLMapString(root, "apiVersion") {
+		case kubeadmAPIVersionV1Beta3:
+			kubeletExtraArgs = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			appendYAMLMapValue(nodeRegistration, "kubeletExtraArgs", kubeletExtraArgs)
+		case kubeadmAPIVersionV1Beta4:
+			kubeletExtraArgs = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+			appendYAMLMapValue(nodeRegistration, "kubeletExtraArgs", kubeletExtraArgs)
+		default:
+			return false
+		}
+	}
+
+	switch kubeletExtraArgs.Kind {
+	case yaml.MappingNode: // kubeadm.k8s.io/v1beta3
+		return upsertYAMLMapString(kubeletExtraArgs, "provider-id", kubeadmProviderIDValue)
+	case yaml.SequenceNode: // kubeadm.k8s.io/v1beta4
+		return upsertNamedValueSequenceItem(kubeletExtraArgs, "provider-id", kubeadmProviderIDValue)
+	default:
+		return false
+	}
+}
+
+func splitCloudConfigHeader(data string) (string, string) {
+	lines := strings.Split(data, "\n")
+	if len(lines) == 0 {
+		return "", data
+	}
+
+	index := 0
+	header := make([]string, 0, 2)
+	if strings.TrimSpace(lines[index]) == "## template: jinja" {
+		header = append(header, lines[index])
+		index++
+	}
+
+	if index >= len(lines) || strings.TrimSpace(lines[index]) != "#cloud-config" {
+		return "", data
+	}
+
+	header = append(header, lines[index])
+	index++
+
+	for index < len(lines) && strings.TrimSpace(lines[index]) == "" {
+		index++
+	}
+
+	return strings.Join(header, "\n"), strings.Join(lines[index:], "\n")
+}
+
+func splitYAMLDocumentHeader(data string) (string, string) {
+	lines := strings.Split(data, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", data
+	}
+
+	index := 1
+	for index < len(lines) && strings.TrimSpace(lines[index]) == "" {
+		index++
+	}
+
+	return lines[0], strings.Join(lines[index:], "\n")
+}
+
+func parseYAMLMapping(data string) (*yaml.Node, bool) {
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(data), &document); err != nil {
+		return nil, false
+	}
+
+	if len(document.Content) == 0 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, false
+	}
+
+	return document.Content[0], true
+}
+
+func parseYAMLDocuments(data string) ([]*yaml.Node, bool) {
+	decoder := yaml.NewDecoder(strings.NewReader(data))
+	documents := make([]*yaml.Node, 0)
+
+	for {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return nil, false
+		}
+
+		if len(document.Content) == 0 {
+			continue
+		}
+
+		documents = append(documents, document.Content[0])
+	}
+
+	return documents, len(documents) > 0
+}
+
+func marshalYAMLDocuments(documents []*yaml.Node, header string) (string, error) {
+	rendered := make([]string, 0, len(documents))
+	for _, document := range documents {
+		marshaled, err := yaml.Marshal(document)
+		if err != nil {
+			return "", err
+		}
+
+		rendered = append(rendered, strings.TrimSuffix(string(marshaled), "\n"))
+	}
+
+	var buffer bytes.Buffer
+	if header != "" {
+		buffer.WriteString(header)
+		buffer.WriteString("\n")
+	}
+	buffer.WriteString(strings.Join(rendered, "\n---\n"))
+	buffer.WriteString("\n")
+
+	return buffer.String(), nil
+}
+
+func isKubeadmConfigWriteFile(path string) bool {
+	return strings.HasPrefix(path, "/run/kubeadm/") && strings.HasSuffix(path, ".yaml")
+}
+
+func ensureYAMLMappingValue(parent *yaml.Node, key string) (*yaml.Node, bool) {
+	if parent == nil || parent.Kind != yaml.MappingNode {
+		return nil, false
+	}
+
+	if existing := findYAMLMapValue(parent, key); existing != nil {
+		if existing.Kind != yaml.MappingNode {
+			return nil, false
+		}
+
+		return existing, false
+	}
+
+	child := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	appendYAMLMapValue(parent, key, child)
+
+	return child, true
+}
+
+func findYAMLMapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+func getYAMLMapString(node *yaml.Node, key string) string {
+	value := findYAMLMapValue(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+
+	return value.Value
+}
+
+func appendYAMLMapValue(parent *yaml.Node, key string, value *yaml.Node) {
+	parent.Content = append(parent.Content, newStringYAMLNode(key), value)
+}
+
+func upsertYAMLMapString(parent *yaml.Node, key, value string) bool {
+	existing := findYAMLMapValue(parent, key)
+	if existing == nil {
+		appendYAMLMapValue(parent, key, newStringYAMLNode(value))
+		return true
+	}
+
+	if existing.Kind != yaml.ScalarNode {
+		return false
+	}
+	if existing.Value == value {
+		return false
+	}
+
+	existing.Tag = "!!str"
+	existing.Value = value
+
+	return true
+}
+
+func upsertNamedValueSequenceItem(sequence *yaml.Node, name, value string) bool {
+	for _, item := range sequence.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+
+		itemName := findYAMLMapValue(item, "name")
+		if itemName == nil || itemName.Value != name {
+			continue
+		}
+
+		return upsertYAMLMapString(item, "value", value)
+	}
+
+	sequence.Content = append(sequence.Content, newNamedValueMappingNode(name, value))
+	return true
+}
+
+func newBoolYAMLNode(value bool) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!bool",
+		Value: strconv.FormatBool(value),
+	}
+}
+
+func newScalarNodes(values []string) []*yaml.Node {
+	nodes := make([]*yaml.Node, 0, len(values))
+	for _, value := range values {
+		nodes = append(nodes, newStringYAMLNode(value))
+	}
+
+	return nodes
+}
+
+func newNamedValueMappingNode(name, value string) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	appendYAMLMapValue(node, "name", newStringYAMLNode(name))
+	appendYAMLMapValue(node, "value", newStringYAMLNode(value))
+
+	return node
+}
+
+func newStringYAMLNode(value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: value,
+	}
+}

--- a/controllers/elfmachine_controller_cloudinit_test.go
+++ b/controllers/elfmachine_controller_cloudinit_test.go
@@ -1,0 +1,153 @@
+package controllers
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestEnsureKubeadmConfigContentPreservesMultiDocumentInitConfiguration(t *testing.T) {
+	content := newStringYAMLNode(`---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: ClusterConfiguration
+clusterName: phy
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    event-qps: "0"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: 0.0.0.0:10249
+`)
+
+	changed, err := ensureKubeadmConfigContent(content, "")
+	if err != nil {
+		t.Fatalf("ensureKubeadmConfigContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("ensureKubeadmConfigContent() should report changed")
+	}
+
+	header, body := splitYAMLDocumentHeader(content.Value)
+	if header != "---" {
+		t.Fatalf("expected YAML document header to be preserved, got %q", header)
+	}
+
+	documents := mustParseYAMLDocuments(t, body)
+	if len(documents) != 3 {
+		t.Fatalf("expected 3 yaml documents, got %d", len(documents))
+	}
+
+	expectScalarValue(t, documents[0], "kind", "ClusterConfiguration")
+	if nodeRegistration := findYAMLMapValue(documents[0], "nodeRegistration"); nodeRegistration != nil {
+		t.Fatalf("ClusterConfiguration should not gain nodeRegistration, got %#v", nodeRegistration)
+	}
+
+	expectScalarValue(t, documents[1], "kind", "InitConfiguration")
+	nodeRegistration := findYAMLMapValue(documents[1], "nodeRegistration")
+	if nodeRegistration == nil {
+		t.Fatalf("InitConfiguration should keep nodeRegistration")
+	}
+
+	kubeletExtraArgs := findYAMLMapValue(nodeRegistration, "kubeletExtraArgs")
+	if kubeletExtraArgs == nil || kubeletExtraArgs.Kind != yaml.MappingNode {
+		t.Fatalf("v1beta3 kubeletExtraArgs should stay a mapping, got %#v", kubeletExtraArgs)
+	}
+	expectScalarValue(t, kubeletExtraArgs, "event-qps", "0")
+	expectScalarValue(t, kubeletExtraArgs, "provider-id", kubeadmProviderIDValue)
+
+	expectScalarValue(t, documents[2], "kind", "KubeProxyConfiguration")
+	expectScalarValue(t, documents[2], "metricsBindAddress", "0.0.0.0:10249")
+}
+
+func TestEnsureKubeadmConfigContentSupportsV1Beta4JoinConfigurationSequence(t *testing.T) {
+	content := newStringYAMLNode(`---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    - name: event-qps
+      value: "0"
+`)
+
+	changed, err := ensureKubeadmConfigContent(content, "")
+	if err != nil {
+		t.Fatalf("ensureKubeadmConfigContent() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("ensureKubeadmConfigContent() should report changed")
+	}
+
+	_, body := splitYAMLDocumentHeader(content.Value)
+	documents := mustParseYAMLDocuments(t, body)
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 yaml document, got %d", len(documents))
+	}
+
+	nodeRegistration := findYAMLMapValue(documents[0], "nodeRegistration")
+	if nodeRegistration == nil {
+		t.Fatalf("JoinConfiguration should keep nodeRegistration")
+	}
+
+	kubeletExtraArgs := findYAMLMapValue(nodeRegistration, "kubeletExtraArgs")
+	if kubeletExtraArgs == nil || kubeletExtraArgs.Kind != yaml.SequenceNode {
+		t.Fatalf("v1beta4 kubeletExtraArgs should stay a sequence, got %#v", kubeletExtraArgs)
+	}
+
+	if eventQPS := findNamedValueSequenceItem(kubeletExtraArgs, "event-qps"); eventQPS == nil {
+		t.Fatalf("existing kubeletExtraArgs entry should be preserved")
+	} else if value := findYAMLMapValue(eventQPS, "value"); value == nil || value.Value != "0" {
+		t.Fatalf("event-qps value should be preserved, got %#v", value)
+	}
+
+	if providerID := findNamedValueSequenceItem(kubeletExtraArgs, "provider-id"); providerID == nil {
+		t.Fatalf("provider-id should be added to sequence kubeletExtraArgs")
+	} else if value := findYAMLMapValue(providerID, "value"); value == nil || value.Value != kubeadmProviderIDValue {
+		t.Fatalf("provider-id value should be %q, got %#v", kubeadmProviderIDValue, value)
+	}
+}
+
+func mustParseYAMLDocuments(t *testing.T, data string) []*yaml.Node {
+	t.Helper()
+
+	documents, ok := parseYAMLDocuments(data)
+	if !ok {
+		t.Fatalf("failed to parse yaml documents from:\n%s", data)
+	}
+
+	return documents
+}
+
+func expectScalarValue(t *testing.T, node *yaml.Node, key, expected string) {
+	t.Helper()
+
+	value := findYAMLMapValue(node, key)
+	if value == nil {
+		t.Fatalf("expected key %q to exist", key)
+	}
+	if value.Kind != yaml.ScalarNode || value.Value != expected {
+		t.Fatalf("unexpected value for %q: got kind=%d value=%q want %q", key, value.Kind, value.Value, expected)
+	}
+}
+
+func findNamedValueSequenceItem(sequence *yaml.Node, name string) *yaml.Node {
+	if sequence == nil || sequence.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	for _, item := range sequence.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+
+		itemName := findYAMLMapValue(item, "name")
+		if itemName != nil && itemName.Value == name {
+			return item
+		}
+	}
+
+	return nil
+}

--- a/controllers/elfmachine_controller_gpu_test.go
+++ b/controllers/elfmachine_controller_gpu_test.go
@@ -462,16 +462,21 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 
 		BeforeEach(func() {
 			elfMachine.Spec.GPUDevices = append(elfMachine.Spec.GPUDevices, infrav1.GPUPassthroughDeviceSpec{Model: gpuModel, Count: 1})
+			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
 		})
 
 		AfterEach(func() {
 			Expect(testEnv.Delete(ctx, node)).To(Succeed())
+			Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
 		})
 
 		It("should set clusterAutoscaler GPU label for node", func() {
 			elfMachine.Status.HostServerRef = fake.UUID()
 			elfMachine.Status.HostServerName = fake.UUID()
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			ctrlMgrCtx := &context.ControllerManagerContext{
 				Client:                  testEnv.Client,
 				Name:                    fake.ControllerManagerName,
@@ -491,13 +496,12 @@ var _ = Describe("ElfMachineReconciler-GPU", func() {
 					Name:   elfMachine.Name,
 					Labels: map[string]string{},
 				},
+				Spec: corev1.NodeSpec{ProviderID: providerID},
 			}
 			Expect(testEnv.CreateAndWait(ctx, node)).To(Succeed())
-			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
-			ok, err := reconciler.reconcileNode(ctx, machineContext, vm)
-			Expect(ok).Should(BeTrue())
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
+			err := reconciler.reconcileNode(ctx, machineContext, vm)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				if err := testEnv.Get(ctx, client.ObjectKey{Namespace: node.Namespace, Name: node.Name}, node); err != nil {

--- a/controllers/elfmachine_controller_resources.go
+++ b/controllers/elfmachine_controller_resources.go
@@ -244,11 +244,12 @@ func (r *ElfMachineReconciler) reconcileHostJob(ctx goctx.Context, machineCtx *c
 	log := ctrl.LoggerFrom(ctx)
 
 	// Agent needs to wait for the node exists before it can run and execute commands.
-	if machineCtx.Machine.Status.NodeInfo == nil {
+	if machineCtx.Machine.Status.NodeRef == nil {
 		log.Info("Waiting for node exists for host agent job", "jobType", jobType)
 
 		return false, nil
 	}
+	nodeName := machineCtx.Machine.Status.NodeRef.Name
 
 	failReason := ""
 	switch jobType {
@@ -273,7 +274,7 @@ func (r *ElfMachineReconciler) reconcileHostJob(ctx goctx.Context, machineCtx *c
 	}
 
 	if agentJob == nil {
-		agentJob, err = hostagent.GenerateJob(ctx, r.Client, machineCtx.ElfMachine, jobType, macTypes)
+		agentJob, err = hostagent.GenerateJob(ctx, r.Client, machineCtx.ElfMachine, jobType, macTypes, nodeName)
 		if err != nil {
 			conditions.MarkFalse(machineCtx.ElfMachine, infrav1.ResourcesHotUpdatedCondition, failReason, clusterv1.ConditionSeverityWarning, "failed to generate host agent job: "+err.Error())
 			return false, err

--- a/controllers/elfmachine_controller_resources_test.go
+++ b/controllers/elfmachine_controller_resources_test.go
@@ -82,7 +82,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 	Context("reconcileVMResources", func() {
 		It("should mark ResourcesHotUpdatedCondition to true", func() {
-			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "")
+			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "", "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: agentJob.Namespace, Name: agentJob.Name}, agentJob)).NotTo(HaveOccurred())
 			agentJobPatchSource := agentJob.DeepCopy()
@@ -90,7 +90,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(testEnv.PatchAndWait(ctx, agentJob, agentJobPatchSource)).To(Succeed())
 			kubeConfigSecret, err := helpers.NewKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)
 			Expect(err).ShouldNot(HaveOccurred())
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMDiskReason, clusterv1.ConditionSeverityInfo, "")
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -266,7 +266,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should create agent job to expand root partition", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMDiskReason, clusterv1.ConditionSeverityInfo, "")
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret, hostAgentJobsConfig)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -289,9 +289,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should retry when job failed", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMDiskReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "")
+			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "", "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret, hostAgentJobsConfig)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -329,9 +329,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should record job succeeded", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMDiskReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "")
+			agentJob := hostagent.GenerateExpandRootPartitionJob(elfMachine, "", "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: agentJob.Namespace, Name: agentJob.Name}, agentJob)).NotTo(HaveOccurred())
 			agentJobPatchSource := agentJob.DeepCopy()
@@ -384,7 +384,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should create agent job to restart kubelet", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMComputeResourcesReason, clusterv1.ConditionSeverityInfo, "")
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret, hostAgentJobsConfig)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -407,9 +407,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should retry when job failed", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMComputeResourcesReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateRestartKubeletJob(elfMachine, "")
+			agentJob := hostagent.GenerateRestartKubeletJob(elfMachine, "", "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -447,9 +447,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 
 		It("should record job succeeded", func() {
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.ExpandingVMComputeResourcesReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateRestartKubeletJob(elfMachine, "")
+			agentJob := hostagent.GenerateRestartKubeletJob(elfMachine, "", "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: agentJob.Namespace, Name: agentJob.Name}, agentJob)).NotTo(HaveOccurred())
 			agentJobPatchSource := agentJob.DeepCopy()
@@ -563,8 +563,8 @@ var _ = Describe("ElfMachineReconciler", func() {
 			vmNic.IPAddress = ptr.To("")
 			vmNics := []*models.VMNic{vmNic}
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return(vmNics, nil)
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
-			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", nil)
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
+			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", nil, "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).To(Succeed())
 			agentJobPatchSource := agentJob.DeepCopy()
 			agentJob.Status.Phase = agentv1.PhaseSucceeded
@@ -724,7 +724,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			nic2 := fake.NewVMNic()
 			macTypes := []hostagent.MacType{{Mac: *nic1.MacAddress}, {Mac: *nic2.MacAddress}}
 			elfMachine.Spec.Network.Devices = append(elfMachine.Spec.Network.Devices, infrav1.NetworkDeviceSpec{NetworkType: infrav1.NetworkTypeIPV4})
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.AddingVMNetworkDeviceReason, clusterv1.ConditionSeverityInfo, "")
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret, hostAgentJobsConfig)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -748,9 +748,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 			nic2 := fake.NewVMNic()
 			macTypes := []hostagent.MacType{{Mac: *nic1.MacAddress}, {Mac: *nic2.MacAddress}}
 			elfMachine.Spec.Network.Devices = append(elfMachine.Spec.Network.Devices, infrav1.NetworkDeviceSpec{NetworkType: infrav1.NetworkTypeIPV4})
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.AddingVMNetworkDeviceReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", macTypes)
+			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", macTypes, "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kubeConfigSecret, hostAgentJobsConfig)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
@@ -793,9 +793,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 			nic2 := fake.NewVMNic()
 			macTypes := []hostagent.MacType{{Mac: *nic1.MacAddress}, {Mac: *nic2.MacAddress}}
 			elfMachine.Spec.Network.Devices = append(elfMachine.Spec.Network.Devices, infrav1.NetworkDeviceSpec{NetworkType: infrav1.NetworkTypeIPV4})
-			machine.Status.NodeInfo = &corev1.NodeSystemInfo{}
+			machine.Status.NodeRef = &corev1.ObjectReference{Name: "test-node"}
 			conditions.MarkFalse(elfMachine, infrav1.ResourcesHotUpdatedCondition, infrav1.AddingVMNetworkDeviceReason, clusterv1.ConditionSeverityInfo, "")
-			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", macTypes)
+			agentJob := hostagent.GenerateSetNetworkDeviceConfigJob(elfMachine, "", macTypes, "test-node")
 			Expect(testEnv.CreateAndWait(ctx, agentJob)).NotTo(HaveOccurred())
 			Expect(testEnv.Get(ctx, client.ObjectKey{Namespace: agentJob.Namespace, Name: agentJob.Name}, agentJob)).NotTo(HaveOccurred())
 			agentJobPatchSource := agentJob.DeepCopy()

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -430,6 +430,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should allow VM to be temporarily disconnected", func() {
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusRUNNING
 			vm.Status = &status
@@ -448,6 +449,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 					Type:    corev1.NodeInternalIP,
 				},
 			}
+			k8sNode.Spec.ProviderID = providerID
 			Expect(testEnv.CreateAndWait(ctx, k8sNode)).To(Succeed())
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
@@ -455,14 +457,13 @@ var _ = Describe("ElfMachineReconciler", func() {
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
-			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 			vmVolume := fake.NewVMVolume(elfMachine)
 			vmDisk := fake.NewVMDisk(vmVolume)
 			vm.VMDisks = []*models.NestedVMDisk{{ID: vmDisk.ID}}
 			mockVMService.EXPECT().GetVMDisks([]string{*vmDisk.ID}).Return([]*models.VMDisk{vmDisk}, nil)
 			mockVMService.EXPECT().GetVMVolume(*vmVolume.ID).Return(vmVolume, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
 			Expect(reconciler.Client.Get(ctx, elfMachineKey, elfMachine)).To(Succeed())
@@ -1298,7 +1299,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{vm2}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				ok, err = reconciler.joinPlacementGroup(ctx, machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
@@ -1312,7 +1313,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				ok, err = reconciler.joinPlacementGroup(ctx, machineContext, vm)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
@@ -1332,7 +1333,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs([]string{*placementGroup.Vms[0].ID}).Return([]*models.VM{}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				ok, err = reconciler.joinPlacementGroup(ctx, machineContext, vm)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(BeZero())
@@ -1481,7 +1482,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 				fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine1, machine1)
 				fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine2, machine2)
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				ok, err = reconciler.joinPlacementGroup(ctx, machineContext, vm0)
 				Expect(ok).To(BeTrue())
 				Expect(err).To(BeZero())
@@ -1577,7 +1578,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host), nil)
 				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID})).Return([]*models.VM{vm1}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err = reconciler.preCheckPlacementGroup(ctx, machineContext)
 				Expect(err).To(BeZero())
 				Expect(hostID).To(BeNil())
@@ -1651,7 +1652,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				host, err = reconciler.preCheckPlacementGroup(ctx, machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
@@ -1665,7 +1666,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				host, err = reconciler.preCheckPlacementGroup(ctx, machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
@@ -1679,7 +1680,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				host, err = reconciler.preCheckPlacementGroup(ctx, machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
@@ -1696,7 +1697,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				mockVMService.EXPECT().GetHostsByCluster(elfCluster.Spec.Cluster).Return(service.NewHosts(host1, host2, host3), nil)
 				mockVMService.EXPECT().FindByIDs(gomock.InAnyOrder([]string{*vm1.ID, *vm2.ID, *vm3.ID})).Return([]*models.VM{vm1, vm2, vm3}, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				host, err = reconciler.preCheckPlacementGroup(ctx, machineContext)
 				Expect(err).To(BeZero())
 				Expect(host).To(BeNil())
@@ -1708,7 +1709,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				hosts := []*models.Host{host1, host2, host3}
 				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err := reconciler.getVMHostForRollingUpdate(ctx, machineContext, placementGroup, service.NewHostsFromList(hosts))
 				Expect(err).To(BeZero())
 				Expect(hostID).To(Equal(""))
@@ -1720,7 +1721,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				hosts = []*models.Host{host1, host2, host3}
 				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err = reconciler.getVMHostForRollingUpdate(ctx, machineContext, placementGroup, service.NewHostsFromList(hosts))
 				Expect(err).To(BeZero())
 				Expect(hostID).To(Equal(""))
@@ -1737,7 +1738,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				hosts = []*models.Host{host1, host2, host3, host4}
 				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err = reconciler.getVMHostForRollingUpdate(ctx, machineContext, placementGroup, service.NewHostsFromList(hosts))
 				Expect(err).To(BeZero())
 				Expect(hostID).To(Equal(*vm3.Host.ID))
@@ -1749,7 +1750,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				hosts = []*models.Host{host1, host2, host3, host4}
 				mockVMService.EXPECT().Get(*vm3.ID).Return(vm3, nil)
 
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err = reconciler.getVMHostForRollingUpdate(ctx, machineContext, placementGroup, service.NewHostsFromList(hosts))
 				Expect(err).To(BeZero())
 				Expect(hostID).To(Equal(*vm3.Host.ID))
@@ -1757,7 +1758,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 				ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, kcp)
 				machineContext = newMachineContext(elfCluster, cluster, elfMachine, machine, mockVMService)
-				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+				reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 				hostID, err = reconciler.getVMHostForRollingUpdate(ctx, machineContext, placementGroup, service.NewHostsFromList(hosts))
 				Expect(err).To(BeZero())
 				Expect(hostID).To(Equal(""))
@@ -1952,7 +1953,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				err := reconciler.reconcileHostAndZone(ctx, machineCtx, vm)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(machineCtx.ElfMachine.Status.ComputeCluster).To(Equal(infrav1.ComputeClusterStatus{
-					ClusterID: computeClusterName,
+					ClusterID: computeClusterID,
 					Name:      computeClusterName,
 				}))
 				Expect(machineCtx.ElfMachine.Status.Zone.IsZero()).To(BeTrue())
@@ -1960,10 +1961,11 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			It("should not update compute cluster when unchanged", func() {
 				vm := fake.NewTowerVMFromElfMachine(elfMachine)
+				computeClusterID := fake.ID()
 				computeClusterName := "compute-cluster-a"
-				vm.Cluster = &models.NestedCluster{ID: service.TowerString(fake.ID()), Name: service.TowerString(computeClusterName)}
+				vm.Cluster = &models.NestedCluster{ID: service.TowerString(computeClusterID), Name: service.TowerString(computeClusterName)}
 				elfMachine.Status.ComputeCluster = infrav1.ComputeClusterStatus{
-					ClusterID: computeClusterName,
+					ClusterID: computeClusterID,
 					Name:      computeClusterName,
 				}
 				machineCtx := newMachineContext(elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -1972,7 +1974,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				err := reconciler.reconcileHostAndZone(ctx, machineCtx, vm)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(machineCtx.ElfMachine.Status.ComputeCluster).To(Equal(infrav1.ComputeClusterStatus{
-					ClusterID: computeClusterName,
+					ClusterID: computeClusterID,
 					Name:      computeClusterName,
 				}))
 			})
@@ -1982,12 +1984,18 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ctrlutil.AddFinalizer(elfMachine, infrav1.MachineFinalizer)
 			ctrlutil.AddFinalizer(elfMachine, infrav1.MachineStaticIPFinalizer)
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
+			elfMachine.Spec.ProviderID = ptr.To(providerID)
 
+			k8sNode.Spec.ProviderID = providerID
 			Expect(testEnv.CreateAndWait(ctx, k8sNode)).To(Succeed())
-			patchHelper, err := patch.NewHelper(k8sNode, testEnv.Client)
-			Expect(err).ShouldNot(HaveOccurred())
+			patchNodeAddresses := func(addresses []corev1.NodeAddress) {
+				patchSource := k8sNode.DeepCopy()
+				k8sNode.Status.Addresses = addresses
+				Expect(testEnv.PatchAndWait(ctx, k8sNode, patchSource)).To(Succeed())
+			}
 
 			// test elfMachine has one network device with DHCP type
 			elfMachine.Spec.Network.Devices = []infrav1.NetworkDeviceSpec{
@@ -1997,15 +2005,22 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
+			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			defer func() {
+				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node IP is null, VM has no nic
 			machineCtx := newMachineContext(elfCluster, cluster, elfMachine, machine, mockVMService)
@@ -2038,13 +2053,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(machineCtx.ElfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForNetworkAddressesReason}})
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "test",
 					Type:    corev1.NodeHostName,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node IP is null, VM has no nic
 			machineCtx.ElfMachine.Status.Conditions = nil
@@ -2056,13 +2070,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(machineCtx.ElfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForNetworkAddressesReason}})
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "127.0.0.1",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node has node IP, VM has nic IP
 			nic = fake.NewTowerVMNic(0)
@@ -2082,16 +2095,15 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
-			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 
 			// k8s node IP is null, VM has no nic IP
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			machineCtx.ElfMachine.Status.Conditions = nil
 			nic = fake.NewTowerVMNic(0)
@@ -2113,21 +2125,20 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "127.0.0.1",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node has node IP, VM has no nic ip
 			nic = fake.NewTowerVMNic(0)
 			nic.IPAddress = service.TowerString("")
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Return([]*models.VMNic{nic}, nil)
 			ok, err = reconciler.reconcileNetwork(ctx, machineCtx, vm)
-			Expect(ok).To(BeTrue())
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
 			logBuffer.Reset()
 
 			// k8s node has node IP, VM has one nic ip
@@ -2151,15 +2162,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
-			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node IP is null, VM has no nic IP
 			machineCtx.ElfMachine.Status.Conditions = nil
@@ -2186,13 +2196,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "127.0.0.1",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node has node IP, the IP is static IP, VM has no nic IP
 			machineCtx.ElfMachine.Status.Conditions = nil
@@ -2208,13 +2217,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(machineCtx.ElfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForNetworkAddressesReason}})
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "127.0.0.2",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node has node IP, the IP is DHCP IP, VM has no nic IP
 			nic1 = fake.NewTowerVMNic(0)
@@ -2240,15 +2248,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
-			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node IP is null, VM has no nic IP
 			machineCtx.ElfMachine.Status.Conditions = nil
@@ -2275,13 +2282,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "127.0.0.1",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node has node IP, VM has no nic IP
 			nic1 = fake.NewTowerVMNic(0)
@@ -2305,7 +2311,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md, kubeConfigSecret)
 			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
-			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 
 			// k8s node has node IP, VM has no nic IP
 			machineCtx.ElfMachine.Status.Conditions = nil
@@ -2317,13 +2323,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 			expectConditions(machineCtx.ElfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForNetworkAddressesReason}})
 			logBuffer.Reset()
 
-			k8sNode.Status.Addresses = []corev1.NodeAddress{
+			patchNodeAddresses([]corev1.NodeAddress{
 				{
 					Address: "",
 					Type:    corev1.NodeInternalIP,
 				},
-			}
-			Expect(patchHelper.Patch(ctx, k8sNode)).To(Succeed())
+			})
 
 			// k8s node IP is null, VM has two nic IP
 			nic1 = fake.NewTowerVMNic(0)
@@ -2366,6 +2371,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should set ElfMachine to ready when VM network is ready", func() {
 			vm := fake.NewTowerVMFromElfMachine(elfMachine)
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
 			nic0 := fake.NewTowerVMNic(0)
@@ -2381,20 +2387,20 @@ var _ = Describe("ElfMachineReconciler", func() {
 					Type:    corev1.NodeInternalIP,
 				},
 			}
+			k8sNode.Spec.ProviderID = providerID
 			Expect(testEnv.CreateAndWait(ctx, k8sNode)).To(Succeed())
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().GetVMNics(*vm.ID).Times(2).Return([]*models.VMNic{nic0, nic1}, nil)
 			mockVMService.EXPECT().GetVMPlacementGroup(gomock.Any()).Times(2).Return(placementGroup, nil)
 			mockVMService.EXPECT().UpsertLabel(gomock.Any(), gomock.Any()).Times(3).Return(fake.NewTowerLabel(), nil)
 			mockVMService.EXPECT().AddLabelsToVM(gomock.Any(), gomock.Any()).Times(1)
-			mockVMService.EXPECT().FindVMsByName(elfMachine.Name).Return(nil, nil)
 			vmVolume := fake.NewVMVolume(elfMachine)
 			vmDisk := fake.NewVMDisk(vmVolume)
 			vm.VMDisks = []*models.NestedVMDisk{{ID: vmDisk.ID}}
 			mockVMService.EXPECT().GetVMDisks([]string{*vmDisk.ID}).Return([]*models.VMDisk{vmDisk}, nil)
 			mockVMService.EXPECT().GetVMVolume(*vmVolume.ID).Return(vmVolume, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 			elfMachineKey := capiutil.ObjectKey(elfMachine)
 			_, _ = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: elfMachineKey})
 			elfMachine = &infrav1.ElfMachine{}
@@ -2934,11 +2940,13 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should delete k8s node before destroying VM.", func() {
 			vm := fake.NewTowerVM()
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
 			vm.Status = &status
 			task := fake.NewTowerTask("")
 			elfMachine.Status.VMRef = *vm.LocalID
+			elfMachine.Spec.ProviderID = ptr.To(providerID)
 			cluster.Status.ControlPlaneReady = true
 
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md)
@@ -2953,6 +2961,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 					Name:   elfMachine.Name,
 					Labels: map[string]string{},
 				},
+				Spec: corev1.NodeSpec{ProviderID: providerID},
 			}
 			Expect(testEnv.CreateAndWait(ctx, node)).To(Succeed())
 			// before reconcile, create kubeconfig secret for cluster.
@@ -2960,11 +2969,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 			defer func() {
 				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
 			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(task, nil)
-
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 			result, err := reconciler.reconcileDelete(ctx, machineContext)
 			Expect(result.RequeueAfter).NotTo(BeZero())
 			Expect(err).ToNot(HaveOccurred())
@@ -3010,6 +3022,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
 			defer func() {
 				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
 			}()
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
@@ -3058,6 +3074,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 			defer func() {
 				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
 			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 			mockVMService.EXPECT().Delete(elfMachine.Status.VMRef).Return(task, nil)
@@ -3079,10 +3099,12 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 		It("should handle error when delete k8s node failed", func() {
 			vm := fake.NewTowerVM()
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			status := models.VMStatusSTOPPED
 			vm.Status = &status
 			elfMachine.Status.VMRef = *vm.LocalID
+			elfMachine.Spec.ProviderID = ptr.To(providerID)
 			cluster.Status.ControlPlaneReady = true
 
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md)
@@ -3102,7 +3124,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 			mockVMService.EXPECT().Get(elfMachine.Status.VMRef).Return(vm, nil)
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
 			_, err := reconciler.reconcileDelete(ctx, machineContext)
 			Expect(err).NotTo(BeZero())
 
@@ -3569,6 +3591,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Type:   infrav1.ElfClusterZoneTypePreferred,
 			}
 			vm := fake.NewTowerVM()
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			ctrlMgrCtx := &context.ControllerManagerContext{
 				Client:                  testEnv.Client,
 				Name:                    fake.ControllerManagerName,
@@ -3587,20 +3610,27 @@ var _ = Describe("ElfMachineReconciler", func() {
 					Name:   elfMachine.Name,
 					Labels: map[string]string{},
 				},
+				Spec: corev1.NodeSpec{ProviderID: providerID},
 			}
 			Expect(testEnv.CreateAndWait(ctx, node)).To(Succeed())
 			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			defer func() {
+				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
-			ok, err := reconciler.reconcileNode(ctx, machineContext, vm)
-			Expect(ok).Should(BeTrue())
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
+			err := reconciler.reconcileNode(ctx, machineContext, vm)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				if err := testEnv.Get(ctx, client.ObjectKey{Namespace: node.Namespace, Name: node.Name}, node); err != nil {
 					return false
 				}
 
-				return node.Spec.ProviderID == machineutil.ConvertUUIDToProviderID(*vm.LocalID) &&
+				return node.Spec.ProviderID == providerID &&
 					node.Labels[infrav1.ComputeClusterIDLabel] == elfMachine.Status.ComputeCluster.ClusterID &&
 					node.Labels[infrav1.ComputeClusterNameLabel] == elfMachine.Status.ComputeCluster.Name &&
 					node.Labels[infrav1.HostServerIDLabel] == elfMachine.Status.HostServerRef &&
@@ -3626,6 +3656,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 				Type:   infrav1.ElfClusterZoneTypePreferred,
 			}
 			vm := fake.NewTowerVM()
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			ctrlMgrCtx := &context.ControllerManagerContext{
 				Client:                  testEnv.Client,
 				Name:                    fake.ControllerManagerName,
@@ -3639,7 +3670,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 				ElfMachine: elfMachine,
 			}
 
-			providerID := machineutil.ConvertUUIDToProviderID(fake.UUID())
 			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: elfMachine.Name,
@@ -3659,10 +3689,16 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			Expect(testEnv.CreateAndWait(ctx, node)).To(Succeed())
 			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			defer func() {
+				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
-			ok, err := reconciler.reconcileNode(ctx, machineContext, vm)
-			Expect(ok).Should(BeTrue())
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
+			err := reconciler.reconcileNode(ctx, machineContext, vm)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
@@ -3688,6 +3724,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			elfMachine.Status.HostServerRef = fake.UUID()
 			elfMachine.Status.HostServerName = fake.UUID()
 			vm := fake.NewTowerVM()
+			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			ctrlMgrCtx := &context.ControllerManagerContext{
 				Client:                  testEnv.Client,
 				Name:                    fake.ControllerManagerName,
@@ -3701,7 +3738,6 @@ var _ = Describe("ElfMachineReconciler", func() {
 				ElfMachine: elfMachine,
 			}
 
-			providerID := machineutil.ConvertUUIDToProviderID(fake.UUID())
 			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: elfMachine.Name,
@@ -3721,10 +3757,16 @@ var _ = Describe("ElfMachineReconciler", func() {
 			}
 			Expect(testEnv.CreateAndWait(ctx, node)).To(Succeed())
 			Expect(helpers.CreateKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			defer func() {
+				Expect(helpers.DeleteKubeConfigSecret(testEnv, cluster.Namespace, cluster.Name)).To(Succeed())
+			}()
+			Expect(helpers.EnsureClusterForClusterCacheTest(ctx, testEnv, cluster)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Delete(ctx, cluster)).To(Succeed())
+			}()
 
-			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService}
-			ok, err := reconciler.reconcileNode(ctx, machineContext, vm)
-			Expect(ok).Should(BeTrue())
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx, NewVMService: mockNewVMService, ClusterCache: clusterCache}
+			err := reconciler.reconcileNode(ctx, machineContext, vm)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,8 +32,11 @@ import (
 	cgscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
@@ -49,6 +52,7 @@ const (
 
 var (
 	testEnv         *helpers.TestEnvironment
+	clusterCache    clustercache.ClusterCache
 	ctx             = ctrl.SetupSignalHandler()
 	unexpectedError = errors.New("unexpected error")
 )
@@ -73,6 +77,8 @@ func TestMain(m *testing.M) {
 }
 
 func setup() {
+	var err error
+
 	// set log
 	klog.InitFlags(nil)
 	if err := flag.Set("logtostderr", "false"); err != nil {
@@ -113,10 +119,36 @@ func setup() {
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10}
 
+	clusterCache, err = clustercache.SetupWithManager(ctx, testEnv.Manager, clustercache.Options{
+		SecretClient: testEnv.Manager.GetClient(),
+		Cache: clustercache.CacheOptions{
+			Indexes: []clustercache.CacheOptionsIndex{clustercache.NodeProviderIDIndex},
+		},
+		Client: clustercache.ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("test-controller-manager"),
+			Cache: clustercache.ClientCacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Pod{},
+				},
+			},
+		},
+	}, controllerOpts)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create ClusterCache: %v", err))
+	}
+	go func() {
+		<-ctx.Done()
+		clusterCache.(interface{ Shutdown() }).Shutdown()
+	}()
+	// Setting ConnectionCreationRetryInterval to 2 seconds, otherwise client creation is
+	// only retried every 30s. If we get unlucky tests are then failing with timeout.
+	clusterCache.(interface{ SetConnectionCreationRetryInterval(time.Duration) }).
+		SetConnectionCreationRetryInterval(2 * time.Second)
+
 	if err := AddClusterControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ElfCluster controller: %v", err))
 	}
-	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ElfMachine controller: %v", err))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -24,19 +24,23 @@ import (
 	goruntime "runtime"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
 	capiflags "sigs.k8s.io/cluster-api/util/flags"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
@@ -65,10 +69,13 @@ var (
 	syncPeriod                  time.Duration
 	webhookOpts                 webhook.Options
 	watchNamespace              string
+	clusterCacheClientQPS       float32
+	clusterCacheClientBurst     int
 
 	elfClusterConcurrency         int
 	elfMachineConcurrency         int
 	elfMachineTemplateConcurrency int
+	clusterCacheConcurrency       int
 
 	managerOptions = capiflags.ManagerOptions{}
 
@@ -140,6 +147,15 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
+
+	fs.Float32Var(&clusterCacheClientQPS, "clustercache-client-qps", 20,
+		"Maximum queries per second from the cluster cache clients to the Kubernetes API server of workload clusters.")
+
+	fs.IntVar(&clusterCacheClientBurst, "clustercache-client-burst", 30,
+		"Maximum number of queries that should be allowed in one burst from the cluster cache clients to the Kubernetes API server of workload clusters.")
+
+	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
+		"Number of clusters to process simultaneously")
 
 	fs.IntVar(&webhookOpts.Port, "webhook-port", 9443,
 		"Webhook Server port.")
@@ -238,11 +254,16 @@ func main() {
 		}
 
 		if os.Getenv("ENABLE_CONTROLLERS") != "false" {
+			clusterCache, err := setupClusterCache(ctx, mgr)
+			if err != nil {
+				return err
+			}
+
 			if err := controllers.AddClusterControllerToManager(ctx, ctrlMgrCtx, mgr, controller.Options{MaxConcurrentReconciles: elfClusterConcurrency}); err != nil {
 				return err
 			}
 
-			if err := controllers.AddMachineControllerToManager(ctx, ctrlMgrCtx, mgr, controller.Options{MaxConcurrentReconciles: elfMachineConcurrency}); err != nil {
+			if err := controllers.AddMachineControllerToManager(ctx, ctrlMgrCtx, mgr, clusterCache, controller.Options{MaxConcurrentReconciles: elfMachineConcurrency}); err != nil {
 				return err
 			}
 		}
@@ -290,4 +311,39 @@ func setupChecks(mgr ctrlmgr.Manager) {
 		setupLog.Error(err, "unable to create health check")
 		os.Exit(1)
 	}
+}
+
+func setupClusterCache(ctx goctx.Context, mgr ctrl.Manager) (clustercache.ClusterCache, error) {
+	secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Cache: &client.CacheOptions{
+			Reader: mgr.GetCache(),
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create secret caching client")
+	}
+
+	clusterCache, err := clustercache.SetupWithManager(ctx, mgr, clustercache.Options{
+		SecretClient: secretCachingClient,
+		Cache: clustercache.CacheOptions{
+			Indexes: []clustercache.CacheOptionsIndex{clustercache.NodeProviderIDIndex},
+		},
+		Client: clustercache.ClientOptions{
+			QPS:       clusterCacheClientQPS,
+			Burst:     clusterCacheClientBurst,
+			UserAgent: remote.DefaultClusterAPIUserAgent(controllerName),
+			Cache: clustercache.ClientCacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Pod{},
+				},
+			},
+		},
+		WatchFilterValue: managerOpts.WatchFilterValue,
+	}, controller.Options{MaxConcurrentReconciles: clusterCacheConcurrency})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create ClusterCache")
+	}
+
+	return clusterCache, nil
 }

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -21,10 +21,15 @@ import (
 	"fmt"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/service"
+)
+
+const (
+	cloudInitHostnameRandomLength = 5
 )
 
 // MachineContext is a Go context used with an ElfMachine.
@@ -87,4 +92,26 @@ func (c *MachineContext) GetElfClusterID() string {
 	}
 
 	return ""
+}
+
+// GenerateHostname generates a hostname for the machine.
+// If a HostNamePrefix is specified in the failure domain or machine spec, the hostname will be generated as <prefix>-<random string>.
+// Otherwise, the machine name will be used as the hostname.
+func (c *MachineContext) GenerateHostname() string {
+	if c == nil || c.ElfMachine == nil {
+		return ""
+	}
+
+	var prefix string
+	if failureDomain := c.GetCloudFailureDomain(); failureDomain != nil {
+		prefix = failureDomain.HostNamePrefix
+	}
+	if prefix == "" {
+		prefix = c.ElfMachine.Spec.HostNamePrefix
+	}
+	if prefix != "" {
+		return fmt.Sprintf("%s-%s", prefix, capiutil.RandomString(cloudInitHostnameRandomLength))
+	}
+
+	return c.ElfMachine.Name
 }

--- a/pkg/hostagent/service.go
+++ b/pkg/hostagent/service.go
@@ -88,14 +88,14 @@ func GetJobName(elfMachine *infrav1.ElfMachine, jobType HostAgentJobType, macTyp
 	}
 }
 
-func GenerateExpandRootPartitionJob(elfMachine *infrav1.ElfMachine, playbook string) *agentv1.HostOperationJob {
+func GenerateExpandRootPartitionJob(elfMachine *infrav1.ElfMachine, playbook string, nodeName string) *agentv1.HostOperationJob {
 	return &agentv1.HostOperationJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetExpandRootPartitionJobName(elfMachine),
 			Namespace: "default",
 		},
 		Spec: agentv1.HostOperationJobSpec{
-			NodeName: elfMachine.Name,
+			NodeName: nodeName,
 			Operation: agentv1.Operation{
 				Ansible: &agentv1.Ansible{
 					LocalPlaybookText: &agentv1.YAMLText{
@@ -108,14 +108,14 @@ func GenerateExpandRootPartitionJob(elfMachine *infrav1.ElfMachine, playbook str
 	}
 }
 
-func GenerateRestartKubeletJob(elfMachine *infrav1.ElfMachine, playbook string) *agentv1.HostOperationJob {
+func GenerateRestartKubeletJob(elfMachine *infrav1.ElfMachine, playbook string, nodeName string) *agentv1.HostOperationJob {
 	return &agentv1.HostOperationJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetRestartKubeletJobName(elfMachine),
 			Namespace: "default",
 		},
 		Spec: agentv1.HostOperationJobSpec{
-			NodeName: elfMachine.Name,
+			NodeName: nodeName,
 			Operation: agentv1.Operation{
 				Ansible: &agentv1.Ansible{
 					LocalPlaybookText: &agentv1.YAMLText{
@@ -128,14 +128,14 @@ func GenerateRestartKubeletJob(elfMachine *infrav1.ElfMachine, playbook string) 
 	}
 }
 
-func GenerateSetNetworkDeviceConfigJob(elfMachine *infrav1.ElfMachine, playbook string, macTypes []MacType) *agentv1.HostOperationJob {
+func GenerateSetNetworkDeviceConfigJob(elfMachine *infrav1.ElfMachine, playbook string, macTypes []MacType, nodeName string) *agentv1.HostOperationJob {
 	return &agentv1.HostOperationJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetSetNetworkDeviceConfigJobName(elfMachine, macTypes),
 			Namespace: "default",
 		},
 		Spec: agentv1.HostOperationJobSpec{
-			NodeName: elfMachine.Name,
+			NodeName: nodeName,
 			Operation: agentv1.Operation{
 				Ansible: &agentv1.Ansible{
 					LocalPlaybookText: &agentv1.YAMLText{
@@ -153,7 +153,7 @@ type MacType struct {
 	Type string
 }
 
-func GenerateJob(ctx goctx.Context, cli client.Client, elfMachine *infrav1.ElfMachine, jobType HostAgentJobType, macTypes []MacType) (*agentv1.HostOperationJob, error) {
+func GenerateJob(ctx goctx.Context, cli client.Client, elfMachine *infrav1.ElfMachine, jobType HostAgentJobType, macTypes []MacType, nodeName string) (*agentv1.HostOperationJob, error) {
 	var configmap corev1.ConfigMap
 	if err := cli.Get(ctx, client.ObjectKey{Namespace: constants.NamespaceCape, Name: HostAgentJobsConfigName}, &configmap); err != nil {
 		return nil, err
@@ -166,9 +166,9 @@ func GenerateJob(ctx goctx.Context, cli client.Client, elfMachine *infrav1.ElfMa
 
 	switch jobType {
 	case HostAgentJobTypeExpandRootPartition:
-		return GenerateExpandRootPartitionJob(elfMachine, playbook), nil
+		return GenerateExpandRootPartitionJob(elfMachine, playbook, nodeName), nil
 	case HostAgentJobTypeRestartKubelet:
-		return GenerateRestartKubeletJob(elfMachine, playbook), nil
+		return GenerateRestartKubeletJob(elfMachine, playbook, nodeName), nil
 	case HostAgentJobTypeSetNetworkDeviceConfig:
 		if len(macTypes) > 0 {
 			var sb strings.Builder
@@ -179,7 +179,7 @@ func GenerateJob(ctx goctx.Context, cli client.Client, elfMachine *infrav1.ElfMa
 			playbook = strings.Replace(playbook, "mac_types: {}", sb.String(), 1)
 		}
 
-		return GenerateSetNetworkDeviceConfigJob(elfMachine, playbook, macTypes), nil
+		return GenerateSetNetworkDeviceConfigJob(elfMachine, playbook, macTypes, nodeName), nil
 	default:
 		return nil, fmt.Errorf("unknown job type: %s", jobType)
 	}

--- a/pkg/service/vm.go
+++ b/pkg/service/vm.go
@@ -58,6 +58,7 @@ type CloneVMInfo struct {
 	Host       string           `json:"host,omitempty"`
 	CloudInit  string           `json:"cloudInit,omitempty"`
 	GPUDevices []*GPUDeviceInfo `json:"gpuDevices,omitempty"`
+	HostName   string           `json:"hostName,omitempty"`
 }
 
 type VMService interface {
@@ -324,7 +325,7 @@ func (svr *TowerVMService) createVMFromTemplateParams(
 
 	nameservers := elfMachine.GetLimitedNameservers(config.VM.NameserverLimit)
 	cloudInit := &models.TemplateCloudInit{
-		Hostname: TowerString(elfMachine.Name),
+		Hostname: TowerString(vmInfo.HostName),
 		UserData: TowerString(vmInfo.CloudInit),
 		Networks: networks,
 	}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -90,13 +90,7 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-        name: '{{ ds.meta_data.hostname }}'
     preKubeadmCommands:
-      - hostname "{{ ds.meta_data.hostname }}"
-      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       - /etc/kube-vip-prepare.sh
       #! If you need to expand the system disk capacity (based on the capacity of
       #! the virtual machine template disk) when creating a node virtual machine,
@@ -263,13 +257,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-          name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
-        - hostname "{{ ds.meta_data.hostname }}"
-        - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-        - echo "127.0.0.1   localhost" >>/etc/hosts
-        - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
-        - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       #! If you need to expand the system disk capacity (based on the capacity of
       #! the virtual machine template disk) when creating a node virtual machine,
       #! you need to set the following commands. CAPE will add new disk capacity

--- a/test/helpers/cluster.go
+++ b/test/helpers/cluster.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	goctx "context"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -82,4 +83,22 @@ func NewKubeConfigSecret(testEnv *TestEnvironment, namespace, clusterName string
 		},
 		Type: clusterv1.ClusterSecretType,
 	}, nil
+}
+
+func EnsureClusterForClusterCacheTest(ctx goctx.Context, testEnv *TestEnvironment, cluster *clusterv1.Cluster) error {
+	clusterCopy := cluster.DeepCopy()
+	clusterCopy.ResourceVersion = ""
+	if err := testEnv.CreateAndWait(ctx, clusterCopy); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	patch := client.MergeFrom(clusterCopy.DeepCopy())
+	cluster.Status.InfrastructureReady = true
+	clusterCopy.Status = cluster.Status
+	if err := testEnv.Status().Patch(ctx, clusterCopy, patch); err != nil {
+		return err
+	}
+	time.Sleep(200 * time.Millisecond) // wait for clusterCache accessor
+	return nil
 }


### PR DESCRIPTION
## Issues
[\[SKS-4644\] 支持设置节点 hostname(前缀) - Jira](http://jira.smartx.com/browse/SKS-4644)


## Changes
- 文档：https://docs.google.com/document/d/1T71eSoWdp8Pqcj_L1fhb55l-IeOTVbqFX87vTwNXBDQ/edit?tab=t.0#heading=h.3yfd3hdwab8
- `ElfMachineSpec` 和 `CloudFailureDomain` 中增加 `HostNamePrefix` 字段
- 克隆虚拟机时按以下优先级生成 host name，传入克隆虚拟机 API：
  - 如果 elfMachine 所在的 failureDomain 配置了 `HostNamePrefix`，使用它拼接 `-` + `5 个随机字符`
  - 如果 ElfMachineSpec 配置了 `HostNamePrefix`，则使用它拼接
  - 否则使用 ElfMachine.Name （原有逻辑）
- 不再要求 kubeadmConfig 中填写 `nodeRegistration.name` 和编辑 `/etc/hosts` 的命令，host name 逻辑内置在 controller 逻辑中，node name 自动由 host name 生成
- 解开 cloud-init 数据，注入：
  - 编辑 `/etc/hosts` 的命令
  - `kubeletExtraArgs` 添加参数 `provider-id=elf://{{ ds.meta_data.instance_id }}` ，cloud-init 会渲染真实的 vm.UID
- 获取 node 根据 providerID 查到对应的 node，不再根据 name 查找

## Test
节点组维度 hostNamePrefix:
<img width="933" height="819" alt="image" src="https://github.com/user-attachments/assets/3aaed376-eb29-485e-b7c5-57e85774be2e" />
failureDomain 维度 hostNamePrefix:
<img width="938" height="759" alt="image" src="https://github.com/user-attachments/assets/6fd7709c-0c26-4d16-bb85-ad4b019f1960" />

