### PR TITLE
SKS-4705: Wait cpu/memory online before restart kubelet

### DIFF
--- a/config/hostagent/jobs.yaml
+++ b/config/hostagent/jobs.yaml
@@ -61,6 +61,21 @@ data:
       become: true
       gather_facts: false
       tasks:
+      - name: wait for CPU and memory online
+        shell: |-
+          for i in $(seq 1 180); do
+            if ! grep -q '^0$' /sys/devices/system/cpu/cpu[0-9]*/online 2>/dev/null && \
+               ! grep -qv '^online' /sys/devices/system/memory/memory*/state; then
+              echo "CPU and memory are online"
+              exit 0
+            fi
+
+            echo "Waiting for CPU and memory online"
+            sleep 1
+          done
+
+          echo "Timed out waiting for CPU and memory online" >&2
+          exit 1
       - ansible.builtin.service:
           name: kubelet
           state: restarted


### PR DESCRIPTION
ticket
-
[\[SKS-4705\] SKS 集群热扩容 CPU / 内存后，Node 的 CPU / 内存数量少于期望值 - Jira](http://jira.smartx.com/browse/SKS-4705)

change
-
- restart kubelet job 中，在重启 kubelet 之前，检查 cpu 和内存是否全部 online，如果否则等待。最多等待 3 分钟。

test
-
修复后，在同样集群中扩容 CPU 和内存，不再出现该问题。
通过 ticket 中的脚本确定，kubelet 是在 cpu 和 内存都 online 之后才重启：
<img width="1005" height="247" alt="image" src="https://github.com/user-attachments/assets/9a0b4719-0b6b-4d16-8a5a-98aac8d189c2" />
<img width="748" height="327" alt="image" src="https://github.com/user-attachments/assets/dab83529-3f2a-4ac6-b3a7-a14352aaad87" />
