### PR TITLE
SKS-4699: Handle missing ElfMachine providerID during node lookup

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -1449,17 +1449,24 @@ func (r *ElfMachineReconciler) deleteNode(ctx goctx.Context, machineCtx *context
 		return nil
 	}
 
+	providerID := r.getProviderID(machineCtx)
+	if providerID == "" {
+		log := ctrl.LoggerFrom(ctx)
+		log.V(1).Info("providerID is not set, skip deleting node for " + machineCtx.ElfMachine.Name)
+		return nil
+	}
+
 	remoteClient, err := r.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(machineCtx.Cluster))
 	if err != nil {
 		return errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
 	}
 
-	node, err := r.getNode(ctx, remoteClient, *machineCtx.ElfMachine.Spec.ProviderID)
+	node, err := r.getNode(ctx, remoteClient, providerID)
 	if err != nil {
 		if err == ErrNodeNotFound {
 			return nil
 		}
-		return errors.Wrapf(err, "failed to get node by providerID %s", *machineCtx.ElfMachine.Spec.ProviderID)
+		return errors.Wrapf(err, "failed to get node by providerID %s", providerID)
 	}
 
 	// Attempt to delete the corresponding node.
@@ -1478,7 +1485,8 @@ func (r *ElfMachineReconciler) deleteNode(ctx goctx.Context, machineCtx *context
 
 // getK8sNodeIP get the default network IP of K8s Node.
 func (r *ElfMachineReconciler) getK8sNodeIP(ctx goctx.Context, machineCtx *context.MachineContext) (string, error) {
-	if machineCtx.ElfMachine.Spec.ProviderID == nil {
+	providerID := r.getProviderID(machineCtx)
+	if providerID == "" {
 		return "", nil
 	}
 
@@ -1487,9 +1495,9 @@ func (r *ElfMachineReconciler) getK8sNodeIP(ctx goctx.Context, machineCtx *conte
 		return "", errors.Wrapf(err, "failed to get client for Cluster %s", klog.KObj(machineCtx.Cluster))
 	}
 
-	k8sNode, err := r.getNode(ctx, remoteClient, *machineCtx.ElfMachine.Spec.ProviderID)
+	k8sNode, err := r.getNode(ctx, remoteClient, providerID)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get node by providerID %s", *machineCtx.ElfMachine.Spec.ProviderID)
+		return "", errors.Wrapf(err, "failed to get node by providerID %s", providerID)
 	}
 
 	if len(k8sNode.Status.Addresses) == 0 {
@@ -1664,4 +1672,16 @@ func (r *ElfMachineReconciler) getNode(ctx goctx.Context, c client.Reader, provi
 	}
 
 	return &nodeList.Items[0], nil
+}
+
+func (r *ElfMachineReconciler) getProviderID(machineCtx *context.MachineContext) string {
+	if machineCtx == nil || machineCtx.ElfMachine == nil {
+		return ""
+	}
+
+	if machineCtx.ElfMachine.Spec.ProviderID != nil && *machineCtx.ElfMachine.Spec.ProviderID != "" {
+		return *machineCtx.ElfMachine.Spec.ProviderID
+	}
+
+	return machineutil.ConvertUUIDToProviderID(machineCtx.ElfMachine.Status.VMRef)
 }

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -1934,6 +1934,87 @@ var _ = Describe("ElfMachineReconciler", func() {
 		})
 	})
 
+	Context("Get providerID", func() {
+		It("should get providerID from Spec or VMRef", func() {
+			const (
+				vmRef           = "12345678-1234-1234-1234-123456789abc"
+				providerID      = "elf://12345678-1234-1234-1234-123456789abc"
+				otherProviderID = "elf://12345678-1234-1234-1234-123456789def"
+			)
+
+			tests := []struct {
+				name       string
+				machineCtx *context.MachineContext
+				expected   string
+			}{
+				{
+					name:     "nil context returns empty string",
+					expected: "",
+				},
+				{
+					name:       "nil ElfMachine returns empty string",
+					machineCtx: &context.MachineContext{},
+					expected:   "",
+				},
+				{
+					name: "Spec ProviderID takes precedence",
+					machineCtx: &context.MachineContext{
+						ElfMachine: &infrav1.ElfMachine{
+							Spec: infrav1.ElfMachineSpec{
+								ProviderID: ptr.To(otherProviderID),
+							},
+							Status: infrav1.ElfMachineStatus{
+								VMRef: vmRef,
+							},
+						},
+					},
+					expected: otherProviderID,
+				},
+				{
+					name: "empty Spec ProviderID falls back to VMRef",
+					machineCtx: &context.MachineContext{
+						ElfMachine: &infrav1.ElfMachine{
+							Spec: infrav1.ElfMachineSpec{
+								ProviderID: ptr.To(""),
+							},
+							Status: infrav1.ElfMachineStatus{
+								VMRef: vmRef,
+							},
+						},
+					},
+					expected: providerID,
+				},
+				{
+					name: "nil Spec ProviderID falls back to VMRef",
+					machineCtx: &context.MachineContext{
+						ElfMachine: &infrav1.ElfMachine{
+							Status: infrav1.ElfMachineStatus{
+								VMRef: vmRef,
+							},
+						},
+					},
+					expected: providerID,
+				},
+				{
+					name: "invalid VMRef returns empty string",
+					machineCtx: &context.MachineContext{
+						ElfMachine: &infrav1.ElfMachine{
+							Status: infrav1.ElfMachineStatus{
+								VMRef: "not-a-uuid",
+							},
+						},
+					},
+					expected: "",
+				},
+			}
+
+			reconciler := &ElfMachineReconciler{}
+			for _, tc := range tests {
+				Expect(reconciler.getProviderID(tc.machineCtx)).To(Equal(tc.expected), tc.name)
+			}
+		})
+	})
+
 	Context("Reconcile ElfMachine network", func() {
 		BeforeEach(func() {
 			cluster.Status.InfrastructureReady = true
@@ -1987,7 +2068,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
 			elfMachine.Status.VMRef = *vm.LocalID
-			elfMachine.Spec.ProviderID = ptr.To(providerID)
+			Expect(elfMachine.Spec.ProviderID).To(BeNil())
 
 			k8sNode.Spec.ProviderID = providerID
 			Expect(testEnv.CreateAndWait(ctx, k8sNode)).To(Succeed())
@@ -1995,6 +2076,16 @@ var _ = Describe("ElfMachineReconciler", func() {
 				patchSource := k8sNode.DeepCopy()
 				k8sNode.Status.Addresses = addresses
 				Expect(testEnv.PatchAndWait(ctx, k8sNode, patchSource)).To(Succeed())
+
+				remoteClient, err := clusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() []corev1.NodeAddress {
+					latestNode := &corev1.Node{}
+					if err := remoteClient.Get(ctx, client.ObjectKeyFromObject(k8sNode), latestNode); err != nil {
+						return nil
+					}
+					return latestNode.Status.Addresses
+				}, timeout).Should(Equal(addresses))
 			}
 
 			// test elfMachine has one network device with DHCP type
@@ -2938,7 +3029,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Waiting for the placement group %s to be deleted", *placementGroup.Name)))
 		})
 
-		It("should delete k8s node before destroying VM.", func() {
+		It("should delete k8s node before destroying VM when providerID is only in VMRef", func() {
 			vm := fake.NewTowerVM()
 			providerID := machineutil.ConvertUUIDToProviderID(*vm.LocalID)
 			vm.EntityAsyncStatus = nil
@@ -2946,7 +3037,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			vm.Status = &status
 			task := fake.NewTowerTask("")
 			elfMachine.Status.VMRef = *vm.LocalID
-			elfMachine.Spec.ProviderID = ptr.To(providerID)
+			Expect(elfMachine.Spec.ProviderID).To(BeNil())
 			cluster.Status.ControlPlaneReady = true
 
 			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, secret, md)
@@ -2991,6 +3082,21 @@ var _ = Describe("ElfMachineReconciler", func() {
 			Expect(elfMachine.Status.VMRef).To(Equal(*vm.LocalID))
 			Expect(elfMachine.Status.TaskRef).To(Equal(*task.ID))
 			expectConditions(elfMachine, []conditionAssertion{{infrav1.VMProvisionedCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, clusterv1.DeletingReason}})
+		})
+
+		It("should skip deleting k8s node when providerID is unavailable", func() {
+			vm := fake.NewTowerVM()
+			elfMachine.Status.VMRef = *vm.ID
+			cluster.Status.ControlPlaneReady = true
+
+			machineContext := newMachineContext(elfCluster, cluster, elfMachine, machine, mockVMService)
+			reconciler := &ElfMachineReconciler{}
+
+			var err error
+			Expect(func() {
+				err = reconciler.deleteNode(ctx, machineContext)
+			}).NotTo(Panic())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should not delete k8s node when cluster is deleting", func() {


### PR DESCRIPTION
ticket
-
[\[SKS-4699\] \[PAT\] 创建虚拟机节点后快速删除，CAPE 会 panic - Jira](http://jira.smartx.com/browse/SKS-4699)
<img width="3834" height="1118" alt="image" src="https://github.com/user-attachments/assets/604da064-8e71-4f84-a1c7-5ee569f7d812" />


change
-
- deleteNode 和 getK8sNodeIP 中，提前获取 providerID，如果 ElfMachine.Spec.ProviderID 为空则从 ElfMachine.Status.VMRef 生成，如果还为空，则跳过。

测试
-
修复前，cape-controller 一直 panic，替换修复后版本，machine 被正常删除，新节点创建成功，反复删建节点，不再 panic


